### PR TITLE
Revert "Update babel-core to version 6.6.4 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/mozilla/addons-linter#readme",
   "devDependencies": {
-    "babel-core": "6.6.4",
+    "babel-core": "6.6.0",
     "babel-eslint": "5.0.0",
     "babel-loader": "6.2.4",
     "babel-plugin-transform-class-properties": "6.5.2",


### PR DESCRIPTION
Reverts mozilla/addons-linter#546