### PR TITLE
cope more nicely with badly formed manifest.json

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -349,6 +349,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
+| :white_check_mark: | error | Web extension | manifest.json is not well formed. | manifest.json | | null | MANIFEST_JSON_INVALID |
 | :white_check_mark: | error | Web extension | manifest_version in manifest.json is not valid. | manifest.json | | null | MANIFEST_VERSION_INVALID |
 | :white_check_mark: | error | Web extension | name property missing from manifest.json | manifest.json | | null | PROP_NAME_MISSING |
 | :white_check_mark: | error | Web extension | name property is invalid in manifest.json | manifest.json | | null | PROP_NAME_INVALID |

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -6,10 +6,32 @@ import validate from 'mozilla-web-extension-manifest-schema';
 export default class ManifestJSONParser {
 
   constructor(jsonString, collector) {
-    this.parsedJSON = JSON.parse(jsonString);
     // Provides ability to directly add messages to
     // the collector.
     this.collector = collector;
+
+    // Set up some defaults in case parsing fails.
+    this.parsedJSON = {
+      manifestVersion: null,
+      name: null,
+      type: PACKAGE_EXTENSION,
+      version: null,
+    };
+
+    try {
+      this.parsedJSON = JSON.parse(jsonString);
+    } catch (error) {
+      var errorData = {
+        code: 'MANIFEST_JSON_INVALID',
+        message: 'Invalid JSON in manifest file.',
+        file: 'manifest.json',
+        description: error,
+      };
+      this.collector.addError(errorData);
+      this.isValid = false;
+      return;
+    }
+
     this.isValid = this._validate();
   }
 

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -5,6 +5,25 @@ import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 
 import { validManifestJSON } from '../helpers';
 
+describe('ManifestJSONParser', function() {
+
+  it('should show a message if bad JSON', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var manifestJSONParser = new ManifestJSONParser('blah',
+                                                    addonLinter.collector);
+    assert.equal(manifestJSONParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, 'MANIFEST_JSON_INVALID');
+    assert.include(errors[0].message, 'Invalid JSON in manifest file.');
+
+    var metadata = manifestJSONParser.getMetadata();
+    assert.equal(metadata.manifestVersion, null);
+    assert.equal(metadata.name, null);
+    assert.equal(metadata.version, null);
+  });
+
+});
 
 describe('ManifestJSONParser manifestVersion', function() {
 


### PR DESCRIPTION
note the evil trailing comma.

![screenshot 2016-04-20 13 08 34](https://cloud.githubusercontent.com/assets/74699/14688822/4e2f5cd4-06f9-11e6-99fe-ffca84ae903f.png)

before:

![screenshot 2016-04-20 13 11 33](https://cloud.githubusercontent.com/assets/74699/14688844/6b82170e-06f9-11e6-8bb4-c872f0ff59d4.png)

after:

![screenshot 2016-04-20 13 11 12](https://cloud.githubusercontent.com/assets/74699/14688832/60557e3e-06f9-11e6-936d-e5fbeaf1cabe.png)

it feels like a) i should be reading some bugs although I couldn't spot one 
and b) there should be a general JSON linting library that gives awesome errors I should be running this through, maybe jsonlint?