### PR TITLE
Fold web-extension-manifest-schema into addons-linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "json-loader": "0.5.4",
     "load-grunt-configs": "1.0.0",
     "load-grunt-tasks": "3.5.0",
+    "lodash.clonedeep": "4.3.2",
     "markdown-it": "6.0.4",
     "markdown-it-anchor": "2.5.0",
     "markdown-it-emoji": "1.2.0",
@@ -61,6 +62,7 @@
     "webpack-dev-server": "1.14.0"
   },
   "dependencies": {
+    "ajv": "4.1.3",
     "babel-polyfill": "6.9.1",
     "bunyan": "1.8.1",
     "chalk": "1.1.3",
@@ -72,7 +74,6 @@
     "eslint": "2.12.0",
     "esprima": "2.7.2",
     "first-chunk-stream": "2.0.0",
-    "mozilla-web-extension-manifest-schema": "0.5.3",
     "postcss": "5.0.21",
     "semver": "5.1.0",
     "sha.js": "2.4.5",

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1,5 +1,5 @@
 import esprima from 'esprima';
-import validate from 'mozilla-web-extension-manifest-schema';
+import validate from 'schema/validator';
 
 import cli from 'cli';
 import { PACKAGE_EXTENSION } from 'const';

--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -1,0 +1,33 @@
+const VALIDNUMRX = /^[0-9]{1,5}$/;
+const RELATIVE_URL_REGEX = /^(?!(.+|)\/)/;
+
+
+export function isValidVersionString(version) {
+  // We should be starting with a string.
+  if (typeof version !== 'string') {
+    return false;
+  }
+  var parts = version.split('.');
+  if (parts.length > 4) {
+    return false;
+  }
+  for (var part of parts) {
+    // Leading or multiple zeros not allowed.
+    if (part.startsWith('0') && part.length > 1) {
+      return false;
+    }
+    // Disallow things like 123e5 which parseInt will convert.
+    if (!VALIDNUMRX.test(part)) {
+      return false;
+    }
+    part = parseInt(part, 10);
+    if (Number.isNaN(part) || part < 0 || part > 65535) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isRelativeURL(url) {
+  return Boolean(url.match(RELATIVE_URL_REGEX));
+}

--- a/src/schema/manifest-schema.json
+++ b/src/schema/manifest-schema.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://jsonschema.net",
+    "type": "object",
+    "properties": {
+        "applications": {
+            "type": "object",
+            "properties": {
+                "gecko": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "description": "id is the extension ID. Optional. See https://developer.mozilla.org/Add-ons/Install_Manifests#id",
+                            "pattern": "^{[A-Fa-f0-9]{8}-([A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}}$|^[A-Za-z0-9-._]*\\@[A-Za-z0-9-._]+$",
+                            "type": "string"
+                        },
+                        "strict_min_version": {
+                            "default": "42a1",
+                            "description": "Minimum version of Gecko to support. Defaults to '42a1'. (Requires Gecko 45)",
+                            "type": "string"
+                        },
+                        "strict_max_version": {
+                            "default": "*",
+                            "description": "Maximum version of Gecko to support. Defaults to '*'. (Requires Gecko 45)",
+                            "type": "string"
+                        },
+                        "update_url": {
+                            "description": "Link to an add-on update manifest. (Requires Gecko 45)",
+                            "type": "string",
+                            "format": "uri"
+                        }
+                    }
+                }
+            }
+        },
+        "name": {
+            "description": "Name of the extension. This is used to identify the extension in the browser's user interface and on sites like addons.mozilla.org.",
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 45
+        },
+        "homepage_url": {
+            "description": "The URL of the homepage for this add-on. The add-on management page will contain a link to this URL.",
+            "type": "string",
+            "format": "uri"
+        },
+        "icons": {
+            "description": "Icons to be shown in buttons and the add-on management page.",
+            "type": "object",
+            "patternProperties": {
+                "^[1-9]\\d*$": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "background": {
+            "description": "This key specifies how background scripts will work.",
+            "type": "object",
+            "properties": {
+                "scripts": {
+                    "type": "array",
+                    "items": {
+                        "format": "relativeURL"
+                    }
+                },
+                "page": {
+                    "type": "string",
+                    "format": "relativeURL"
+                }
+            },
+            "additionalProperties": false
+        },
+        "manifest_version": {
+            "description": "This key specifies the version of manifest.json used by this extension. Currently, this must always be 2.",
+            "minimum": 2,
+            "maximum": 2,
+            "type": "integer"
+        },
+        "version": {
+            "$ref": "#/definitions/versionString"
+        },
+        "permissions": {
+            "description": "Permissions allowed for the extension",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "enum": [
+                            "activeTab",
+                            "alarms",
+                            "bookmarks",
+                            "contextMenus",
+                            "cookies",
+                            "downloads",
+                            "downloads.open",
+                            "downloads.shelf",
+                            "idle",
+                            "notifications",
+                            "storage",
+                            "tabs",
+                            "webNavigation",
+                            "webRequest",
+                            "webRequestBlocking",
+                            "<all_urls>"
+                        ]
+                    },
+                    {
+                        "type": "string",
+                        "pattern": "^(https?|file|ftp|app|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$"
+                    },
+                    {
+                        "type": "string",
+                        "pattern": "^file:///.*$"
+                    }
+                ]
+            }
+        },
+        "web_accessible_resources": {
+            "description": "Resources accessible to the extension",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "name",
+        "manifest_version",
+        "version"
+    ],
+    "definitions": {
+        "versionString": {
+            "format": "versionString",
+            "type": "string",
+            "description": "Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3."
+        }
+    }
+}

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -1,0 +1,15 @@
+import ajv from 'ajv';
+import { isRelativeURL, isValidVersionString } from './formats';
+
+export var schemaObject = require('json!schema/manifest-schema');
+
+var validator = ajv({
+  allErrors: true,
+  errorDataPath: 'property',
+  jsonPointers: true,
+  verbose: true,
+});
+validator.addFormat('versionString', isValidVersionString);
+validator.addFormat('relativeURL', isRelativeURL);
+
+export default validator.compile(schemaObject);

