### PR TITLE
Only load yargs when used directly (fix #735)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,64 @@
 import argv from 'yargs';
 
+import log from 'logger';
+import { singleLineString } from 'utils';
 import { version } from 'json!../package';
 
+
+export function getConfig({useCLI=true} = {}) {
+  if (useCLI === false) {
+    log.fatal(singleLineString`Config requested from CLI, but not in CLI mode.
+      Please supply a config instead of relying on the getConfig() call.`);
+    throw new Error('Cannot request config from CLI in library mode');
+  }
+
+  return argv
+    .usage(`Usage: ./$0 [options] addon-package-or-dir \n\n
+      Add-ons Linter (JS Edition) v${version}`)
+    .option('log-level', {
+      describe: 'The log-level to generate',
+      type: 'string',
+      default: 'fatal',
+      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
+    })
+    .option('output', {
+      alias: 'o',
+      describe: 'The type of output to generate',
+      type: 'string',
+      default: 'text',
+      choices: ['json', 'text'],
+    })
+    .option('metadata', {
+      describe: 'Output only metadata as JSON',
+      type: 'boolean',
+      default: 'false',
+    })
+    .option('pretty', {
+      describe: 'Prettify JSON output',
+      type: 'boolean',
+      default: false,
+    })
+    .option('stack', {
+      describe: 'Show stacktraces when errors are thrown',
+      type: 'boolean',
+      default: false,
+    })
+    .option('boring', {
+      describe: 'Disables colorful shell output',
+      type: 'boolean',
+      default: false,
+    })
+    .option('self-hosted', {
+      describe: 'Disables messages related to hosting on addons.mozilla.org.',
+      type: 'boolean',
+      default: false,
+    })
+    // Require one non-option.
+    .demand(1)
+    .help('help')
+    .alias('h', 'help')
+    .wrap(terminalWidth());
+}
 
 export function terminalWidth(_process=process) {
   if (_process && _process.stdout && _process.stdout.columns > 0) {
@@ -16,50 +73,3 @@ export function terminalWidth(_process=process) {
     return 78;
   }
 }
-
-export default argv
-  .usage(`Usage: ./$0 [options] addon-package-or-dir \n\n
-    Add-ons Linter (JS Edition) v${version}`)
-  .option('log-level', {
-    describe: 'The log-level to generate',
-    type: 'string',
-    default: 'fatal',
-    choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
-  })
-  .option('output', {
-    alias: 'o',
-    describe: 'The type of output to generate',
-    type: 'string',
-    default: 'text',
-    choices: ['json', 'text'],
-  })
-  .option('metadata', {
-    describe: 'Output only metadata as JSON',
-    type: 'boolean',
-    default: 'false',
-  })
-  .option('pretty', {
-    describe: 'Prettify JSON output',
-    type: 'boolean',
-    default: false,
-  })
-  .option('stack', {
-    describe: 'Show stacktraces when errors are thrown',
-    type: 'boolean',
-    default: false,
-  })
-  .option('boring', {
-    describe: 'Disables colorful shell output',
-    type: 'boolean',
-    default: false,
-  })
-  .option('self-hosted', {
-    describe: 'Disables messages related to hosting on addons.mozilla.org.',
-    type: 'boolean',
-    default: false,
-  })
-  // Require one non-option.
-  .demand(1)
-  .help('help')
-  .alias('h', 'help')
-  .wrap(terminalWidth());

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,24 @@
-import cli from 'cli';
+import { getConfig } from 'cli';
 import Linter from 'linter';
 import log from 'logger';
 
+/* istanbul ignore if */
 if (!global._babelPolyfill) {
   require('babel-polyfill');
 }
 
-export function createInstance({config=cli.argv, runAsBinary=false} = {}) {
+
+export function isRunFromCLI(_module=module) {
+  return require.main === _module;
+}
+
+export function createInstance({
+  config=getConfig({useCLI: isRunFromCLI()}).argv, runAsBinary=false,
+} = {}) {
   log.level(config.logLevel);
   log.info('Creating new linter instance', { config: config });
   config.runAsBinary = runAsBinary;
   return new Linter(config);
 }
+
+export default Linter;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -2,7 +2,7 @@ import esprima from 'esprima';
 import RJSON from 'relaxed-json';
 import validate from 'schema/validator';
 
-import cli from 'cli';
+import { getConfig } from 'cli';
 import { MANIFEST_JSON, PACKAGE_EXTENSION } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -12,7 +12,7 @@ import { singleLineString } from 'utils';
 export default class ManifestJSONParser {
 
   constructor(jsonString, collector, {
-    rJSON=RJSON, selfHosted=cli.argv.selfHosted,
+    rJSON=RJSON, selfHosted=getConfig().argv.selfHosted,
   }={}) {
     // Add the JSON string to the object; we'll use this for testing.
     this._jsonString = jsonString;

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -1,4 +1,4 @@
-import { default as cli_, terminalWidth } from 'cli';
+import { getConfig, terminalWidth } from 'cli';
 
 
 var cli;
@@ -9,7 +9,7 @@ describe('Basic CLI tests', function() {
     // Override yargs fail func so we can introspect the right errors
     // are happening when we hand it bogus input.
     this.fakeFail = sinon.stub();
-    cli = cli_.exitProcess(false).fail(this.fakeFail);
+    cli = getConfig().exitProcess(false).fail(this.fakeFail);
   });
 
   it('should default logLevel type to "fatal"', () => {
@@ -86,6 +86,17 @@ describe('Basic CLI tests', function() {
   it('should use a terminal width of $COLUMNS - 2', () => {
     var fakeProcess = {stdout: {columns: 170}};
     assert.equal(terminalWidth(fakeProcess), 168);
+  });
+
+  it('should have a default config when called via CLI', () => {
+    let config = getConfig({useCLI: true}).argv;
+    assert.isAbove(Object.keys(config).length, 0);
+  });
+
+  it('should error when requesting CLI config in library mode', () => {
+    assert.throws(() => {
+      getConfig({useCLI: false});
+    }, 'Cannot request config from CLI in library mode');
   });
 
 });

--- a/tests/test.main.js
+++ b/tests/test.main.js
@@ -1,0 +1,27 @@
+import { getConfig } from 'cli';
+import { createInstance, isRunFromCLI } from 'main';
+
+
+describe('Main module tests', function() {
+
+  it('should error when used as library without explicit config', () => {
+    assert.throws(() => {
+      createInstance({
+        config: getConfig({useCLI: isRunFromCLI(null)}).argv,
+      });
+    }, 'Cannot request config from CLI in library mode');
+  });
+
+  it('getConfig should not error when called via CLI', () => {
+    assert.doesNotThrow(() => {
+      createInstance({
+        config: getConfig({useCLI: true}).argv,
+      });
+    });
+  });
+
+  it("should return false when modules don't match up", () => {
+    assert.isFalse(isRunFromCLI(null));
+  });
+
+});


### PR DESCRIPTION
Addresses the issue in `web-ext`, and anything else including the
linter as a dep.

Whoever can r? first 😄 