### PR TITLE
Start testing on node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
 - '4'
 - '5'
+- '6'
 script: npm test
 notifications:
   irc:

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -18,7 +18,7 @@ describe('JSONParser', function() {
     assert.equal(errors.length, 1);
     assert.equal(errors[0].code, messages.JSON_INVALID.code);
     assert.include(errors[0].message, 'Your JSON is not valid.');
-    assert.equal(errors[0].description, 'Unexpected token b');
+    assert.include(errors[0].description, 'Unexpected token b');
   });
 
 });


### PR DESCRIPTION
Let's see what travis makes of this. Starting testing on node 6 is part of the preparation to move to running this service under node 6.

Fixes #945
