### PR TITLE
Add callback to control which files can be scanned

### DIFF
--- a/src/io/base.js
+++ b/src/io/base.js
@@ -14,6 +14,15 @@ export class IOBase {
     // If this is too large the node process will hit a RangeError
     // when it runs out of memory.
     this.maxSizeBytes = 1024 * 1024 * MAX_FILE_SIZE_MB;
+    // A callback that accepts a relative file path and returns
+    // true if the path should be included in results for scanning.
+    this.shouldScanFile = () => true;
+  }
+
+  setScanFileCallback(callback) {
+    if (typeof callback === 'function') {
+      this.shouldScanFile = callback;
+    }
   }
 
   getFile(path, fileStreamType='string') {

--- a/src/io/directory.js
+++ b/src/io/directory.js
@@ -24,7 +24,10 @@ export class Directory extends IOBase {
       return Promise.resolve(this.files);
     }
 
-    return _walkPromise(this.path)
+    return _walkPromise(
+      this.path, {
+        shouldIncludePath: this.shouldScanFile.bind(this),
+      })
       .then((files) => {
         this.files = files;
         this.entries = Object.keys(files);

--- a/src/io/directory.js
+++ b/src/io/directory.js
@@ -26,7 +26,7 @@ export class Directory extends IOBase {
 
     return _walkPromise(
       this.path, {
-        shouldIncludePath: this.shouldScanFile.bind(this),
+        shouldIncludePath: (...args) => this.shouldScanFile(...args),
       })
       .then((files) => {
         this.files = files;

--- a/src/linter.js
+++ b/src/linter.js
@@ -359,15 +359,19 @@ export default class Linter {
         if (stats.isFile() === true) {
           if (this.packagePath.endsWith('.crx')) {
             log.info('Package is a file ending in .crx; parsing as a CRX');
-            this.io = new _Crx(this.packagePath);
+            return new _Crx(this.packagePath);
           } else {
             log.info('Package is a file. Attempting to parse as an .xpi/.zip');
-            this.io = new _Xpi(this.packagePath);
+            return new _Xpi(this.packagePath);
           }
         } else if (stats.isDirectory()) {
           log.info('Package path is a directory. Parsing as a directory');
-          this.io = new _Directory(this.packagePath);
+          return new _Directory(this.packagePath);
         }
+      })
+      .then((io) => {
+        io.setScanFileCallback(this.config.shouldScanFile);
+        this.io = io;
         return this.getAddonMetadata();
       })
       .then((addonMetadata) => {

--- a/tests/io/test.base.js
+++ b/tests/io/test.base.js
@@ -80,4 +80,29 @@ describe('io.IOBase()', function() {
     assert.ok(io.getChunkAsBuffer.calledWith('get-a-chunk-as-buffer',
       FLAGGED_FILE_MAGIC_NUMBERS_LENGTH));
   });
+
+  it('should scan all files by default', () => {
+    const io = new IOBase('foo/bar');
+    assert.ok(io.shouldScanFile('install.rdf'));
+    assert.ok(io.shouldScanFile('manifest.json'));
+  });
+
+  it('should allow configuration of which files can be scanned', () => {
+    const io = new IOBase('foo/bar');
+    io.setScanFileCallback((fileName) => fileName !== 'install.rdf');
+    assert.notOk(io.shouldScanFile('install.rdf'));
+    assert.ok(io.shouldScanFile('manifest.json'));
+  });
+
+  it('should ignore undefined scan file callbacks', () => {
+    const io = new IOBase('foo/bar');
+    io.setScanFileCallback(undefined);
+    assert.ok(io.shouldScanFile('manifest.json'));
+  });
+
+  it('should ignore a non-function scan file callback', () => {
+    const io = new IOBase('foo/bar');
+    io.setScanFileCallback(42); // this is not a function
+    assert.ok(io.shouldScanFile('manifest.json'));
+  });
 });

--- a/tests/io/test.directory.js
+++ b/tests/io/test.directory.js
@@ -37,6 +37,21 @@ describe('Directory.getFiles()', function() {
       });
   });
 
+  it('can be configured to not scan file paths', () => {
+    const myDirectory = new Directory('tests/fixtures/io/');
+    myDirectory.setScanFileCallback((filePath) => {
+      return !filePath.startsWith('dir2');
+    });
+
+    return myDirectory.getFiles()
+      .then((files) => {
+        var fileNames = Object.keys(files);
+        assert.include(fileNames, 'dir1/file1.txt');
+        assert.notInclude(fileNames, 'dir2/file2.txt');
+        assert.notInclude(fileNames, 'dir2/dir3/file3.txt');
+      });
+  });
+
 });
 
 describe('Directory._getPath()', function() {

--- a/tests/io/test.utils.js
+++ b/tests/io/test.utils.js
@@ -50,4 +50,18 @@ describe('io.utils.walkPromise()', function() {
       });
   });
 
+  it('can exclude the topmost directory', () => {
+    return walkPromise(
+      'tests/fixtures/io/', {
+        shouldIncludePath: (filePath) => {
+          // This would be the topmost directory.
+          return filePath !== '';
+        },
+      })
+      .then((files) => {
+        var fileNames = Object.keys(files);
+        assert.deepEqual(fileNames, []);
+      });
+  });
+
 });

--- a/tests/io/test.utils.js
+++ b/tests/io/test.utils.js
@@ -21,4 +21,33 @@ describe('io.utils.walkPromise()', function() {
       });
   });
 
+  it('can be configured to not walk a directory', () => {
+    return walkPromise(
+      'tests/fixtures/io/', {
+        shouldIncludePath: (filePath) => {
+          return !filePath.startsWith('dir2');
+        },
+      })
+      .then((files) => {
+        var fileNames = Object.keys(files);
+        assert.include(fileNames, 'dir1/file1.txt');
+        assert.notInclude(fileNames, 'dir2/file2.txt');
+        assert.notInclude(fileNames, 'dir2/dir3/file3.txt');
+      });
+  });
+
+  it('can be configured to not include a file', () => {
+    return walkPromise(
+      'tests/fixtures/io/', {
+        shouldIncludePath: (filePath) => {
+          return filePath !== 'dir2/file2.txt';
+        },
+      })
+      .then((files) => {
+        var fileNames = Object.keys(files);
+        assert.notInclude(fileNames, 'dir2/file2.txt');
+        assert.include(fileNames, 'dir2/dir3/file3.txt');
+      });
+  });
+
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/849

This satisfies what web-ext needs for https://github.com/mozilla/web-ext/issues/397 I'm not sure if the addons-linter command itself needs to support filtering or not.