### PR TITLE
Report known js libraries.

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -121,6 +121,7 @@ A :white_check_mark: next to a section of rules means they have all been filed i
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :white_check_mark: | error | BANNED_LIBRARY | | This version of a JS library is banned for security reasons. | | | | BANNED_LIBRARY |
 | :white_check_mark: | warning | UNADVISED_LIBRARY | | This version of a JS library is not recommended. | | | | UNADVISED_LIBRARY |
+| :white_check_mark: | notice | KNOWN_LIBRARY | This version of a JS library is known and generally accepted. | | | | KNOWN_LIBRARY |
 
 ## Markup
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -121,7 +121,7 @@ A :white_check_mark: next to a section of rules means they have all been filed i
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :white_check_mark: | error | BANNED_LIBRARY | | This version of a JS library is banned for security reasons. | | | | BANNED_LIBRARY |
 | :white_check_mark: | warning | UNADVISED_LIBRARY | | This version of a JS library is not recommended. | | | | UNADVISED_LIBRARY |
-| :white_check_mark: | notice | KNOWN_LIBRARY | This version of a JS library is known and generally accepted. | | | | KNOWN_LIBRARY |
+| :white_check_mark: | notice | KNOWN_LIBRARY | This version of a JS library is known and generally accepted. | | | blacklisted_js_library | KNOWN_LIBRARY |
 
 ## Markup
 
@@ -179,7 +179,6 @@ A :white_check_mark: next to a section of rules means they have all been filed i
 | :negative_squared_cross_mark: | warning | found_in_chrome_manifest| | newTab.xul is now newTab.xhtml |  chrome.manifest | | | |
 | :white_check_mark: | warning | hidden_files | | Hidden file flagged | | | [testcases/content.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/content.py) | HIDDEN_FILE |
 | :white_check_mark: | warning | flagged_files | | Flagged filename found | | |[testcases/content.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/content.py) | FLAGGED_FILE |
-| :x: | notice | blacklisted_js_library | | JS Library Detected | | | | |
 | :negative_squared_cross_mark: | warning | invalid_chrome_url | | Invalid chrome URL | | | | |
 | :x: | warning | too_much_js | | TOO MUCH JS FOR EXHAUSTIVE VALIDATION | | | | |
 | :negative_squared_cross_mark: | error | unsigned_sub_xpi | | Sub-package must be signed | | | | |

--- a/src/linter.js
+++ b/src/linter.js
@@ -513,6 +513,12 @@ export default class Linter {
               if (hashResult !== false) {
                 log.debug(`${hashResult} detected in ${filename}`);
                 jsLibs[filename] = hashResult;
+
+                this.collector.addNotice(
+                  Object.assign({}, messages.KNOWN_LIBRARY, {
+                    file: filename,
+                  })
+                );
               }
             }));
         }

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -229,3 +229,13 @@ export const UNADVISED_LIBRARY = {
     not recommend. Read more: https://bit.ly/1TRIyZY`),
   legacyCode: null,
 };
+
+export const KNOWN_LIBRARY = {
+  code: 'KNOWN_LIBRARY',
+  message: _('Known JS library detected'),
+  description: _(singleLineString`JavaScript libraries are discouraged for
+    simple add-ons, but are generally accepted.`),
+  legacyCode: [
+    'testcases_content', 'test_packed_packages', 'blacklisted_js_library',
+  ],
+};

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -840,13 +840,16 @@ describe('Linter.extractMetadata()', function() {
     return addonLinter.extractMetadata({
       _console: fakeConsole,
       _Xpi: FakeXpi,
-    }).then(() => {
+    }).then((metadata) => {
       assert.ok(markJSFilesSpy.called);
-      // assert.equal(Object.keys(metadata.jsLibs).length, 2);
-      // assert.deepEqual(metadata.jsLibs, {
-      //   'angular.js': 'angularjs.1.2.28.angular.min.js',
-      //   'my/nested/library/path/j.js': 'jquery.2.1.4.jquery-2.1.4.min.js',
-      // });
+      assert.equal(Object.keys(metadata.jsLibs).length, 1);
+      assert.deepEqual(metadata.jsLibs, {
+        'my/nested/library/path/j.js': 'jquery.2.1.4.jquery.min.js',
+      });
+
+      var notices = addonLinter.collector.notices;
+      assert.equal(notices.length, 3);
+      assert.equal(notices[2].code, messages.KNOWN_LIBRARY.code);
     });
   });
 


### PR DESCRIPTION
This is something the amo-validator does so we need that
for compatibility reasons.

Refs mozilla/addons-server#3015