### PR TITLE
Use error instead of fatal for quiet tests (fix #894)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,7 +7,7 @@ import { version } from 'json!../package';
 
 export function getConfig({useCLI=true} = {}) {
   if (useCLI === false) {
-    log.fatal(singleLineString`Config requested from CLI, but not in CLI mode.
+    log.error(singleLineString`Config requested from CLI, but not in CLI mode.
       Please supply a config instead of relying on the getConfig() call.`);
     throw new Error('Cannot request config from CLI in library mode');
   }

--- a/tests/test.cli-process.js
+++ b/tests/test.cli-process.js
@@ -10,6 +10,8 @@ import { singleLineString } from 'utils';
 
 describe('Process', function() {
 
+  this.slow(5000);
+
   it('should exit with exit code 0 when no errors.', (done) => {
     let cmd = 'bin/addons-linter tests/fixtures/good.zip --output json';
     shell.exec(cmd, {silent: true}, (code, output) => {


### PR DESCRIPTION
r? for anyone really, just makes things a bit quieter in the tests.