### PR TITLE
Add support for default Node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
+- '0.12'
 - '4'
 - '5'
 script: npm test


### PR DESCRIPTION
It would be nice to support the default version of Node (like, what ships with OS X). I don't know how hard it would be so I wanted to kick off a build to see.

My main motivation is that `web-ext` aims to support the default Node (more importantly, npm 2.x) and we got this error when trying to upgrade to the latest `addons-linter`: https://travis-ci.org/mozilla/web-ext/jobs/147481973