### PR TITLE
fail if both install.rdf and manifest.json defined

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -354,3 +354,4 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | name property is invalid in manifest.json | manifest.json | | null | PROP_NAME_INVALID |
 | :white_check_mark: | error | Web extension | version property missing from manifest.json | manifest.json | | null | PROP_VERSION_MISSING |
 | :white_check_mark: | error | Web extension | version is invalid in manifest.json | manifest.json | | null | PROP_VERSION_INVALID |
+| :white_check_mark: | error | Web extension | install.rdf and manifest.json present | manifest.json | | null | MULITPLE_MANIFESTS |

--- a/src/linter.js
+++ b/src/linter.js
@@ -211,7 +211,9 @@ export default class Linter {
 
         if (files.hasOwnProperty(INSTALL_RDF) &&
             files.hasOwnProperty(MANIFEST_JSON)) {
-          throw new Error(`Both ${INSTALL_RDF} and ${MANIFEST_JSON} found`);
+          log.warn(`Both ${INSTALL_RDF} and ${MANIFEST_JSON} found`);
+          this.collector.addError(messages.MULITPLE_MANIFESTS);
+          return {};
         } else if (files.hasOwnProperty(INSTALL_RDF)) {
           log.info('Retrieving metadata from install.rdf');
           return this.io.getFileAsString(INSTALL_RDF)

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -47,6 +47,19 @@ export const TYPE_NO_MANIFEST_JSON = {
     will be attempted to be inferred by package layout.`),
 };
 
+export const MULITPLE_MANIFESTS = {
+  code: 'MULITPLE_MANIFESTS',
+  legacyCode: [
+    'typedetection',
+    'detect_type',
+    'install_rdf_and_manifest_json',
+  ],
+  message: _('Both install_rdf and manifest.json found'),
+  description: _(singleLineString`The type should be determined by
+    manifest.json if present. Both install_rdf and manifest_json
+    are defined.`),
+};
+
 export const TYPE_NOT_DETERMINED = {
   code: 'TYPE_NOT_DETERMINED',
   legacyCode: [

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -607,7 +607,7 @@ describe('Linter.getAddonMetadata()', function() {
       });
   });
 
-  it('should throw error if both manifest.json and install.rdf found', () => {
+  it('should collect an error if manifest.json and install.rdf found', () => {
     var addonLinter = new Linter({_: ['bar']});
     addonLinter.io = {
       getFiles: () => {
@@ -618,9 +618,11 @@ describe('Linter.getAddonMetadata()', function() {
       },
     };
     return addonLinter.getAddonMetadata()
-      .then(unexpectedSuccess)
-      .catch((err) => {
-        assert.include(err.message, 'Both install.rdf and manifest.json');
+      .then(() => {
+        var errors = addonLinter.collector.errors;
+        assert.equal(errors.length, 2);
+        assert.equal(errors[0].code, messages.MULITPLE_MANIFESTS.code);
+        assert.equal(errors[1].code, messages.TYPE_NOT_DETERMINED.code);
       });
   });
 


### PR DESCRIPTION
* fixes #605 sorta

before:
![screenshot 2016-04-20 15 03 56](https://cloud.githubusercontent.com/assets/74699/14692041/7cfd7d88-0709-11e6-864e-3aa9ded556a4.png)

after:
![screenshot 2016-04-20 15 05 14](https://cloud.githubusercontent.com/assets/74699/14692038/7af8f5bc-0709-11e6-81a0-8cf1dd9522b8.png)

It feels like i'm changing some fundamental decision about the linter was written that if it just fails with some key files it throws a system error. I felt that this way there's a clear and consistent error @EnTeQuAk can pass back to the user who uploaded an addon. But I'm probably wrong :)