### PR TITLE
allow homepage_url to be localised

### DIFF
--- a/src/schema/manifest-schema.json
+++ b/src/schema/manifest-schema.json
@@ -42,7 +42,16 @@
         "homepage_url": {
             "description": "The URL of the homepage for this add-on. The add-on management page will contain a link to this URL.",
             "type": "string",
-            "format": "uri"
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "uri"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^__MSG_.*?__$"
+                }
+            ]
         },
         "icons": {
             "description": "Icons to be shown in buttons and the add-on management page.",

--- a/tests/schema/test.homepage_url.js
+++ b/tests/schema/test.homepage_url.js
@@ -9,6 +9,7 @@ describe('/homepage_url', () => {
   const validURLs = [
     'https://example.com/some/page',
     'http://foo.com',
+    '__MSG_foo^&#__',
   ];
 
   for (let validURL of validURLs) {
@@ -20,13 +21,21 @@ describe('/homepage_url', () => {
     });
   }
 
-  it('not a URI should be invalid', () => {
-    var manifest = cloneDeep(validManifest);
-    manifest.homepage_url = 'wat';
-    validate(manifest);
-    assert.equal(validate.errors.length, 1);
-    assert.equal(validate.errors[0].dataPath, '/homepage_url');
-    assert.equal(validate.errors[0].message, 'should match format "uri"');
-  });
+  const invalidURLs = [
+    '__MSG_',
+    'wat',
+  ];
 
+  for (let invalidURL of invalidURLs) {
+    it(`${invalidURL} a URI should be invalid`, () => {
+      var manifest = cloneDeep(validManifest);
+      manifest.homepage_url = invalidURL;
+      validate(manifest);
+      assert.equal(validate.errors.length, 3);
+      assert.equal(validate.errors[0].dataPath, '/homepage_url');
+      assert.equal(validate.errors[0].message, 'should match format "uri"');
+      assert.equal(validate.errors[1].message,
+        'should match pattern "^__MSG_.*?__$"');
+    });
+  }
 });


### PR DESCRIPTION
* fixes #836 
* until we can get the linter to understand localisations, allow to be a URI a localised string as per the docs https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Internationalization#Internationalizing_manifest.json