### PR TITLE
Don't allow duplicate keys in manifest (fix #803)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -357,6 +357,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :white_check_mark: | error | Web extension | manifest.json is not well formed. | manifest.json | | null | MANIFEST_JSON_INVALID |
+| :white_check_mark: | error | Web extension | Duplicate key in manifest.json. | manifest.json | | null | MANIFEST_DUPLICATE_KEY |
 | :white_check_mark: | error | Web extension | manifest_version in manifest.json is not valid. | manifest.json | | null | MANIFEST_VERSION_INVALID |
 | :white_check_mark: | error | Web extension | name property missing from manifest.json | manifest.json | | null | PROP_NAME_MISSING |
 | :white_check_mark: | error | Web extension | name property is invalid in manifest.json | manifest.json | | null | PROP_NAME_INVALID |

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "esprima": "2.7.2",
     "first-chunk-stream": "2.0.0",
     "postcss": "5.0.21",
+    "relaxed-json": "1.0.0",
     "semver": "5.2.0",
     "sha.js": "2.4.5",
     "source-map-support": "0.4.1",

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -19,6 +19,14 @@ export const MANIFEST_BLOCK_COMMENTS = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_DUPLICATE_KEY = {
+  code: 'MANIFEST_DUPLICATE_KEY',
+  legacyCode: null,
+  message: _('Duplicate keys are not allowed in manifest.'),
+  description: _(singleLineString`Duplicate key found in manifest.json.`),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_FIELD_REQUIRED = {
   code: 'MANIFEST_FIELD_REQUIRED',
   legacyCode: null,


### PR DESCRIPTION
I tried to do this with [`JSON.parse`'s reviver parameter](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Using_the_reviver_parameter), but unfortunately it doesn't behave as I hoped and actually doesn't report dupe keys and is overall a bit weird.

So the easiest solution was to include a parser solely to check for dupe keys.