### PR TITLE
Strip BOM from files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "semver": "5.1.0",
     "sha.js": "2.4.5",
     "source-map-support": "0.4.0",
+    "strip-bom-stream": "2.0.0",
     "xmldom": "0.1.22",
     "yargs": "4.6.0",
     "yauzl": "2.4.1"

--- a/src/io/directory.js
+++ b/src/io/directory.js
@@ -1,10 +1,12 @@
 import * as path from 'path';
 import { createReadStream } from 'fs';
+import stripBomStream from 'strip-bom-stream';
 
 import { IOBase } from 'io/base';
 import { walkPromise } from 'io/utils';
 
 import { singleLineString } from '../utils';
+
 
 import log from 'logger';
 
@@ -56,7 +58,7 @@ export class Directory extends IOBase {
       flags: 'r',
       encoding: 'utf8',
       autoClose: true,
-    }));
+    }).pipe(stripBomStream()));
   }
 
   getFileAsString(path) {

--- a/src/io/xpi.js
+++ b/src/io/xpi.js
@@ -1,4 +1,5 @@
 import yauzl from 'yauzl';
+import stripBomStream from 'strip-bom-stream';
 
 import { IOBase } from 'io/base';
 
@@ -99,7 +100,7 @@ export class Xpi extends IOBase {
             if (err) {
               return reject(err);
             }
-            resolve(readStream);
+            resolve(readStream.pipe(stripBomStream()));
           });
         })
         .catch(reject);

--- a/src/scanners/css.js
+++ b/src/scanners/css.js
@@ -33,7 +33,7 @@ export default class CSSScanner extends BaseScanner {
 
     if (cssNode.type === 'atrule') {
       log.debug('Processing media rules');
-      if (cssNode.nodes.length) {
+      if (cssNode.nodes && cssNode.nodes.length) {
         for (let mediaCssNode of cssNode.nodes) {
           this.processCode(mediaCssNode, cssInstruction, _rules);
         }

--- a/tests/fixtures/io/dir3/foo.txt
+++ b/tests/fixtures/io/dir3/foo.txt
@@ -1,0 +1,1 @@
+﻿A test file with a BOM

--- a/tests/io/test.directory.js
+++ b/tests/io/test.directory.js
@@ -134,6 +134,17 @@ describe('Directory.getFileAsStream()', function() {
 
 describe('Directory.getFileAsString()', function() {
 
+  it('should strip a BOM', () => {
+    var myDirectory = new Directory('tests/fixtures/io/');
+    return myDirectory.getFiles()
+      .then(() => {
+        return myDirectory.getFileAsString('dir3/foo.txt');
+      })
+      .then((content) => {
+        assert.notOk(content.charCodeAt(0) === 0xFEFF);
+      });
+  });
+
   it('should return a string', () => {
     var myDirectory = new Directory('tests/fixtures/io/');
     return myDirectory.getFiles()
@@ -185,6 +196,5 @@ describe('Directory.getFileAsString()', function() {
           err.message, 'File "install.rdf" is too large');
       });
   });
-
 
 });

--- a/tests/io/test.xpi.js
+++ b/tests/io/test.xpi.js
@@ -1,9 +1,11 @@
 import { Readable } from 'stream';
 import { EventEmitter } from 'events';
 
+import fs from 'fs';
 import { Xpi } from 'io';
 import { DEFLATE_COMPRESSION, NO_COMPRESSION } from 'const';
 import { unexpectedSuccess } from '../helpers';
+
 
 const defaultData = {
   compressionMethod: DEFLATE_COMPRESSION,
@@ -321,6 +323,24 @@ describe('Xpi.getFileAsStream()', function() {
     return myXpi.getFileAsString('install.rdf')
       .then((string) => {
         assert.equal(string, 'line one\nline two');
+      });
+  });
+
+  it('should strip a BOM', () => {
+    var myXpi = new Xpi('foo/bar', this.fakeZipLib);
+    myXpi.files = {
+      'install.rdf': installRdfEntry,
+      'chrome.manifest': chromeManifestEntry,
+    };
+
+    this.openStub.yieldsAsync(null, this.fakeZipFile);
+
+    var rstream = fs.createReadStream('tests/fixtures/io/dir3/foo.txt');
+    this.openReadStreamStub.yields(null, rstream);
+
+    return myXpi.getFileAsString('install.rdf')
+      .then((string) => {
+        assert.notOk(string.charCodeAt(0) === 0xFEFF);
       });
   });
 


### PR DESCRIPTION
Fixes #606 

Removes the BOM when pulling from a directory or the zip.

Also fixes a small bug in the CSS parser which was preventing manual testing of the extension mentioned in the related bug.