### PR TITLE
Fix path for hashes in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,7 @@ docs/
 karma.conf.js
 node_modules/
 src/
+!src/hashes.txt
 tasks/
 tests/
 webpack.config.js

--- a/bin/addons-linter
+++ b/bin/addons-linter
@@ -2,5 +2,8 @@
 
 var path = require('path');
 
+var absoluteAppRoot = path.resolve(__dirname);
+global.appRoot = path.relative(process.cwd(), absoluteAppRoot);
+
 var AddonLinter = require('../dist/addons-linter').createInstance();
 AddonLinter.run();

--- a/src/filehasher.js
+++ b/src/filehasher.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import readline from 'readline';
 
 import createHash from 'sha.js';
@@ -6,10 +7,14 @@ import createHash from 'sha.js';
 import log from 'logger';
 import { lstatPromise } from 'io/utils';
 
+// TODO: This will be removed when hashes are coming
+// from the dispensary module.
+let hashesPath = global.appRoot ?
+  path.join(global.appRoot, '../src/hashes.txt') : './src/hashes.txt';
 
 export default class FileHasher {
 
-  constructor({hashes=null, path='./src/hashes.txt', lstat=lstatPromise} = {}) {
+  constructor({hashes=null, path=hashesPath, lstat=lstatPromise} = {}) {
     this._hashes = hashes;
     this._lstatPromise = lstat;
     this._pathToHashes = path;


### PR DESCRIPTION
This adds back the global appRoot hack so we can determine paths in two different ways one for test and one for when we're calling via the binary.