--- a/tests/schema/helpers.js
+++ b/tests/schema/helpers.js
@@ -1,0 +1,10 @@
+export const validManifest = {
+  manifest_version: 2,
+  name: 'test-manifest',
+  version: '1.0',
+  applications: {
+    gecko: {
+      id: 'test-manifest@mozilla.org',
+    },
+  },
+};

--- a/tests/schema/test.applications.js
+++ b/tests/schema/test.applications.js
@@ -1,0 +1,84 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import cloneDeep from 'lodash.clonedeep';
+
+
+describe('/applications/*', () => {
+  it('should not require an application object', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications = undefined;
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+});
+
+describe('/applications/gecko/*', () => {
+
+  it('should not require a gecko object', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko = undefined;
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('should be invalid due to invalid update_url', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.update_url = 'whatevs';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/applications/gecko/update_url');
+  });
+
+  it('should be invalid due to invalid strict_min_version type', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.strict_min_version = 42;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath,
+      '/applications/gecko/strict_min_version');
+  });
+
+  it('should be invalid due to invalid strict_max_version type', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.strict_max_version = 42;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath,
+      '/applications/gecko/strict_max_version');
+  });
+
+  it('should be a valid id (email-like format)', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.id = 'extensionname@example.org';
+    assert.ok(validate(manifest));
+  });
+
+  it('should be a valid id @whatever', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.id = '@example.org';
+    assert.ok(validate(manifest));
+  });
+
+  it('should be a valid id (guid format)', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.id = '{daf44bf7-a45e-4450-979c-91cf07434c3d}';
+    assert.ok(validate(manifest));
+  });
+
+  it('should be invalid id format', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.id = 'whatevs';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath,
+      '/applications/gecko/id');
+  });
+
+  it('should accept an add-on without an id', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko.id = undefined;
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+});

