### PR TITLE
Scan all JSON files (close #779)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -356,8 +356,8 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
-| :white_check_mark: | error | Web extension | manifest.json is not well formed. | manifest.json | | null | MANIFEST_JSON_INVALID |
-| :white_check_mark: | error | Web extension | Duplicate key in manifest.json. | manifest.json | | null | MANIFEST_DUPLICATE_KEY |
+| :white_check_mark: | error | Web extension | JSON is not well formed. | manifest.json | | null | JSON_INVALID |
+| :white_check_mark: | error | Web extension | Duplicate key in JSON. | manifest.json | | null | JSON_DUPLICATE_KEY |
 | :white_check_mark: | error | Web extension | manifest_version in manifest.json is not valid. | manifest.json | | null | MANIFEST_VERSION_INVALID |
 | :white_check_mark: | error | Web extension | name property missing from manifest.json | manifest.json | | null | PROP_NAME_MISSING |
 | :white_check_mark: | error | Web extension | name property is invalid in manifest.json | manifest.json | | null | PROP_NAME_INVALID |
@@ -372,7 +372,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | A field is invalid | manifest.json | | null | MANIFEST_FIELD_INVALID |
 | :white_check_mark: | error | Web extension | Bad permission | manifest.json | | null | MANIFEST_BAD_PERMISSION |
 | :white_check_mark: | warning | Web extension | Unknown permission | manifest.json | | null | MANIFEST_PERMISSIONS |
-| :white_check_mark: | error | Web extension | Block Comments are not allowed in `manifest.json` | manifest.json | | null | MANIFEST_BLOCK_COMMENTS |
+| :white_check_mark: | error | Web extension | Block Comments are not allowed in JSON | manifest.json | | null | JSON_BLOCK_COMMENTS |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.getSelected | | | null | TABS_GETSELECTED |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.sendRequest | | | null | TABS_SENDREQUEST |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.getAllInWindow | | | null | TABS_GETALLINWINDOW |

--- a/src/linter.js
+++ b/src/linter.js
@@ -16,12 +16,13 @@ import log from 'logger';
 import Collector from 'collector';
 import InstallRdfParser from 'parsers/installrdf';
 import ManifestJSONParser from 'parsers/manifestjson';
-import ChromeManifestScanner from 'scanners/chromemanifest';
 import BinaryScanner from 'scanners/binary';
+import ChromeManifestScanner from 'scanners/chromemanifest';
 import CSSScanner from 'scanners/css';
 import FilenameScanner from 'scanners/filename';
 import HTMLScanner from 'scanners/html';
 import JavaScriptScanner from 'scanners/javascript';
+import JSONScanner from 'scanners/json';
 import RDFScanner from 'scanners/rdf';
 import { Crx, Directory, Xpi } from 'io';
 
@@ -304,6 +305,8 @@ export default class Linter {
         return HTMLScanner;
       case '.js':
         return JavaScriptScanner;
+      case '.json':
+        return JSONScanner;
       case '.rdf':
         return RDFScanner;
       default:
@@ -333,6 +336,11 @@ export default class Linter {
 
         let scanner = new ScannerClass(fileData, filename, {
           addonMetadata: this.addonMetadata,
+          // This is for the JSONScanner, which is a bit of an anomaly and
+          // accesses the collector directly.
+          // TODO: Bring this in line with other scanners, see:
+          // https://github.com/mozilla/addons-linter/issues/895
+          collector: this.collector,
         });
 
         return scanner.scan();

--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -5,6 +5,7 @@ export * from './chromemanifest';
 export * from './css';
 export * from './html';
 export * from './javascript';
+export * from './json';
 export * from './layout';
 export * from './manifestjson';
 export * from './rdf';

--- a/src/messages/json.js
+++ b/src/messages/json.js
@@ -1,0 +1,24 @@
+import { gettext as _, singleLineString } from 'utils';
+
+export const JSON_INVALID = {
+  code: 'JSON_INVALID',
+  legacyCode: null,
+  message: _('Your JSON is not valid.'),
+  description: _('Your JSON file could not be parsed.'),
+};
+
+export const JSON_BLOCK_COMMENTS = {
+  code: 'JSON_BLOCK_COMMENTS',
+  legacyCode: null,
+  message: _('Your JSON contains block comments.'),
+  description: _(singleLineString`Only line comments (comments beginning with
+    "//") are allowed in JSON files. Please remove block comments (comments
+    beginning with "/*")`),
+};
+
+export const JSON_DUPLICATE_KEY = {
+  code: 'JSON_DUPLICATE_KEY',
+  legacyCode: null,
+  message: _('Duplicate keys are not allowed in JSON files.'),
+  description: _(singleLineString`Duplicate key found in JSON file.`),
+};

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,31 +1,6 @@
 import { gettext as _, singleLineString } from 'utils';
 import { MANIFEST_JSON } from 'const';
 
-export const MANIFEST_JSON_INVALID = {
-  code: 'MANIFEST_JSON_INVALID',
-  legacyCode: null,
-  message: _('The manifest.json is not valid.'),
-  description: _('See https://mzl.la/1ZOhoEN (MDN Docs) for more information.'),
-  file: MANIFEST_JSON,
-};
-
-export const MANIFEST_BLOCK_COMMENTS = {
-  code: 'MANIFEST_BLOCK_COMMENTS',
-  legacyCode: null,
-  message: _('The manifest.json contains block comments.'),
-  description: _(singleLineString`Only line comments (comments beginning with
-    "//") are allowed in manifest.json files. Please remove block comments
-    (comments beginning with "/*")`),
-  file: MANIFEST_JSON,
-};
-
-export const MANIFEST_DUPLICATE_KEY = {
-  code: 'MANIFEST_DUPLICATE_KEY',
-  legacyCode: null,
-  message: _('Duplicate keys are not allowed in manifest.'),
-  description: _(singleLineString`Duplicate key found in manifest.json.`),
-  file: MANIFEST_JSON,
-};
 
 export const MANIFEST_FIELD_REQUIRED = {
   code: 'MANIFEST_FIELD_REQUIRED',

--- a/src/parsers/json.js
+++ b/src/parsers/json.js
@@ -1,0 +1,110 @@
+import esprima from 'esprima';
+import RJSON from 'relaxed-json';
+
+import * as messages from 'messages';
+
+export default class JSONParser {
+
+  constructor(jsonString, collector, {filename=null}={}) {
+    // Add the JSON string to the object; we'll use this for testing.
+    this._jsonString = jsonString;
+
+    // Provides ability to directly add messages to
+    // the collector.
+    this.collector = collector;
+
+    // Set the filename for this file
+    this.filename = filename;
+
+    // This marks whether a JSON file is valid; in the case of the base JSON
+    // parser, that's just whether it can be parsed and has duplicate keys.
+    this.isValid = null;
+  }
+
+  parse(RelaxedJSON=RJSON) {
+    try {
+      this.parsedJSON = JSON.parse(this._jsonString);
+    } catch (originalError) {
+      // First we'll try to remove comments with esprima;
+      // WebExtension manifests can contain comments, so we'll strip
+      // them out and see if we can parse the JSON.
+      // If not it's just garbage JSON and we error.
+      //
+      // Originally from https://github.com/abarreir/crx2ff/blob/d2b882056f902d751ad05e329efda7eddcb9d268/libs/ext-converter.js#L19-L37
+      var manifestString = `var o = ${this._jsonString}`;
+      try {
+        // This converts the JSON into a real JS object, and removes any
+        // comments from the JS code.
+        // This has some drawbacks because JSON and JS are not _100%_
+        // compatible. This is largely to do with Unicode characters we
+        // wouldn't expect to see in manifests anyway, and it should simply be
+        // a JSON parse error anyway.
+        // See:
+        // http://stackoverflow.com/questions/23752156/are-all-json-objects-also-valid-javascript-objects/23753148#23753148
+        // https://github.com/judofyr/timeless/issues/57#issuecomment-31872462
+        var tokens = esprima.tokenize(manifestString, {comment: true}).slice(3);
+        this._jsonString = tokens.reduce((json, token) => {
+          // Ignore line comments (`// comments`) and just return the existing
+          // json we've built.
+          if (token.type === 'LineComment') {
+            return json;
+          }
+
+          // Block comments are not allowed, so this is an error.
+          if (token.type === 'BlockComment') {
+            this.collector.addError(messages.JSON_BLOCK_COMMENTS);
+            this.isValid = false;
+          }
+
+          return `${json}${token.value}`;
+        }, '');
+
+        // We found block-level comments, so this manifest is not valid.
+        // Don't bother parsing it again.
+        if (this.isValid === false) {
+          return;
+        }
+
+        this.parsedJSON = JSON.parse(this._jsonString);
+      } catch (error) {
+        // There was still an error, so looks like this manifest is actually
+        // invalid.
+        var errorData = Object.assign({}, messages.JSON_INVALID, {
+          file: this.filename,
+          description: error,
+        });
+        this.collector.addError(errorData);
+        this.isValid = false;
+        return;
+      }
+    }
+
+    // Check for duplicate keys, which renders the manifest invalid.
+    this._checkForDuplicateKeys(RelaxedJSON);
+
+    // If never marked as invalid, this is a valid JSON file.
+    if (this.isValid !== false) {
+      this.isValid = true;
+    }
+  }
+
+  _checkForDuplicateKeys(RelaxedJSON=RJSON) {
+    try {
+      RelaxedJSON.parse(this._jsonString, { duplicate: true, tolerant: true });
+    } catch (err) {
+      if (err.warnings && err.warnings.length > 0) {
+        for (let error of err.warnings) {
+          if (error.message.startsWith('Duplicate key:')) {
+            let message = Object.assign({}, messages.JSON_DUPLICATE_KEY, {
+              file: this.filename,
+              line: error.line,
+              description: `${error.message} found in JSON`,
+            });
+            this.collector.addError(message);
+            this.isValid = false;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/scanners/json.js
+++ b/src/scanners/json.js
@@ -1,0 +1,24 @@
+import JSONParser from 'parsers/json';
+import BaseScanner from 'scanners/base';
+
+
+export default class JSONScanner extends BaseScanner {
+
+  _getContents() {
+    return Promise.resolve(this.contents);
+  }
+
+  scan() {
+    return this.getContents()
+      .then((json) => {
+        let jsonParser = new JSONParser(json, this.options.collector, {
+          filename: this.filename});
+        jsonParser.parse();
+        return Promise.resolve([]);
+      })
+      .catch((err) => {
+        return Promise.reject(err);
+      });
+  }
+
+}

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -1,0 +1,257 @@
+import Linter from 'linter';
+import JSONParser from 'parsers/json';
+
+import * as messages from 'messages';
+import { singleLineString } from 'utils';
+import { validManifestJSON } from '../helpers';
+
+
+describe('JSONParser', function() {
+
+  it('should show a message if bad JSON', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var jsonParser = new JSONParser('blah', addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
+    assert.include(errors[0].message, 'Your JSON is not valid.');
+  });
+
+});
+
+describe('JSONParser duplicate keys', function() {
+
+  it('should error if duplicate keys are found in a JSON file', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    // We aren't using singleLineString here so we can test the line number
+    // reporting.
+    var json = ['{',
+      '"description": "Very good music.",',
+      '"manifest_version": 2,',
+      '"name": "Prince",',
+      '"version": "0.0.1",',
+      '"name": "The Artist Formerly Known As Prince",',
+      '"applications": {',
+          '"gecko": {',
+              '"id": "@webextension-guid"',
+          '}',
+      '}',
+    '}'].join('\n');
+
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.lengthOf(errors, 1);
+    assert.equal(errors[0].code, messages.JSON_DUPLICATE_KEY.code);
+    assert.include(errors[0].message, 'Duplicate keys are not allowed');
+    assert.equal(errors[0].line, 6);
+    assert.include(errors[0].description, 'Duplicate key: name found');
+  });
+
+  it('should report all dupes if multiple duplicate keys are found', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = singleLineString`{
+      "description": "Very good music.",
+      "manifest_version": 2,
+      "name": "Prince",
+      "name": "Male Symbol",
+      "version": "0.0.1",
+      "version": "0.0.2",
+      "name": "The Artist Formerly Known As Prince",
+      "applications": {
+          "gecko": {
+              "id": "@webextension-guid"
+          }
+      }
+    }`;
+
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.lengthOf(errors, 3);
+    assert.equal(errors[0].code, messages.JSON_DUPLICATE_KEY.code);
+    // We expect the duplicate error messages to be in the order of the
+    // dupliate keys in the manifest.
+    assert.include(errors[0].message, 'Duplicate keys are not allowed');
+    assert.include(errors[0].description, 'Duplicate key: name found');
+    assert.include(errors[1].description, 'Duplicate key: version found');
+    assert.include(errors[2].description, 'Duplicate key: name found');
+  });
+
+  it('should not expose other RJSON errors', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    // We aren't using singleLineString here so we can test the line number
+    // reporting.
+    var json = ['{',
+      '"description": "Very good music.",',
+      '"manifest_version": 2,',
+      '"name": "Prince",',
+      '"version": "0.0.1",',
+      '"applications": {',
+          '"gecko": {',
+              '"id": "@webextension-guid"',
+          '}',
+      '}',
+    '}'].join('\n');
+
+    var fakeRJSON = { parse: () => {} };
+    var parseStub = sinon.stub(fakeRJSON, 'parse', () => {
+      throw {
+        warnings: [
+          {
+            line: 1,
+            message: 'Duplicate key: not actually found but this is a test',
+          },
+          {
+            line: 1,
+            message: 'DifferentError: Who cares',
+          },
+        ],
+      };
+    });
+
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse(fakeRJSON);
+
+    assert.equal(jsonParser.isValid, false);
+    assert.ok(parseStub.called);
+    var errors = addonLinter.collector.errors;
+    assert.lengthOf(errors, 1);
+    assert.equal(errors[0].code, messages.JSON_DUPLICATE_KEY.code);
+    assert.include(errors[0].message, 'Duplicate keys are not allowed');
+    assert.equal(errors[0].line, 1);
+    assert.include(errors[0].description,
+                   'Duplicate key: not actually found but this is a test');
+  });
+
+  it('should not be invalid if unknown RJSON errors', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    // We aren't using singleLineString here so we can test the line number
+    // reporting.
+    var json = '{}';
+
+    var fakeRJSON = { parse: () => {} };
+    var parseStub = sinon.stub(fakeRJSON, 'parse', () => {
+      throw {
+        warnings: [
+          {
+            line: 1,
+            message: 'DifferentError: Who cares',
+          },
+        ],
+      };
+    });
+
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse(fakeRJSON);
+
+    // If RJSON throws an error we don't recognise, we should ignore it and
+    // continue on like the JSON is valid. Regular parsing errors will be
+    // picked up earlier in the process.
+    assert.equal(jsonParser.isValid, true);
+    assert.ok(parseStub.called);
+    var errors = addonLinter.collector.errors;
+    assert.lengthOf(errors, 0);
+  });
+});
+
+describe('JSONParser with comments', function() {
+
+  it('parses JSON', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = `// I am a JSON comment, sigh\n${validManifestJSON()}`;
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, true);
+  });
+
+  // Chrome will accept multiline /* */ comments, but Firefox will not and
+  // the Web Extension spec does not allow them. So we will error on them.
+  it('does not parse JSON with a multiline comment', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = `/* I am a JSON comment, sigh*/\n${validManifestJSON()}`;
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    // There should not be another error; a file with block-level comments
+    // will throw that specific error and not a parse error.
+    assert.lengthOf(errors, 1);
+    assert.equal(errors[0].code, messages.JSON_BLOCK_COMMENTS.code);
+    assert.equal(errors[0].message, messages.JSON_BLOCK_COMMENTS.message);
+  });
+
+  it('parses the example from Chrome developer docs', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    // Example from https://developer.chrome.com/extensions/manifest
+    var json = [
+      '{',
+      '// Required',
+      '"manifest_version": 2,',
+      '"name": "My Extension",',
+      '// Make the hell sure to use semvar.org if increasing this',
+      '"version": "0.0.1"',
+      '}',
+    ].join('\n');
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, true);
+    assert.notInclude(jsonParser._jsonString, 'semvar.org');
+  });
+
+  it('returns the correct error for malformed JSON', () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = `{"something": true,\n// I am a JSON comment, sigh\nblah}`;
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
+    assert.include(errors[0].message, 'Your JSON is not valid.');
+  });
+
+  it("doesn't evaluate JS code in comments", () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = '// eval("");\n{"something": true}\nvar bla = "foo";';
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
+    assert.include(errors[0].message, 'Your JSON is not valid.');
+    assert.notInclude(jsonParser._jsonString, 'var bla');
+    assert.notInclude(jsonParser._jsonString, 'eval');
+  });
+
+  it("doesn't evaluate JS code even though esprima is used", () => {
+    var addonLinter = new Linter({_: ['bar']});
+    var json = [
+      '{',
+      '// Required',
+      '"manifest_version": 2,',
+      '"name": "My Extension",',
+      '// Make the hell sure to use semvar.org if increasing this',
+      '"version": eval("alert(\'uh-oh\')")',
+      '}',
+    ].join('\n');
+    var jsonParser = new JSONParser(json, addonLinter.collector);
+    jsonParser.parse();
+
+    assert.equal(jsonParser.isValid, false);
+    var errors = addonLinter.collector.errors;
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
+    assert.include(errors[0].message, 'Your JSON is not valid.');
+  });
+});

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -3,20 +3,19 @@ import ManifestJSONParser from 'parsers/manifestjson';
 
 import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import * as messages from 'messages';
