### PR TITLE
Fixed issue with inconsistent eslint type

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -87,16 +87,18 @@ export function getNodeReference(context, node) {
     let occurances = scopeVar.defs[0].parent.parent.body;
     let lastAssignment;
 
-    for (let occurance of occurances) {
-      if (occurance.type === 'VariableDeclaration' &&
-          occurance.declarations[0].init !== null) {
-        // Get what the name of what it was assigned to or the raw
-        // value depending on the initalization
-        lastAssignment = occurance.declarations[0].init;
-      } else if (occurance.type === 'ExpressionStatement' &&
-                 occurance.expression.type === 'AssignmentExpression') {
-        // Get the right hand side of the assignment
-        lastAssignment = occurance.expression.right;
+    if (occurances instanceof Array) {
+      for (let occurance of occurances) {
+        if (occurance.type === 'VariableDeclaration' &&
+            occurance.declarations[0].init !== null) {
+          // Get what the name of what it was assigned to or the raw
+          // value depending on the initalization
+          lastAssignment = occurance.declarations[0].init;
+        } else if (occurance.type === 'ExpressionStatement' &&
+                   occurance.expression.type === 'AssignmentExpression') {
+          // Get the right hand side of the assignment
+          lastAssignment = occurance.expression.right;
+        }
       }
     }
 


### PR DESCRIPTION
So turns out that `scopeVar.defs[0].parent.parent.body` can sometimes return an array and sometimes return an object. Since for-of cannot iterate over javascript objects it would throw a type error when that happened.

This should fix that.