### PR TITLE
Make flagged file regex case insensitive

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -115,6 +115,4 @@ export const VALID_MANIFEST_VERSION = 2;
 export const MAX_FILE_SIZE_MB = 100;
 
 export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
-export const FLAGGED_FILE_REGEX = /(t|T)humbs.db$|.DS_STORE$|.orig$|.old$|\~$/;
-export const HIDDEN_FILE_SCANNER_REGEX = new RegExp(
-  `${FLAGGED_FILE_REGEX.source}|${HIDDEN_FILE_REGEX.source}`);
+export const FLAGGED_FILE_REGEX = /thumbs.db$|.DS_Store$|.orig$|.old$|\~$/i;

--- a/src/linter.js
+++ b/src/linter.js
@@ -298,7 +298,8 @@ export default class Linter {
       return ChromeManifestScanner;
     }
 
-    if (filename.match(constants.HIDDEN_FILE_SCANNER_REGEX)) {
+    if (filename.match(constants.HIDDEN_FILE_REGEX) ||
+        filename.match(constants.FLAGGED_FILE_REGEX)) {
       return HiddenScanner;
     }
 

--- a/tests/scanners/test.hidden.js
+++ b/tests/scanners/test.hidden.js
@@ -1,5 +1,5 @@
 import HiddenScanner from 'scanners/hidden';
-import {HIDDEN_FILE_SCANNER_REGEX} from 'const';
+import { FLAGGED_FILE_REGEX, HIDDEN_FILE_REGEX } from 'const';
 
 describe('HiddenScanner', function() {
 
@@ -37,16 +37,59 @@ describe('HiddenScanner', function() {
 
 });
 
-describe('Hidden regexes', function() {
+describe('Hidden and Flagged File Regexes', function() {
 
-  it('should find the right files', () => {
-    // Because regexes never go wrong, some sanity checks.
-    assert.isOk('__MACOSX/foo.txt'.match(HIDDEN_FILE_SCANNER_REGEX));
-    assert.isNotOk('__MACOSXfoo.txt'.match(HIDDEN_FILE_SCANNER_REGEX));
-    assert.isNotOk('foo/__MACOSX'.match(HIDDEN_FILE_SCANNER_REGEX));
-    assert.isOk('foo/Thumbs.db'.match(HIDDEN_FILE_SCANNER_REGEX));
-    assert.isOk('foo/thumbs.db'.match(HIDDEN_FILE_SCANNER_REGEX));
-    assert.isNotOk('Thumbs.db/foo'.match(HIDDEN_FILE_SCANNER_REGEX));
-  });
+  const matchingHiddenFiles = [
+    '__MACOSX/foo.txt',
+    '__MACOSX/.DS_Store',
+  ];
 
+  for (const filePath of matchingHiddenFiles) {
+    it(`should match ${filePath} as a hidden file`, () => {
+      assert.isOk(filePath.match(HIDDEN_FILE_REGEX),
+        `${filePath} should match hidden file regex`);
+    });
+  }
+
+  const nonMatchingHiddenFiles = [
+    '__MACOSXfoo.txt',
+    'foo/__MACOSX',
+  ];
+
+  for (const filePath of nonMatchingHiddenFiles) {
+    it(`should not match ${filePath} as a hidden file`, () => {
+      assert.isNotOk(filePath.match(HIDDEN_FILE_REGEX),
+        `${filePath} should not match hidden file regex`);
+    });
+  }
+
+  const matchingFlaggedFiles = [
+    'foo/Thumbs.db',
+    'foo/thumbs.db',
+    'whatever/something.orig',
+    'whatever/OLD.old',
+    'whatever/.DS_STORE',
+    'whatever/.DS_Store',
+    'something~',
+  ];
+
+  for (const filePath of matchingFlaggedFiles) {
+    it(`should match ${filePath} as a flagged file`, () => {
+      assert.isOk(filePath.match(FLAGGED_FILE_REGEX),
+        `${filePath} should match flagged file regex`);
+    });
+  }
+
+  const nonMatchingFlaggedFiles = [
+    'Thumbs.db/foo',
+    'whatever.orig/something',
+    'whatever.old/something',
+  ];
+
+  for (const filePath of nonMatchingFlaggedFiles) {
+    it(`should not match ${filePath} as a flagged file`, () => {
+      assert.isNotOk(filePath.match(FLAGGED_FILE_REGEX),
+        `${filePath} should not match flagged file regex`);
+    });
+  }
 });


### PR DESCRIPTION
r? @andymckay

I realise I messed-up the original description of #617 since I put  `.DS_STORE` instead of `.DS_Store` however I think there's no harm in making that entire regex case insensitive.

The regexes are used individually because you can't have part of a regex case insensitive. That said maybe we should consider making the __MACOSX one the same since I don't see it would create false positives.

The other question I had is I see we don't match a directory `foo.old` or `foo.orig` and instead only match files ending with `.orig`/`.old`. I wondered it that was intended?

Should we also check for .git directories etc? Although I guess this could be a endless list...

Lastly - the regex tests are now created via loops as that will make it easier to add strings later and this way it's much easier to know what string caused a problem:

<img src="https://cloud.githubusercontent.com/assets/1514/14912371/ab03ae82-0df3-11e6-9c44-ee4d2f206f26.png">