--- a/tests/schema/test.background.js
+++ b/tests/schema/test.background.js
@@ -1,0 +1,53 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+
+
+describe('/background', () => {
+
+  it('script absolute URL should be invalid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.background = {scripts: ['http://foo']};
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/background/scripts/0');
+    assert.equal(validate.errors[0].message,
+                 'should match format "relativeURL"');
+  });
+
+  it('script relative URL should be valid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.background = {scripts: ['foo.png']};
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('page absolute URL should be invalid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.background = {page: 'http://foo'};
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/background/page');
+    assert.equal(validate.errors[0].message,
+                 'should match format "relativeURL"');
+  });
+
+  it('page relative URL should be valid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.background = {page: 'foo.png'};
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('persistent not expected', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.background = {persistent: true};
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/background/persistent');
+    assert.equal(validate.errors[0].message,
+                 'should NOT have additional properties');
+  });
+
+});

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -1,0 +1,60 @@
+import { isRelativeURL, isValidVersionString } from 'schema/formats';
+
+describe('formats.isValidVersionString', () => {
+
+  var validVersionStrings = [
+    '1.0',
+    '2.10.2',
+    '3.1.2.4567',
+    '3.1.2.65535',
+  ];
+
+  var invalidVersionStrings = [
+    2,
+    '123e5',
+    '1.',
+    '.',
+    'a.b.c.d',
+    '1.2.2.2.4',
+    '01',
+    '1.000000',
+    '2.99999',
+    '3.65536',
+    '1.0.0-beta2',
+  ];
+
+
+  for (let validVersionString of validVersionStrings) {
+    it(`should find ${validVersionString} to be valid`, () => {
+      assert.ok(isValidVersionString(validVersionString));
+    });
+  }
+
+  for (let invalidVersionString of invalidVersionStrings) {
+    it(`should find ${invalidVersionString} to be invalid`, () => {
+      assert.notOk(isValidVersionString(invalidVersionString));
+    });
+  }
+});
+
+describe('formats.isRelativeURL', () => {
+
+  const notRelativeURLs = [
+    'http://foo',
+    'Https://foo.com/bar',
+    'moz-extension://wat',
+    '//foo',
+    '/foo',
+  ];
+
+  for (const notRelativeURL of notRelativeURLs) {
+    it(`${notRelativeURL} should be invalid`, () => {
+      assert.notOk(isRelativeURL(notRelativeURL));
+    });
+  }
+
+  it('should be valid', () => {
+    assert.isOk(isRelativeURL('something.png'));
+  });
+
+});

--- a/tests/schema/test.homepage_url.js
+++ b/tests/schema/test.homepage_url.js
@@ -1,0 +1,32 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+
+
+describe('/homepage_url', () => {
+
+  const validURLs = [
+    'https://example.com/some/page',
+    'http://foo.com',
+  ];
+
+  for (let validURL of validURLs) {
+    it(`${validURL} should be valid`, () => {
+      var manifest = cloneDeep(validManifest);
+      manifest.homepage_url = validURL;
+      validate(manifest);
+      assert.isNull(validate.errors);
+    });
+  }
+
+  it('not a URI should be invalid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.homepage_url = 'wat';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/homepage_url');
+    assert.equal(validate.errors[0].message, 'should match format "uri"');
+  });
+
+});

--- a/tests/schema/test.icons.js
+++ b/tests/schema/test.icons.js
@@ -1,0 +1,34 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+
+
+describe('/icons', () => {
+
+  it('should be valid', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.icons = {48: 'icon.png', 96: 'bigger.png'};
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('should fail on integer value', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.icons = {48: 1};
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/icons/48');
+    assert.equal(validate.errors[0].message, 'should be string');
+  });
+
+  it('should fail on non-number key', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.icons = {wat: 'foo'};
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/icons/wat');
+    assert.equal(validate.errors[0].message,
+                 'should NOT have additional properties');
+  });
+});

