### PR TITLE
Bump to version 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-linter",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Mozilla Add-ons Linter",
   "main": "dist/addons-linter.js",
   "bin": {
@@ -67,7 +67,7 @@
     "cheerio": "0.20.0",
     "columnify": "1.5.4",
     "crx-parser": "0.1.2",
-    "dispensary": "0.5.0",
+    "dispensary": "0.5.1",
     "es6-promisify": "4.1.0",
     "eslint": "2.11.1",
     "esprima": "2.7.2",


### PR DESCRIPTION
Includes updated JS hashes and library info.

Closes #742.