### PR TITLE
create a hidden scanner that triggers for hidden files and throws a w…

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -269,6 +269,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :x: | warning | unknown_file | | Unknown file found in add-on | | | | |
 | :x: | warning | missing_required | | Required file missing | | | | |
 | :white_check_mark: | error |  |  | Bad zip file  | |  | | BAD_ZIPFILE |
+| :white_check_mark: | error |  |  | Hidden files flagged  | |  | | HIDDEN_FILE |
 
 ## Type detection
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -171,8 +171,8 @@ A :white_check_mark: next to a section of rules means they have all been filed i
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :negative_squared_cross_mark: | warning | found_in_chrome_manifest| | xpcnativewrappers not allowed in chrome.manifest |  chrome.manifest | [testcases/content.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/content.py)| | |
 | :negative_squared_cross_mark: | warning | found_in_chrome_manifest| | newTab.xul is now newTab.xhtml |  chrome.manifest | | | |
-| :x: | warning | hidden_files | | Hidden files and folders flagged | | | | |
-| :x: | warning | flagged_files | | Flagged filename found | | | | |
+| :white_check_mark: | warning | hidden_files | | Hidden file flagged | | | [testcases/content.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/content.py) | HIDDEN_FILE |
+| :white_check_mark: | warning | flagged_files | | Flagged filename found | | |[testcases/content.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/content.py) | FLAGGED_FILE |
 | :x: | notice | blacklisted_js_library | | JS Library Detected | | | | |
 | :negative_squared_cross_mark: | warning | invalid_chrome_url | | Invalid chrome URL | | | | |
 | :x: | warning | too_much_js | | TOO MUCH JS FOR EXHAUSTIVE VALIDATION | | | | |
@@ -269,7 +269,6 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :x: | warning | unknown_file | | Unknown file found in add-on | | | | |
 | :x: | warning | missing_required | | Required file missing | | | | |
 | :white_check_mark: | error |  |  | Bad zip file  | |  | | BAD_ZIPFILE |
-| :white_check_mark: | error |  |  | Hidden files flagged  | |  | | HIDDEN_FILE |
 
 ## Type detection
 

--- a/src/const.js
+++ b/src/const.js
@@ -114,4 +114,7 @@ export const VALID_MANIFEST_VERSION = 2;
 // io classes will open as strings or streams.
 export const MAX_FILE_SIZE_MB = 100;
 
-export const HIDDEN_FILE_REGEX = /^__MACOSX/;
+export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
+export const FLAGGED_FILE_REGEX = /Thumbs.db$|.DS_STORE$|.orig$|.old$|\~$/;
+export const HIDDEN_FILE_SCANNER_REGEX = new RegExp(
+  `${FLAGGED_FILE_REGEX.source}|${HIDDEN_FILE_REGEX.source}`);

--- a/src/const.js
+++ b/src/const.js
@@ -115,6 +115,6 @@ export const VALID_MANIFEST_VERSION = 2;
 export const MAX_FILE_SIZE_MB = 100;
 
 export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
-export const FLAGGED_FILE_REGEX = /Thumbs.db$|.DS_STORE$|.orig$|.old$|\~$/;
+export const FLAGGED_FILE_REGEX = /(t|T)humbs.db$|.DS_STORE$|.orig$|.old$|\~$/;
 export const HIDDEN_FILE_SCANNER_REGEX = new RegExp(
   `${FLAGGED_FILE_REGEX.source}|${HIDDEN_FILE_REGEX.source}`);

--- a/src/const.js
+++ b/src/const.js
@@ -113,3 +113,5 @@ export const VALID_MANIFEST_VERSION = 2;
 // The max file size in MB that the
 // io classes will open as strings or streams.
 export const MAX_FILE_SIZE_MB = 100;
+
+export const HIDDEN_FILE_REGEX = /^__MACOSX/;

--- a/src/linter.js
+++ b/src/linter.js
@@ -298,7 +298,7 @@ export default class Linter {
       return ChromeManifestScanner;
     }
 
