### PR TITLE
Add some coverage for period escapes

### DIFF
--- a/tests/scanners/test.filename.js
+++ b/tests/scanners/test.filename.js
@@ -93,6 +93,9 @@ describe('Hidden and Flagged File Regexes', function() {
   }
 
   const nonMatchingFlaggedFiles = [
+    'something/fooorig',
+    'something/old',
+    'foo/DS_Store',
     'Thumbs.db/foo',
     'whatever.orig/something',
     'whatever.old/something',


### PR DESCRIPTION
@tofumatt made a nice catch re: the missing period escapes in the file regexes. This adds a couple of test strings to cover those cases for the flagged files.