### PR TITLE
warn on deprecated apis

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -372,3 +372,12 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | Bad permission | manifest.json | | null | MANIFEST_BAD_PERMISSION |
 | :white_check_mark: | warning | Web extension | Unknown permission | manifest.json | | null | MANIFEST_PERMISSIONS |
 | :white_check_mark: | error | Web extension | Block Comments are not allowed in `manifest.json` | manifest.json | | null | MANIFEST_BLOCK_COMMENTS |
+| :white_check_mark: | warning | Web extension | Deprecated API tabs.getSelected | | | null | TABS_GETSELECTED |
+| :white_check_mark: | warning | Web extension | Deprecated API tabs.sendRequest | | | null | TABS_SENDREQUEST |
+| :white_check_mark: | warning | Web extension | Deprecated API tabs.getAllInWindow | | | null | TABS_GETALLINWINDOW |
+| :white_check_mark: | warning | Web extension | Deprecated API tabs.onSelectionChanged | | | null | TABS_ONSELECTIONCHANGED |
+| :white_check_mark: | warning | Web extension | Deprecated API tabs.onActiveChanged | | | null | TABS_ONACTIVECHANGED |
+| :white_check_mark: | warning | Web extension | Deprecated API extension.sendRequest | | | null | EXT_SENDREQUEST |
+| :white_check_mark: | warning | Web extension | Deprecated API extension.onRequestExternal | | | null | EXT_ONREQUESTEXTERNAL |
+| :white_check_mark: | warning | Web extension | Deprecated API extension.onRequest | | | null | EXT_ONREQUEST |
+| :white_check_mark: | warning | Web extension | Deprecated API app.getDetails | | | null | APP_GETDETAILS |

--- a/src/const.js
+++ b/src/const.js
@@ -18,6 +18,7 @@ export const ESLINT_RULE_MAPPING = {
   opendialog_nonlit_uri: ESLINT_WARNING,
   opendialog_remote_uri: ESLINT_WARNING,
   shallow_wrapper: ESLINT_WARNING,
+  webextension_api: ESLINT_WARNING,
   widget_module: ESLINT_WARNING,
 };
 
@@ -130,9 +131,20 @@ export const FLAGGED_FILE_MAGIC_NUMBERS = [
   [0x23, 0x21], // Shell script
   [0xca, 0xfe, 0xba, 0xbe], // Java + Mach-O (dylib)
   [0xca, 0xfe, 0xd0, 0x0d], // Java packed
-  [0x46, 0x57, 0x53], // Uncompressed SWF
   [0x43, 0x57, 0x53], // Compressed SWF
 ];
 
 // Based on the above, this is how deep we need to look into a file.
 export const FLAGGED_FILE_MAGIC_NUMBERS_LENGTH = 4;
+
+export const DEPRECATED_APIS = [
+  'app.getDetails',
+  'extension.onRequest',
+  'extension.onRequestExternal',
+  'extension.sendRequest',
+  'tabs.getAllInWindow',
+  'tabs.getSelected',
+  'tabs.onActiveChanged',
+  'tabs.onSelectionChanged',
+  'tabs.sendRequest',
+];

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,4 +1,4 @@
-import { gettext as _, singleLineString } from 'utils';
+import { apiToMessage, gettext as _, singleLineString } from 'utils';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
@@ -239,3 +239,29 @@ export const KNOWN_LIBRARY = {
     'testcases_content', 'test_packed_packages', 'blacklisted_js_library',
   ],
 };
+
+function deprecatedAPI(api) {
+  return {
+    code: apiToMessage(api),
+    legacyCode: [
+      'js',
+      'deprecated',
+      api,
+    ],
+    message: _(`"${api}" is deprecated or unimplemented`),
+    description: _(singleLineString`This API has been deprecated by Chrome
+      and has not been implemented by Firefox.`),
+  };
+}
+
+export const APP_GETDETAILS = deprecatedAPI('app.getDetails');
+export const EXT_ONREQUEST = deprecatedAPI('extension.onRequest');
+export const EXT_ONREQUESTEXTERNAL = deprecatedAPI(
+  'extension.onRequestExternal');
+export const EXT_SENDREQUEST = deprecatedAPI('extension.sendRequest');
+export const TABS_GETALLINWINDOW = deprecatedAPI('tabs.getAllInWindow');
+export const TABS_GETSELECTED = deprecatedAPI('tabs.getSelected');
+export const TABS_ONACTIVECHANGED = deprecatedAPI('tabs.onActiveChanged');
+export const TABS_ONSELECTIONCHANGED = deprecatedAPI(
+  'tabs.onSelectionChanged');
+export const TABS_SENDREQUEST = deprecatedAPI('tabs.sendRequest');

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -11,4 +11,5 @@ export * from './only_prefs_in_defaults';
 export * from './opendialog_nonlit_uri';
 export * from './opendialog_remote_uri';
 export * from './shallow_wrapper';
+export * from './webextension_api';
 export * from './widget_module';

--- a/src/rules/javascript/webextension_api.js
+++ b/src/rules/javascript/webextension_api.js
@@ -1,0 +1,16 @@
+import { DEPRECATED_APIS } from 'const';
+import { apiToMessage } from '../../utils';
+
+export function webextension_api(context) {
+  return {
+    MemberExpression: function(node) {
+      if (node.object.object &&
+          ['chrome', 'browser'].includes(node.object.object.name)) {
+        let api = `${node.object.property.name}.${node.property.name}`;
+        if (DEPRECATED_APIS.includes(api)) {
+          return context.report(node, apiToMessage(api));
+        }
+      }
+    },
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,3 +215,11 @@ export function isLocalUrl(urlInput) {
   }
   return true;
 }
+
+export function apiToMessage(string) {
+  return string
+    .replace(/^extension/, 'ext')
+    .replace(/\./g, '_')
+    .toUpperCase()
+    .substr(0, 25);
+}

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -1,14 +1,13 @@
 import ESLint from 'eslint';
 
-import { ESLINT_ERROR, ESLINT_RULE_MAPPING, VALIDATION_ERROR,
+import { DEPRECATED_APIS, ESLINT_ERROR, ESLINT_RULE_MAPPING, VALIDATION_ERROR,
          VALIDATION_WARNING } from 'const';
 import JavaScriptScanner from 'scanners/javascript';
 import * as messages from 'messages';
 import * as rules from 'rules/javascript';
-import { ignorePrivateFunctions, singleLineString } from 'utils';
+import { apiToMessage, ignorePrivateFunctions, singleLineString } from 'utils';
 import { fakeMessageData, getRuleFiles, getVariable, unexpectedSuccess,
          validMetadata } from '../helpers';
-
 
 describe('JavaScript Scanner', function() {
 
@@ -282,4 +281,18 @@ describe('JavaScript Scanner', function() {
                      Object.keys(ignorePrivateFunctions(rules)).length);
       });
   });
+
+  for (let api of DEPRECATED_APIS) {
+    it(`should return warning when ${api} is used`, () => {
+      var jsScanner = new JavaScriptScanner(
+        `chrome.${api}(function() {});`, 'code.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code, apiToMessage(api));
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+  }
 });


### PR DESCRIPTION
* supports: #780 and maybe fixes it, dunno
* fixes #777
* fixes #776
* fixes #775
* fixes #774
* fixes #773
* fixes #772
* fixes #769
* fixes #762
* fixes #761

* feels a bit clunky in that the code needs to be truncated down and each deprecated API needs to be added in 3 places
* also not sure about the eslint scanner, `node.object.object.name` feels clunky