-import { singleLineString } from 'utils';
 import { validManifestJSON } from '../helpers';
 
 describe('ManifestJSONParser', function() {
 
-  it('should show a message if bad JSON', () => {
+  it('should have empty metadata if bad JSON', () => {
     var addonLinter = new Linter({_: ['bar']});
     var manifestJSONParser = new ManifestJSONParser('blah',
                                                     addonLinter.collector);
     assert.equal(manifestJSONParser.isValid, false);
     var errors = addonLinter.collector.errors;
     assert.equal(errors.length, 1);
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
-    assert.include(errors[0].message, 'Invalid JSON in manifest file.');
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
+    assert.include(errors[0].message, 'Your JSON is not valid.');
 
     var metadata = manifestJSONParser.getMetadata();
     assert.equal(metadata.manifestVersion, null);
@@ -48,7 +47,7 @@ describe('ManifestJSONParser id', function() {
     assert.equal(manifestJSONParser.isValid, false);
     var errors = addonLinter.collector.errors;
     assert.equal(errors.length, 1);
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message, '/applications/gecko/id');
   });
 
@@ -99,121 +98,6 @@ describe('ManifestJSONParser manifestVersion', function() {
     assert.equal(metadata.manifestVersion, VALID_MANIFEST_VERSION);
   });
 
-});
-
-describe('ManifestJSONParser duplicate keys', function() {
-
-  it('should error if duplicate keys are found in a JSON file', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    // We aren't using singleLineString here so we can test the line number
-    // reporting.
-    var json = ['{',
-      '"description": "Very good music.",',
-      '"manifest_version": 2,',
-      '"name": "Prince",',
-      '"version": "0.0.1",',
-      '"name": "The Artist Formerly Known As Prince",',
-      '"applications": {',
-          '"gecko": {',
-              '"id": "@webextension-guid"',
-          '}',
-      '}',
-    '}'].join('\n');
-
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    assert.lengthOf(errors, 1);
-    assert.equal(errors[0].code, messages.MANIFEST_DUPLICATE_KEY.code);
-    assert.include(errors[0].message,
-                   'Duplicate keys are not allowed in manifest');
-    assert.equal(errors[0].line, 6);
-    assert.include(errors[0].description,
-                   'Duplicate key: name found in manifest.json');
-  });
-
-  it('should report all dupes if multiple duplicate keys are found', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = singleLineString`{
-      "description": "Very good music.",
-      "manifest_version": 2,
-      "name": "Prince",
-      "name": "Male Symbol",
-      "version": "0.0.1",
-      "version": "0.0.2",
-      "name": "The Artist Formerly Known As Prince",
-      "applications": {
-          "gecko": {
-              "id": "@webextension-guid"
-          }
-      }
-    }`;
-
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    assert.lengthOf(errors, 3);
-    assert.equal(errors[0].code, messages.MANIFEST_DUPLICATE_KEY.code);
-    // We expect the duplicate error messages to be in the order of the
-    // dupliate keys in the manifest.
-    assert.include(errors[0].message,
-                   'Duplicate keys are not allowed in manifest');
-    assert.include(errors[0].description,
-                   'Duplicate key: name found in manifest.json');
-    assert.include(errors[1].description,
-                   'Duplicate key: version found in manifest.json');
-    assert.include(errors[2].description,
-                   'Duplicate key: name found in manifest.json');
-  });
-
-  it('should not expose other RJSON errors', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    // We aren't using singleLineString here so we can test the line number
-    // reporting.
-    var json = ['{',
-      '"description": "Very good music.",',
-      '"manifest_version": 2,',
-      '"name": "Prince",',
-      '"version": "0.0.1",',
-      '"applications": {',
-          '"gecko": {',
-              '"id": "@webextension-guid"',
-          '}',
-      '}',
-    '}'].join('\n');
-
-    var fakeRJSON = { parse: () => {} };
-    var parseStub = sinon.stub(fakeRJSON, 'parse', () => {
-      throw {
-        warnings: [
-          {
-            line: 1,
-            message: 'Duplicate key: not actually found but this is a test',
-          },
-          {
-            line: 1,
-            message: 'DifferentError: Who cares',
-          },
-        ],
-      };
-    });
-
-    var manifestJSONParser = new ManifestJSONParser(json,
-      addonLinter.collector, {rJSON: fakeRJSON});
-
-    assert.equal(manifestJSONParser.isValid, false);
-    assert.ok(parseStub.called);
-    var errors = addonLinter.collector.errors;
-    assert.lengthOf(errors, 1);
-    assert.equal(errors[0].code, messages.MANIFEST_DUPLICATE_KEY.code);
-    assert.include(errors[0].message,
-                   'Duplicate keys are not allowed in manifest');
-    assert.equal(errors[0].line, 1);
-    assert.include(errors[0].description,
-                   'Duplicate key: not actually found but this is a test');
-  });
 });
 
 describe('ManifestJSONParser bad permissions', function() {
@@ -297,7 +181,7 @@ describe('ManfiestJSONParser lookup', function() {
       var parser = new ManifestJSONParser(validManifestJSON(),
                                           addonLinter.collector);
       var message = parser.errorLookup({dataPath: ''});
-      assert.equal(message.code, messages.MANIFEST_JSON_INVALID.code);
+      assert.equal(message.code, messages.JSON_INVALID.code);
     });
   }
 
@@ -498,95 +382,6 @@ describe('ManifestJSONParser update_url', function() {
   });
 });
 
