### PR TITLE
show a warning if content_security_policy defined

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -356,3 +356,4 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | version property missing from manifest.json | manifest.json | | null | PROP_VERSION_MISSING |
 | :white_check_mark: | error | Web extension | version is invalid in manifest.json | manifest.json | | null | PROP_VERSION_INVALID |
 | :white_check_mark: | error | Web extension | install.rdf and manifest.json present | manifest.json | | null | MULITPLE_MANIFESTS |
+| :white_check_mark: | warning | Web extension | content_security_policy in manifest.json means more review | manifest.json | | null | MANIFEST_CSP |

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -10,6 +10,14 @@ export const MANIFEST_VERSION_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_CSP = {
+  code: 'MANIFEST_CSP',
+  legacyCode: null,
+  message: _('"content_security_policy" is defined in the manifest.json'),
+  description: _('A custom content_security_policy needs additional review.'),
+  file: MANIFEST_CSP,
+};
+
 export const PROP_NAME_INVALID = {
   code: 'PROP_NAME_INVALID',
   legacyCode: null,

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1,6 +1,7 @@
 import { PACKAGE_EXTENSION } from 'const';
 import log from 'logger';
 import validate from 'mozilla-web-extension-manifest-schema';
+import * as messages from 'messages';
 
 
 export default class ManifestJSONParser {
@@ -58,6 +59,10 @@ export default class ManifestJSONParser {
         errorData.description = description || 'MISSING_SCHEMA_DESCRIPTION';
         this.collector.addError(errorData);
       }
+    }
+
+    if (this.parsedJSON.content_security_policy) {
+      this.collector.addWarning(messages.MANIFEST_CSP);
     }
     return isValid;
   }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -153,3 +153,18 @@ describe('ManifestJSONParser version', function() {
   });
 
 });
+
+describe('ManifestJSONParser content security policy', function() {
+
+  it('should warn that csp will mean more review', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = validManifestJSON({content_security_policy: 'wat?'});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonLinter.collector);
+    assert.equal(manifestJSONParser.isValid, true);
+    var warnings = addonLinter.collector.warnings;
+    assert.equal(warnings[0].code, 'MANIFEST_CSP');
+    assert.include(warnings[0].message, 'content_security_policy');
+  });
+
+});


### PR DESCRIPTION
fixes #562, but...
* I'm not sure if we should be doing something more fancy using the schema in web-extension-manifest-schema
* even raising a warning is the right thing to do here

This doesn't do anything fancy like validate the contents of the CSP policy, that would be a nice next bug.