### PR TITLE
Don't swallow the detailed error description on invalid JSON.

### DIFF
--- a/src/parsers/json.js
+++ b/src/parsers/json.js
@@ -71,7 +71,7 @@ export default class JSONParser {
         // invalid.
         var errorData = Object.assign({}, messages.JSON_INVALID, {
           file: this.filename,
-          description: error.toString(),
+          description: error.message,
         });
         this.collector.addError(errorData);
         this.isValid = false;

--- a/src/parsers/json.js
+++ b/src/parsers/json.js
@@ -71,7 +71,7 @@ export default class JSONParser {
         // invalid.
         var errorData = Object.assign({}, messages.JSON_INVALID, {
           file: this.filename,
-          description: error,
+          description: error.toString(),
         });
         this.collector.addError(errorData);
         this.isValid = false;

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -18,6 +18,9 @@ describe('JSONParser', function() {
     assert.equal(errors.length, 1);
     assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message, 'Your JSON is not valid.');
+    assert.include(
+      errors[0].description,
+      'SyntaxError: Unexpected token b in JSON at position 0');
   });
 
 });

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -18,9 +18,9 @@ describe('JSONParser', function() {
     assert.equal(errors.length, 1);
     assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message, 'Your JSON is not valid.');
-    assert.include(
+    assert.equal(
       errors[0].description,
-      'SyntaxError: Unexpected token b in JSON at position 0');
+      'Unexpected token b in JSON at position 0');
   });
 
 });

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -18,9 +18,7 @@ describe('JSONParser', function() {
     assert.equal(errors.length, 1);
     assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message, 'Your JSON is not valid.');
-    assert.equal(
-      errors[0].description,
-      'Unexpected token b in JSON at position 0');
+    assert.equal(errors[0].description, 'Unexpected token b');
   });
 
 });


### PR DESCRIPTION
The problem here is that `error` is an actual `SyntaxError` instance
and the json export expects things to be strings which leads to
swallowing the actual message.

Fixes mozilla/addons-server#3385