-
-describe('ManifestJSONParser with comments', function() {
-
-  it('parses JSON', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = `// I am a JSON comment, sigh\n${validManifestJSON()}`;
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, true);
-  });
-
-  // Chrome will accept multiline /* */ comments, but Firefox will not and
-  // the Web Extension spec does not allow them. So we will error on them.
-  it('does not parse JSON with a multiline comment', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = `/* I am a JSON comment, sigh*/\n${validManifestJSON()}`;
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    // There should not be another error; a manifest with block-level comments
-    // will throw that specific error and not a parse error.
-    assert.lengthOf(errors, 1);
-    assert.equal(errors[0].code, messages.MANIFEST_BLOCK_COMMENTS.code);
-    assert.equal(errors[0].message, messages.MANIFEST_BLOCK_COMMENTS.message);
-  });
-
-  it('parses the example from Chrome developer docs', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    // Example from https://developer.chrome.com/extensions/manifest
-    var json = [
-      '{',
-      '// Required',
-      '"manifest_version": 2,',
-      '"name": "My Extension",',
-      '// Make the hell sure to use semvar.org if increasing this',
-      '"version": "0.0.1"',
-      '}',
-    ].join('\n');
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, true);
-    assert.notInclude(manifestJSONParser._jsonString, 'semvar.org');
-  });
-
-  it('returns the correct error for malformed JSON', () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = `{"something": true,\n// I am a JSON comment, sigh\nblah}`;
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
-    assert.include(errors[0].message, 'Invalid JSON in manifest file.');
-  });
-
-  it("doesn't evaluate JS code in comments", () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = '// eval("");\n{"something": true}\nvar bla = "foo";';
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
-    assert.include(errors[0].message, 'Invalid JSON in manifest file.');
-    assert.notInclude(manifestJSONParser._jsonString, 'var bla');
-    assert.notInclude(manifestJSONParser._jsonString, 'eval');
-  });
-
-  it("doesn't evaluate JS code even though esprima is used", () => {
-    var addonLinter = new Linter({_: ['bar']});
-    var json = [
-      '{',
-      '// Required',
-      '"manifest_version": 2,',
-      '"name": "My Extension",',
-      '// Make the hell sure to use semvar.org if increasing this',
-      '"version": eval("alert(\'uh-oh\')")',
-      '}',
-    ].join('\n');
-    var manifestJSONParser = new ManifestJSONParser(json,
-                                                    addonLinter.collector);
-    assert.equal(manifestJSONParser.isValid, false);
-    var errors = addonLinter.collector.errors;
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
-    assert.include(errors[0].message, 'Invalid JSON in manifest file.');
-  });
-});
-
 describe('ManifestJSONParser schema error overrides', function() {
   // https://github.com/mozilla/addons-linter/issues/732
   it('uses a modified error message', () => {
@@ -596,7 +391,7 @@ describe('ManifestJSONParser schema error overrides', function() {
                                                     addonLinter.collector);
     assert.equal(manifestJSONParser.isValid, false);
     var errors = addonLinter.collector.errors;
-    assert.equal(errors[0].code, messages.MANIFEST_JSON_INVALID.code);
+    assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message,
                    'is not a valid key or has invalid extra properties');
   });

--- a/tests/scanners/test.json.js
+++ b/tests/scanners/test.json.js
@@ -1,0 +1,25 @@
+import Linter from 'linter';
+import JSONScanner from 'scanners/json';
+
+import { unexpectedSuccess } from '../helpers';
+
+
+describe('JSONScanner', function() {
+
+  it('should throw an error if getContents fails', () => {
+    var addonsLinter = new Linter({_: ['foo']});
+    var jsonScanner = new JSONScanner('{}', 'test.json', {
+      collector: addonsLinter.collector});
+
+    sinon.stub(jsonScanner, 'getContents', () => {
+      return Promise.reject('Explode!');
+    });
+
+    return jsonScanner.scan()
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.equal(err, 'Explode!');
+      });
+  });
+
+});

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -5,9 +5,10 @@ import Linter from 'linter';
 import * as constants from 'const';
 import * as messages from 'messages';
 
-import CSSScanner from 'scanners/css';
 import BinaryScanner from 'scanners/binary';
+import CSSScanner from 'scanners/css';
 import FilenameScanner from 'scanners/filename';
+import JSONScanner from 'scanners/json';
 import { fakeMessageData,
          unexpectedSuccess,
          validManifestJSON } from './helpers';
@@ -260,6 +261,12 @@ describe('Linter.getScanner()', function() {
     var addonLinter = new Linter({_: ['foo']});
     var Scanner = addonLinter.getScanner('foo.css');
     assert.deepEqual(Scanner, CSSScanner);
+  });
+
+  it('should return JSONScanner', function() {
+    var addonLinter = new Linter({_: ['foo']});
+    var Scanner = addonLinter.getScanner('locales/en.json');
+    assert.deepEqual(Scanner, JSONScanner);
   });
 
   var shouldBeFilenameScanned = [


### PR DESCRIPTION
This turned out to be a lot more work than I thought it'd be, because of how we were scanning manifest.json files.

Now we scan all JSON files, so anything that would throw Firefox for a loop should be caught by the linter.