--- a/tests/schema/test.manifest_version.js
+++ b/tests/schema/test.manifest_version.js
@@ -1,0 +1,25 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import cloneDeep from 'lodash.clonedeep';
+
+
+describe('/manifest_version', () => {
+
+  it('should be invalid due to old manifest_version', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.manifest_version = 1;
+    validate(manifest);
+    assert.equal(validate.errors[0].dataPath, '/manifest_version');
+    assert.equal(validate.errors.length, 1);
+  });
+
+  it('should be invalid due to missing manifest_version', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.manifest_version = undefined;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/manifest_version');
+    assert.equal(validate.errors[0].params.missingProperty, 'manifest_version');
+  });
+
+});

--- a/tests/schema/test.name.js
+++ b/tests/schema/test.name.js
@@ -1,0 +1,33 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import cloneDeep from 'lodash.clonedeep';
+
+
+describe('/name', () => {
+
+  it('should be invalid due to name > 45 chars', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.name = 'a'.repeat(46);
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/name');
+  });
+
+  it('should be invalid due to name < 2 chars', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.name = 'a';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/name');
+  });
+
+  it('should be invalid due to missing a name', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.name = undefined;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/name');
+    assert.equal(validate.errors[0].params.missingProperty, 'name');
+  });
+
+});

--- a/tests/schema/test.permissions.js
+++ b/tests/schema/test.permissions.js
@@ -1,0 +1,49 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import cloneDeep from 'lodash.clonedeep';
+
+
+describe('/permissions', () => {
+
+  it('should allow a valid permission', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.permissions = ['tabs'];
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('should not allow duplicate permissions', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.permissions = ['tabs', 'tabs'];
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/permissions');
+  });
+
+  it('should not allow an invalid permission', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.permissions = ['wat'];
+    validate(manifest);
+    assert.equal(validate.errors.length, 4);
+    assert.equal(validate.errors[0].dataPath, '/permissions/0');
+  });
+
+  var matchingPatterns = [
+    '*://developer.mozilla.org/*',
+    'http://developer.mozilla.org/*',
+    'https://foo.com',
+    'ftp://do.people.still.use.this',
+    'app://wat',
+    'file:///etc/hosts',
+  ];
+
+  for (var matchPattern of matchingPatterns) {
+    it(`should allow the pattern: ${matchPattern}`, () => {
+      var manifest = cloneDeep(validManifest);
+      manifest.permissions = [matchPattern];
+      validate(manifest);
+      assert.isNull(validate.errors);
+    });
+  }
+
+});

--- a/tests/schema/test.schema.js
+++ b/tests/schema/test.schema.js
@@ -1,0 +1,12 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+
+
+describe('Schema JSON', () => {
+
+  it('should be valid against the reference schema', () => {
+    var isValid = validate(validManifest);
+    assert.ok(isValid);
+  });
+
+});

--- a/tests/schema/test.version.js
+++ b/tests/schema/test.version.js
@@ -1,0 +1,25 @@
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import cloneDeep from 'lodash.clonedeep';
+
+
+describe('/version', () => {
+
+  it('should be invalid due to invalid version', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.version = '01';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/version');
+  });
+
+  it('should be invalid due to missing version', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.version = undefined;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/version');
+    assert.equal(validate.errors[0].params.missingProperty, 'version');
+  });
+
+});

--- a/tests/schema/test.web_accessible_resources.js
+++ b/tests/schema/test.web_accessible_resources.js
@@ -1,0 +1,34 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+
+
+describe('/web_accessible_resources', () => {
+
+  it('should be an array', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.web_accessible_resources = 'foo.png';
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/web_accessible_resources');
+    assert.equal(validate.errors[0].message, 'should be array');
+  });
+
+  it('should fail if not an array of strings', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.web_accessible_resources = ['foo.png', 1];
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/web_accessible_resources/1');
+    assert.equal(validate.errors[0].message, 'should be string');
+  });
+
+  it('should be array of strings', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.web_accessible_resources = ['foo.png', 'bar.css'];
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+});


### PR DESCRIPTION
Fixes #750

This PR moves the schema into the linter so we have one less package to deal with when making updates. 

Once this passes review we can deprecate web-extension-manifest-schema repo and move all the bugs.