### PR TITLE
Speed up grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,23 +54,22 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('test', [
-    'clean',
     'instrument',
     'webpack:build',
     'webpack:coverage',
     'mochaTest',
     'storeCoverage',
     'makeReport',
-    'eslint',
-    'jscs',
+    'newer:eslint',
+    'newer:jscs',
   ]);
 
   grunt.registerTask('test-no-coverage', [
     'clean',
     'webpack:test',
     'mochaTest',
-    'eslint',
-    'jscs',
+    'newer:eslint',
+    'newer:jscs',
   ]);
 
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-istanbul": "0.6.1",
     "grunt-jscs": "2.6.0",
     "grunt-mocha-test": "0.12.7",
+    "grunt-newer": "1.1.1",
     "grunt-webpack": "1.0.11",
     "isparta": "4.0.0",
     "json-loader": "0.5.4",

--- a/tasks/jscs.js
+++ b/tasks/jscs.js
@@ -3,15 +3,16 @@ module.exports = {
     options: {
       config: '.jscsrc',
     },
-    files: {
-      src: [
-        'tasks/**/*.js*',
-        'tests/**/*.js*',
-        '!tests/fixtures/jslibs/**.js',
-        'src/**/*.js',
-        'Gruntfile.js',
-        'webpack.config.js',
-      ],
-    },
+    files: [
+      { src: [
+          'tasks/**/*.js*',
+          'tests/**/*.js*',
+          'src/**/*.js',
+          'Gruntfile.js',
+          'webpack.config.js',
+          '!tests/fixtures/jslibs/**.js',
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
* Saves instumenting files on every test run.
* Runs jshint and eslint only when src files have changed.

Hopefully at somepoint we can do something to make webpack not do a full rebuild each time too when the src is unchanged. Though currently that requires keeping a caching object around between runs if using webpacks own cache (as used in webpack's own watch).