-    if (filename.match(constants.HIDDEN_FILE_REGEX)) {
+    if (filename.match(constants.HIDDEN_FILE_SCANNER_REGEX)) {
       return HiddenScanner;
     }
 

--- a/src/linter.js
+++ b/src/linter.js
@@ -19,6 +19,7 @@ import ManifestJSONParser from 'parsers/manifestjson';
 import ChromeManifestScanner from 'scanners/chromemanifest';
 import CSSScanner from 'scanners/css';
 import HTMLScanner from 'scanners/html';
+import HiddenScanner from 'scanners/hidden';
 import JavaScriptScanner from 'scanners/javascript';
 import NullScanner from 'scanners/null';
 import RDFScanner from 'scanners/rdf';
@@ -293,9 +294,12 @@ export default class Linter {
   }
 
   getScanner(filename) {
-
     if (filename === CHROME_MANIFEST) {
       return ChromeManifestScanner;
+    }
+
+    if (filename.match(constants.HIDDEN_FILE_REGEX)) {
+      return HiddenScanner;
     }
 
     switch (extname(filename)) {

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -85,3 +85,15 @@ export const HIDDEN_FILE = {
     generated the add-on. Please modify the packaging process so that these
     files aren't included.`),
 };
+
+export const FLAGGED_FILE = {
+  code: 'FLAGGED_FILE',
+  legacyCode: [
+    'testcases_content',
+    'test_packaged_packages',
+    'flagged_files',
+  ],
+  message: _('Flagged filename found'),
+  description: _(singleLineString`Files were found that are either unnecessary
+    or have been included unintentionally. They should be removed.`),
+};

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -71,3 +71,17 @@ export const TYPE_NOT_DETERMINED = {
   description: _(singleLineString`The type detection algorithm could not
     determine the type of the add-on.`),
 };
+
+export const HIDDEN_FILE = {
+  code: 'HIDDEN_FILE',
+  legacyCode: [
+    'testcases_content',
+    'test_packed_packages',
+    'hidden_files',
+  ],
+  message: _('Hidden file flagged'),
+  description: _(singleLineString`Hidden files complicate the
+    review process and can contain sensitive information about the system that
+    generated the add-on. Please modify the packaging process so that these
+    files aren't included.`),
+};

--- a/src/scanners/hidden.js
+++ b/src/scanners/hidden.js
@@ -1,17 +1,30 @@
 import BaseScanner from 'scanners/base';
-import { HIDDEN_FILE } from 'messages';
-import { VALIDATION_WARNING } from 'const';
+import * as messages from 'messages';
+import * as constants from 'const';
 
 
 export default class HiddenScanner extends BaseScanner {
   scan() {
     return new Promise((resolve) => {
-      this.linterMessages.push(
-        Object.assign({}, HIDDEN_FILE, {
-          type: VALIDATION_WARNING,
-          file: this.filename,
-        })
-      );
+      // Add a warning if it matches a hidden file.
+      if (this.filename.match(constants.HIDDEN_FILE_REGEX)) {
+        this.linterMessages.push(
+          Object.assign({}, messages.HIDDEN_FILE, {
+            type: constants.VALIDATION_WARNING,
+            file: this.filename,
+          })
+        );
+      // Not hidden files are flagged slightly differently.
+      } else if (this.filename.match(constants.FLAGGED_FILE_REGEX)) {
+        this.linterMessages.push(
+          Object.assign({}, messages.FLAGGED_FILE, {
+            type: constants.VALIDATION_WARNING,
+            file: this.filename,
+          })
+        );
+      } else {
+        throw new Error(`Filename didn't match a regex: ${this.filename}.`);
+      }
       return resolve(this.linterMessages);
     });
   }

--- a/src/scanners/hidden.js
+++ b/src/scanners/hidden.js
@@ -1,0 +1,18 @@
+import BaseScanner from 'scanners/base';
+import { HIDDEN_FILE } from 'messages';
+import { VALIDATION_WARNING } from 'const';
+
+
+export default class HiddenScanner extends BaseScanner {
+  scan() {
+    return new Promise((resolve) => {
+      this.linterMessages.push(
+        Object.assign({}, HIDDEN_FILE, {
+          type: VALIDATION_WARNING,
+          file: this.filename,
+        })
+      );
+      return resolve(this.linterMessages);
+    });
+  }
+}

--- a/tests/scanners/test.hidden.js
+++ b/tests/scanners/test.hidden.js
@@ -1,0 +1,17 @@
+import HiddenScanner from 'scanners/hidden';
+
+
+describe('Hidden', function() {
+
+  it('should warn when finding a hidden file', () => {
+    var hiddenScanner = new HiddenScanner('', 'wat.txt');
+
+    return hiddenScanner.scan()
+      .then((linterMessages) => {
+        assert.equal(linterMessages.length, 1);
+        assert.equal(linterMessages[0].code, 'HIDDEN_FILE');
+        assert.equal(linterMessages[0].file, 'wat.txt');
+      });
+  });
+
+});

--- a/tests/scanners/test.hidden.js
+++ b/tests/scanners/test.hidden.js
@@ -1,17 +1,51 @@
 import HiddenScanner from 'scanners/hidden';
+import {HIDDEN_FILE_SCANNER_REGEX} from 'const';
 
-
-describe('Hidden', function() {
+describe('HiddenScanner', function() {
 
   it('should warn when finding a hidden file', () => {
-    var hiddenScanner = new HiddenScanner('', 'wat.txt');
+    var hiddenScanner = new HiddenScanner('', '__MACOSX/foo.txt');
 
     return hiddenScanner.scan()
       .then((linterMessages) => {
         assert.equal(linterMessages.length, 1);
         assert.equal(linterMessages[0].code, 'HIDDEN_FILE');
-        assert.equal(linterMessages[0].file, 'wat.txt');
+        assert.equal(linterMessages[0].file, '__MACOSX/foo.txt');
       });
+  });
+
+  it('should warn when finding a flagged file', () => {
+    var hiddenScanner = new HiddenScanner('', 'Thumbs.db');
+
+    return hiddenScanner.scan()
+      .then((linterMessages) => {
+        assert.equal(linterMessages.length, 1);
+        assert.equal(linterMessages[0].code, 'FLAGGED_FILE');
+        assert.equal(linterMessages[0].file, 'Thumbs.db');
+      });
+  });
+
+  it('should error out when it fails the regexes', () => {
+    var hiddenScanner = new HiddenScanner('', 'wat.txt');
+
+    return hiddenScanner.scan()
+      .catch((err) => {
+        assert.instanceOf(err, Error);
+        assert.include(err.message, 'wat.txt');
+      });
+  });
+
+});
+
+describe('Hidden regexes', function() {
+
+  it('should find the right files', () => {
+    // Because regexes never go wrong, some sanity checks.
+    assert.isOk('__MACOSX/foo.txt'.match(HIDDEN_FILE_SCANNER_REGEX));
+    assert.isNotOk('__MACOSXfoo.txt'.match(HIDDEN_FILE_SCANNER_REGEX));
+    assert.isNotOk('foo/__MACOSX'.match(HIDDEN_FILE_SCANNER_REGEX));
+    assert.isOk('foo/Thumbs.db'.match(HIDDEN_FILE_SCANNER_REGEX));
+    assert.isNotOk('Thumbs.db/foo'.match(HIDDEN_FILE_SCANNER_REGEX));
   });
 
 });

--- a/tests/scanners/test.hidden.js
+++ b/tests/scanners/test.hidden.js
@@ -45,6 +45,7 @@ describe('Hidden regexes', function() {
     assert.isNotOk('__MACOSXfoo.txt'.match(HIDDEN_FILE_SCANNER_REGEX));
     assert.isNotOk('foo/__MACOSX'.match(HIDDEN_FILE_SCANNER_REGEX));
     assert.isOk('foo/Thumbs.db'.match(HIDDEN_FILE_SCANNER_REGEX));
+    assert.isOk('foo/thumbs.db'.match(HIDDEN_FILE_SCANNER_REGEX));
     assert.isNotOk('Thumbs.db/foo'.match(HIDDEN_FILE_SCANNER_REGEX));
   });
 

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -7,6 +7,7 @@ import * as messages from 'messages';
 
 import CSSScanner from 'scanners/css';
 import NullScanner from 'scanners/null';
+import HiddenScanner from 'scanners/hidden';
 import { fakeMessageData,
          unexpectedSuccess,
          validManifestJSON } from './helpers';
@@ -258,6 +259,13 @@ describe('Linter.getScanner()', function() {
     var Scanner = addonLinter.getScanner('foo.css');
     assert.deepEqual(Scanner, CSSScanner);
   });
+
+  it('should return HiddenScanner', function() {
+    var addonLinter = new Linter({_: ['foo']});
+    var Scanner = addonLinter.getScanner('__MACOSX/foo.txt');
+    assert.deepEqual(Scanner, HiddenScanner);
+  });
+
 });
 
 


### PR DESCRIPTION
…arning, if asked to scan the file

* support mozilla/addons-server#2187, but doesn't fix it as there's more things going there.
* this just adds in a hidden scanner, so if we are asked to scan a file and it meets the regex as "hidden" it will throw a warning
* note this doesn't list every hidden file because we currently don't scan every file, but we kinda need to and I think that's a seperate bug

![screenshot 2016-04-21 16 38 15](https://cloud.githubusercontent.com/assets/74699/14727424/9381bd5e-07df-11e6-8bac-a216c022f3e0.png)