### PR TITLE
Flag large files (fix #730)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -263,6 +263,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :x: | notice | deprecated_file | |  Extension contains a deprecated file | | [testcases/packagelayout.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/packagelayout.py) | | |
 | :x: | warning | FLAGGED_FILE_TYPE_type | | Flagged file type found | | | | |
+| :white_check_mark: | error | FILE_TOO_LARGE | webextension | File is too large to parse | | | | FILE_TOO_LARGE |
 | :x: | warning | java_jar | | Java JAR file detected | | | | |
 | :white_check_mark: | warning | disallowed_extension | | Flagged file extensions found | | https://github.com/mozilla/amo-validator/blob/master/validator/testcases/packagelayout.py | | FLAGGED_FILE_EXTENSION |
 | :negative_squared_cross_mark: | error | test_godlikea | | Banned 'godlikea' chrome namespace | | | | |

--- a/src/const.js
+++ b/src/const.js
@@ -113,6 +113,11 @@ export const VALID_MANIFEST_VERSION = 2;
 // The max file size in MB that the
 // io classes will open as strings or streams.
 export const MAX_FILE_SIZE_MB = 100;
+// This is the limit in megabytes of a file we will parse (eg. CSS, JS, etc.)
+// A singular CSS/JS file over 2MB seems bad and may actually be full of data
+// best stored in JSON/some other data format rather than code.
+// https://github.com/mozilla/addons-linter/issues/730
+export const MAX_FILE_SIZE_TO_PARSE_MB = 2;
 
 export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
 export const FLAGGED_FILE_REGEX = /thumbs\.db$|\.DS_Store$|\.orig$|\.old$|\~$/i;

--- a/src/io/base.js
+++ b/src/io/base.js
@@ -23,8 +23,9 @@ export class IOBase {
       case 'string':
         return this.getFileAsString(path);
       case 'chunk':
-        // Assuming that chunk is going to be primarily used for finding magic numbers
-        // in files, then there's no need to have the default be longer than that.
+        // Assuming that chunk is going to be primarily used for finding magic
+        // numbers in files, then there's no need to have the default be longer
+        // than that.
         return this.getChunkAsBuffer(path, FLAGGED_FILE_MAGIC_NUMBERS_LENGTH);
 
       default:

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -1,3 +1,4 @@
+import { MAX_FILE_SIZE_TO_PARSE_MB } from 'const';
 import { gettext as _, singleLineString } from 'utils';
 
 
@@ -70,6 +71,16 @@ export const TYPE_NOT_DETERMINED = {
   message: _('Unable to determine add-on type'),
   description: _(singleLineString`The type detection algorithm could not
     determine the type of the add-on.`),
+};
+
+export const FILE_TOO_LARGE = {
+  code: 'FILE_TOO_LARGE',
+  legacyCode: null,
+  message: _('File is too large to parse.'),
+  description: _(singleLineString`This file is not binary and is too large to
+    parse. Files larger than ${MAX_FILE_SIZE_TO_PARSE_MB}MB will not be
+    parsed. If your JavaScript file has a large list, consider removing the
+    list and loadng it as a separate JSON file instead.`),
 };
 
 export const HIDDEN_FILE = {

--- a/tests/io/test.base.js
+++ b/tests/io/test.base.js
@@ -15,7 +15,7 @@ describe('io.IOBase()', function() {
     assert.equal(io.maxSizeBytes, 104857600);
   });
 
-  it('should should reject calling getFiles()', () => {
+  it('should reject calling getFiles()', () => {
     var io = new IOBase('foo/bar');
 
     return io.getFiles()
@@ -26,7 +26,7 @@ describe('io.IOBase()', function() {
       });
   });
 
-  it('should should reject calling getFileAsString()', () => {
+  it('should reject calling getFileAsString()', () => {
     var io = new IOBase('foo/bar');
 
     return io.getFileAsString()
@@ -37,7 +37,7 @@ describe('io.IOBase()', function() {
       });
   });
 
-  it('should should reject calling getFileAsString()', () => {
+  it('should reject calling getFileAsString()', () => {
     var io = new IOBase('foo/bar');
 
     return io.getFileAsStream()

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -157,7 +157,7 @@ describe('Linter', function() {
 
   it('should throw when message.type is undefined', () => {
     var addonLinter = new Linter({_: ['tests/fixtures/example.xpi']});
-    addonLinter.io = {};
+    addonLinter.io = { files: {whatever: {}} };
     addonLinter.io.getFile = () => Promise.resolve();
     addonLinter.getScanner = sinon.stub();
     class fakeScanner {
@@ -971,6 +971,73 @@ describe('Linter.extractMetadata()', function() {
       .catch((err) => {
         assert.ok(markEmptyFilesSpy.called);
         assert.equal(err.message, 'No size available for whatever');
+      });
+  });
+
+  it('should error if file size of a non-binary file is too large', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    addonLinter.checkFileExists = fakeCheckFileExists;
+    // suppress output.
+    addonLinter.print = sinon.stub();
+    var largeFileSize = (constants.MAX_FILE_SIZE_TO_PARSE_MB * 1024 * 1024) + 1;
+    class FakeXpi {
+      files = {
+        'manifest.json': { uncompressedSize: 839 },
+        'myfile.css': { uncompressedSize: largeFileSize },
+        'myfile.js': { uncompressedSize: largeFileSize },
+      };
+      getFile(filename) {
+        return this.getFileAsString(filename);
+      }
+      getFiles() {
+        return Promise.resolve(this.files);
+      }
+      getFilesByExt(type) {
+        return Promise.resolve(type === 'js' ? ['myfile.js'] : ['myfile.css']);
+      }
+      getFileAsString(filename) {
+        return Promise.resolve((filename === constants.MANIFEST_JSON) ?
+          validManifestJSON() : 'var foo = "bar";');
+      }
+    }
+    return addonLinter.scan({_Xpi: FakeXpi, _console: fakeConsole})
+      .then(() => {
+        assert.equal(addonLinter.collector.errors[0].code,
+                     messages.FILE_TOO_LARGE.code);
+        // CSS and JS files that are too large should be flagged.
+        assert.lengthOf(addonLinter.collector.errors, 2);
+      });
+  });
+
+  it('should ignore large binary files', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    addonLinter.checkFileExists = fakeCheckFileExists;
+    // suppress output.
+    addonLinter.print = sinon.stub();
+    var largeFileSize = constants.MAX_FILE_SIZE_TO_PARSE_MB * 1024 * 1024 * 4;
+    class FakeXpi {
+      files = {
+        'manifest.json': { uncompressedSize: 839 },
+        'myfile.jpg': { uncompressedSize: largeFileSize },
+      };
+      getFile(filename) {
+        return this.getFileAsString(filename);
+      }
+      getFiles() {
+        return Promise.resolve(this.files);
+      }
+      getFilesByExt(type) {
+        return Promise.resolve(type === 'json' ? ['manifest.json'] :
+                                                 ['myfile.jpg']);
+      }
+      getFileAsString(filename) {
+        return Promise.resolve((filename === constants.MANIFEST_JSON) ?
+          validManifestJSON() : '');
+      }
+    }
+    return addonLinter.scan({_Xpi: FakeXpi, _console: fakeConsole})
+      .then(() => {
+        assert.lengthOf(addonLinter.collector.errors, 0);
       });
   });
 


### PR DESCRIPTION
Will fix https://github.com/mozilla/addons-server/issues/2699.

I figured we only need to flag/warn on large JS files, as:

1. it's unlikely other files would be as large
2. I _assume_ large CSS/JSON files won't blow up the parsers the same way JS does because ESLint ends up doing the whole tree-building statement assembling stuff because JS is a real language

If that seems too naive let me know; I thought it was nicer (and it ends up being slightly less complicated code as well, I think?)