### PR TITLE
scan every file and add a null pass through, also remove loop

### DIFF
--- a/src/scanners/null.js
+++ b/src/scanners/null.js
@@ -1,0 +1,11 @@
+import BaseScanner from 'scanners/base';
+import log from 'logger';
+
+export default class NullScanner extends BaseScanner {
+  scan() {
+    return new Promise((resolve) => {
+      log.debug(`No scanner found for: ${this.filename}.`);
+      return resolve([]);
+    });
+  }
+}

--- a/tests/scanners/test.null.js
+++ b/tests/scanners/test.null.js
@@ -1,0 +1,15 @@
+import NullScanner from 'scanners/null';
+
+
+describe('Null', function() {
+
+  it('should do nothing', () => {
+    var nullScanner = new NullScanner('', 'wat.txt');
+
+    return nullScanner.scan()
+      .then((linterMessages) => {
+        assert.equal(linterMessages.length, 0);
+      });
+  });
+
+});

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -6,6 +6,7 @@ import * as constants from 'const';
 import * as messages from 'messages';
 
 import CSSScanner from 'scanners/css';
+import NullScanner from 'scanners/null';
 import { fakeMessageData,
          unexpectedSuccess,
          validManifestJSON } from './helpers';
@@ -201,36 +202,6 @@ describe('Linter', function() {
       });
   });
 
-  it('should bubble up the error if scanFile() blows up', () => {
-    var addonLinter = new Linter({_: ['foo']});
-    // Stub handleError to prevent output.
-    addonLinter.handleError = sinon.stub();
-    addonLinter.checkFileExists = fakeCheckFileExists;
-    addonLinter.scanFile = () => {
-      return Promise.reject(new Error('scanFile explosion'));
-    };
-
-    class FakeXpi {
-      getFile() {
-        return Promise.resolve('');
-      }
-      getFiles() {
-        return Promise.resolve([]);
-      }
-      getFilesByExt() {
-        return Promise.resolve(['foo.js', 'bar.js']);
-      }
-    }
-
-    return addonLinter.scan({_Xpi: FakeXpi})
-      .then(unexpectedSuccess)
-      .catch((err) => {
-        assert.instanceOf(err, Error);
-        assert.include(err.message, 'scanFile explosion');
-      });
-  });
-
-
   it('should call addError when Xpi rejects with dupe entry', () => {
     var addonLinter = new Linter({_: ['bar']});
     addonLinter.checkFileExists = fakeCheckFileExists;
@@ -276,11 +247,10 @@ describe('Linter', function() {
 
 describe('Linter.getScanner()', function() {
 
-  it('should throw if scanner type is not available', () => {
+  it('should return NullScanner', () => {
     var addonLinter = new Linter({_: ['foo']});
-    assert.throws(() => {
-      addonLinter.getScanner('foo.whatever');
-    }, Error, /No scanner available/);
+    var Scanner = addonLinter.getScanner('foo.whatever');
+    assert.deepEqual(Scanner, NullScanner);
   });
 
   it('should return CSSScanner', function() {


### PR DESCRIPTION
* fixes #620 

Means that every file will get passed to `scanFile` and we can do some more stuff there. This will work nicely for when we look for hidden files and binary files.