### PR TITLE
warn if an update_url is defined

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -357,3 +357,4 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | version is invalid in manifest.json | manifest.json | | null | PROP_VERSION_INVALID |
 | :white_check_mark: | error | Web extension | install.rdf and manifest.json present | manifest.json | | null | MULITPLE_MANIFESTS |
 | :white_check_mark: | warning | Web extension | content_security_policy in manifest.json means more review | manifest.json | | null | MANIFEST_CSP |
+| :white_check_mark: | error | Web extension | update_url not allowed in manifest.json | manifest.json | | null | MANIFEST_UPDATE_URL |

--- a/src/cli.js
+++ b/src/cli.js
@@ -55,6 +55,11 @@ export default argv
     type: 'boolean',
     default: false,
   })
+  .option('self-hosted', {
+    describe: 'Disables messages related to hosting on addons.mozilla.org.',
+    type: 'boolean',
+    default: false,
+  })
   // Require one non-option.
   .demand(1)
   .help('help')

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -34,6 +34,14 @@ export const PROP_VERSION_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_UPDATE_URL = {
+  code: 'MANIFEST_UPDATE_URL',
+  legacyCode: null,
+  message: _('The "update_url" property is not allowed.'),
+  description: _('The update_url cannot be defined.'),
+  file: MANIFEST_JSON,
+};
+
 export function manifestPropMissing(property) {
   return {
     code: `PROP_${property.toUpperCase()}_MISSING`,

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -6,7 +6,7 @@ import cli from 'cli';
 
 export default class ManifestJSONParser {
 
-  constructor(jsonString, collector, selfHosted=cli.argv.selfHosted) {
+  constructor(jsonString, collector, {selfHosted=cli.argv.selfHosted}={}) {
     // Provides ability to directly add messages to
     // the collector.
     this.collector = collector;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -2,11 +2,11 @@ import { PACKAGE_EXTENSION } from 'const';
 import log from 'logger';
 import validate from 'mozilla-web-extension-manifest-schema';
 import * as messages from 'messages';
-
+import cli from 'cli';
 
 export default class ManifestJSONParser {
 
-  constructor(jsonString, collector) {
+  constructor(jsonString, collector, selfHosted=cli.argv.selfHosted) {
     // Provides ability to directly add messages to
     // the collector.
     this.collector = collector;
@@ -33,6 +33,7 @@ export default class ManifestJSONParser {
       return;
     }
 
+    this.selfHosted = selfHosted;
     this.isValid = this._validate();
   }
 
@@ -61,12 +62,11 @@ export default class ManifestJSONParser {
       }
     }
 
-
     if (this.parsedJSON.content_security_policy) {
       this.collector.addWarning(messages.MANIFEST_CSP);
     }
 
-    if (this.parsedJSON.hasOwnProperty('update_url')) {
+    if (!this.selfHosted && this.parsedJSON.hasOwnProperty('update_url')) {
       this.collector.addError(messages.MANIFEST_UPDATE_URL);
       isValid = false;
     }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -61,8 +61,14 @@ export default class ManifestJSONParser {
       }
     }
 
+
     if (this.parsedJSON.content_security_policy) {
       this.collector.addWarning(messages.MANIFEST_CSP);
+    }
+
+    if (this.parsedJSON.hasOwnProperty('update_url')) {
+      this.collector.addError(messages.MANIFEST_UPDATE_URL);
+      isValid = false;
     }
     return isValid;
   }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -168,3 +168,18 @@ describe('ManifestJSONParser content security policy', function() {
   });
 
 });
+
+describe('ManifestJSONParser update_url', function() {
+
+  it('is not allowed', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = validManifestJSON({update_url: ''});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonLinter.collector);
+    assert.equal(manifestJSONParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors[0].code, 'MANIFEST_UPDATE_URL');
+    assert.include(errors[0].message, 'update_url');
+  });
+
+});

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -175,11 +175,21 @@ describe('ManifestJSONParser update_url', function() {
     var addonLinter = new Linter({_: ['bar']});
     var json = validManifestJSON({update_url: ''});
     var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
+                                                    addonLinter.collector,
+                                                    false);
     assert.equal(manifestJSONParser.isValid, false);
     var errors = addonLinter.collector.errors;
     assert.equal(errors[0].code, 'MANIFEST_UPDATE_URL');
     assert.include(errors[0].message, 'update_url');
   });
 
+  it('is allowed if self-hosted', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = validManifestJSON({update_url: ''});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonLinter.collector,
+                                                    true);
+    manifestJSONParser.selfHosted = true;
+    assert.equal(manifestJSONParser.isValid, true);
+  });
 });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -176,7 +176,7 @@ describe('ManifestJSONParser update_url', function() {
     var json = validManifestJSON({update_url: ''});
     var manifestJSONParser = new ManifestJSONParser(json,
                                                     addonLinter.collector,
-                                                    false);
+                                                    {selfHosted: false});
     assert.equal(manifestJSONParser.isValid, false);
     var errors = addonLinter.collector.errors;
     assert.equal(errors[0].code, 'MANIFEST_UPDATE_URL');
@@ -188,7 +188,7 @@ describe('ManifestJSONParser update_url', function() {
     var json = validManifestJSON({update_url: ''});
     var manifestJSONParser = new ManifestJSONParser(json,
                                                     addonLinter.collector,
-                                                    true);
+                                                    {selfHosted: true});
     manifestJSONParser.selfHosted = true;
     assert.equal(manifestJSONParser.isValid, true);
   });


### PR DESCRIPTION
fixes #565, but...
* like #611 I'm not sure if this is the right way to do it
* its an AMO problem and isn't something relevant to say Chrome add-ons, is there a special way to run this stuff?
* should this be something in mozilla/web-extension-manifest-schema

advice please...