### PR TITLE
drop all css errors down to warnings

### DIFF
--- a/src/rules/css/detectBadMozBinding.js
+++ b/src/rules/css/detectBadMozBinding.js
@@ -11,7 +11,7 @@ export function detectBadMozBindingURL(cssNode, filename,
         if (isLocalCSSUri(node.value) === false) {
           messageList.push(
             Object.assign({}, messages.MOZ_BINDING_EXT_REFERENCE, {
-              type: 'error',
+              type: 'warning',
               line: startLine,
               column: startColumn,
               file: filename,

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -9,7 +9,7 @@ export function invalidNesting(cssNode, filename,
       if (node.type === 'rule') {
         messageList.push(
           Object.assign({}, messages.INVALID_SELECTOR_NESTING, {
-            type: 'error',
+            type: 'warning',
             line: startLine,
             column: startColumn,
             file: filename,

--- a/src/scanners/css.js
+++ b/src/scanners/css.js
@@ -4,7 +4,7 @@ import * as postcss from 'postcss';
 import BaseScanner from 'scanners/base';
 import log from 'logger';
 import { CSS_SYNTAX_ERROR } from 'messages';
-import { VALIDATION_ERROR } from 'const';
+import { VALIDATION_WARNING } from 'const';
 import { ignorePrivateFunctions } from 'utils';
 
 
@@ -82,7 +82,7 @@ export default class CSSScanner extends BaseScanner {
           return reject(e);
         } else {
           this.linterMessages.push(Object.assign({}, CSS_SYNTAX_ERROR, {
-            type: VALIDATION_ERROR,
+            type: VALIDATION_WARNING,
             // Use the reason for the error as the message.
             // e.message includes an absolute path.
             message: e.reason,

--- a/tests/rules/css/test.detectBadMozBinding.js
+++ b/tests/rules/css/test.detectBadMozBinding.js
@@ -1,6 +1,6 @@
 import * as messages from 'messages';
 
-import { VALIDATION_ERROR } from 'const';
+import { VALIDATION_WARNING } from 'const';
 import { singleLineString } from 'utils';
 
 import CSSScanner from 'scanners/css';
@@ -20,7 +20,7 @@ describe('CSS Rule detectBadMozBinding', () => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.MOZ_BINDING_EXT_REFERENCE.code);
-        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 

--- a/tests/rules/css/test.general.js
+++ b/tests/rules/css/test.general.js
@@ -1,6 +1,6 @@
 import * as messages from 'messages';
 
-import { VALIDATION_ERROR } from 'const';
+import { VALIDATION_WARNING } from 'const';
 
 import CSSScanner from 'scanners/css';
 
@@ -47,7 +47,7 @@ describe('CSS Rule General', () => {
         assert.equal(validationMessages[0].message, 'Unclosed comment');
         assert.equal(validationMessages[0].code,
                      messages.CSS_SYNTAX_ERROR.code);
-        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 });

--- a/tests/rules/css/test.invalidNesting.js
+++ b/tests/rules/css/test.invalidNesting.js
@@ -1,6 +1,6 @@
 import * as messages from 'messages';
 
-import { VALIDATION_ERROR } from 'const';
+import { VALIDATION_WARNING } from 'const';
 import { singleLineString } from 'utils';
 
 import CSSScanner from 'scanners/css';
@@ -22,7 +22,7 @@ describe('CSS Rule InvalidNesting', () => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.INVALID_SELECTOR_NESTING.code);
-        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -57,7 +57,7 @@ describe('CSS Rule InvalidNesting', () => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.INVALID_SELECTOR_NESTING.code);
-        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 

--- a/tests/scanners/test.css.js
+++ b/tests/scanners/test.css.js
@@ -1,5 +1,5 @@
 import * as messages from 'messages';
-import { VALIDATION_ERROR } from 'const';
+import { VALIDATION_WARNING } from 'const';
 import CSSScanner from 'scanners/css';
 import * as rules from 'rules/css';
 import { getRuleFiles, metadataPassCheck, validMetadata } from '../helpers';
@@ -17,7 +17,7 @@ describe('CSSScanner', () => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.CSS_SYNTAX_ERROR.code);
-        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
         assert.equal(validationMessages[0].message, 'Unclosed block');
         assert.equal(validationMessages[0].line, 1);
         assert.equal(validationMessages[0].column, 1);


### PR DESCRIPTION
* fixes #623, maybe it will be a warning in more context now
* but the more important point is that all CSS errors are now warnings

Shame I can't assign more people but a look over from @wagnerand would be nice.