### PR TITLE
Ban jQuery 1.x and angular 1.x

### DIFF
--- a/docs/third-party-libraries.md
+++ b/docs/third-party-libraries.md
@@ -6,10 +6,10 @@ We maintain a list of banned and unadvised third-party JavaScript libraries; the
 
 ### AngularJS `1.x`
 
-AngularJS `1.x` versions except the latest version (currently `1.5.8`) are not allowed due to a [potential CSP vulnerability](http://www.slideshare.net/x00mario/an-abusive-relationship-with-angularjs). The latest version will be allowed for a limited time only.
+AngularJS `1.x` versions are not allowed due to a [CSP vulnerability](http://www.slideshare.net/x00mario/an-abusive-relationship-with-angularjs).
 
-## Unadvised libraries
-
-### jQuery < 2.0
+### jQuery `1.x`
 
 jQuery versions older than 2.0 are not supported by the jQuery team for development inside extensions. Please use a recent version.
+
+## Unadvised libraries

--- a/src/libraries.js
+++ b/src/libraries.js
@@ -162,9 +162,6 @@ export const BANNED_LIBRARIES = [
   'angularjs.1.5.6.angular.min.js',
   'angularjs.1.5.7.angular.js',
   'angularjs.1.5.7.angular.min.js',
-];
-
-export const UNADVISED_LIBRARIES = [
   'angularjs.1.5.8.angular.js',
   'angularjs.1.5.8.angular.min.js',
   'jquery.1.0.1.jquery.js',
@@ -198,12 +195,12 @@ export const UNADVISED_LIBRARIES = [
   'jquery.1.6.4.jquery.min.js',
   'jquery.1.6.jquery.js',
   'jquery.1.6.jquery.min.js',
+  'jquery.1.7.jquery.js',
+  'jquery.1.7.jquery.min.js',
   'jquery.1.7.1.jquery.js',
   'jquery.1.7.1.jquery.min.js',
   'jquery.1.7.2.jquery.js',
   'jquery.1.7.2.jquery.min.js',
-  'jquery.1.7.jquery.js',
-  'jquery.1.7.jquery.min.js',
   'jquery.1.8.0.jquery.js',
   'jquery.1.8.0.jquery.min.js',
   'jquery.1.8.1.jquery.js',
@@ -240,4 +237,7 @@ export const UNADVISED_LIBRARIES = [
   'jquery.1.12.3.jquery.min.js',
   'jquery.1.12.4.jquery.js',
   'jquery.1.12.4.jquery.min.js',
+];
+
+export const UNADVISED_LIBRARIES = [
 ];


### PR DESCRIPTION
We no longer allow angular 1.x and old jQuery versions, so we should error during submission instead of letting it pass, have the add-on wait for days in the queues and finally getting manually rejected by a reviewer.

Related amo-validator patch: https://github.com/mozilla/amo-validator/pull/470