### PR TITLE
Release 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-linter",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Mozilla Add-ons Linter",
   "main": "dist/addons-linter.js",
   "bin": {


### PR DESCRIPTION
* Warn if package already signed
* Less verbose manifest.json validation errors

Releasing a new version for the tag today.