### PR TITLE
add in warning about temporary ids with some APIs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -382,3 +382,6 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | warning | Web extension | Deprecated API extension.onRequestExternal | | | null | EXT_ONREQUESTEXTERNAL |
 | :white_check_mark: | warning | Web extension | Deprecated API extension.onRequest | | | null | EXT_ONREQUEST |
 | :white_check_mark: | warning | Web extension | Deprecated API app.getDetails | | | null | APP_GETDETAILS |
+| :white_check_mark: | warning | Web extension | Temporary IDs can cause issues with storage.local | | | null | STORAGE_LOCAL |
+| :white_check_mark: | warning | Web extension | Temporary IDs can cause issues with storage.sync | | | null | STORAGE_SYNC |
+| :white_check_mark: | warning | Web extension | Temporary IDs can cause issues with identity.getRedirectURL | | | null | IDENTITY_GETREDIRECTURL |

--- a/src/const.js
+++ b/src/const.js
@@ -152,3 +152,11 @@ export const DEPRECATED_APIS = [
   'tabs.onSelectionChanged',
   'tabs.sendRequest',
 ];
+
+// These are APIs that will cause problems when loaded temporarily
+// in about:debugging.
+export const TEMPORARY_APIS = [
+  'identity.getRedirectURL',
+  'storage.local',
+  'storage.sync',
+];

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -265,3 +265,23 @@ export const TABS_ONACTIVECHANGED = deprecatedAPI('tabs.onActiveChanged');
 export const TABS_ONSELECTIONCHANGED = deprecatedAPI(
   'tabs.onSelectionChanged');
 export const TABS_SENDREQUEST = deprecatedAPI('tabs.sendRequest');
+
+function temporaryAPI(api) {
+  return {
+    code: apiToMessage(api),
+    legacyCode: [
+      'js',
+      'temporary',
+      api,
+    ],
+    message: _(`"${api}" can cause issues when loaded temporarily`),
+    description: _(singleLineString`This API can cause issues when loaded
+      temporarily using about:debugging in Firefox unless you specify
+      applications > gecko > id in the manifest. Please see:
+      https://mzl.la/2hizK4a for more.`),
+  };
+}
+
+export const STORAGE_LOCAL = temporaryAPI('storage.local');
+export const STORAGE_SYNC = temporaryAPI('storage.sync');
+export const IDENTITY_GETREDIRECTURL = temporaryAPI('identity.getRedirectURL');

--- a/src/rules/javascript/webextension_api.js
+++ b/src/rules/javascript/webextension_api.js
@@ -1,4 +1,4 @@
-import { DEPRECATED_APIS } from 'const';
+import { DEPRECATED_APIS, TEMPORARY_APIS } from 'const';
 import { apiToMessage } from '../../utils';
 
 export function webextension_api(context) {
@@ -7,7 +7,13 @@ export function webextension_api(context) {
       if (node.object.object &&
           ['chrome', 'browser'].includes(node.object.object.name)) {
         let api = `${node.object.property.name}.${node.property.name}`;
+
         if (DEPRECATED_APIS.includes(api)) {
+          return context.report(node, apiToMessage(api));
+        }
+
+        if (!context.settings.addonMetadata.id &&
+            TEMPORARY_APIS.includes(api)) {
           return context.report(node, apiToMessage(api));
         }
       }

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -1,7 +1,7 @@
 import ESLint from 'eslint';
 
-import { DEPRECATED_APIS, ESLINT_ERROR, ESLINT_RULE_MAPPING, VALIDATION_ERROR,
-         VALIDATION_WARNING } from 'const';
+import { DEPRECATED_APIS, ESLINT_ERROR, ESLINT_RULE_MAPPING, TEMPORARY_APIS,
+         VALIDATION_ERROR, VALIDATION_WARNING } from 'const';
 import JavaScriptScanner from 'scanners/javascript';
 import * as messages from 'messages';
 import * as rules from 'rules/javascript';
@@ -292,6 +292,34 @@ describe('JavaScript Scanner', function() {
           assert.equal(validationMessages.length, 1);
           assert.equal(validationMessages[0].code, apiToMessage(api));
           assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+  }
+
+  for (let api of TEMPORARY_APIS) {
+    it(`should return warning when ${api} is used with no id`, () => {
+      var fakeMetadata = { addonMetadata: validMetadata({}) };
+      var jsScanner = new JavaScriptScanner(
+        `chrome.${api}(function() {});`, 'code.js', fakeMetadata);
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code, apiToMessage(api));
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+  }
+
+  for (let api of TEMPORARY_APIS) {
+    it(`should pass when ${api} is used with an id`, () => {
+      var fakeMetadata = { addonMetadata: validMetadata({id: 'snark'}) };
+      var jsScanner = new JavaScriptScanner(
+        `chrome.${api}(function() {});`, 'code.js', fakeMetadata);
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 0);
         });
     });
   }


### PR DESCRIPTION
![screenshot 2016-12-13 09 34 01](https://cloud.githubusercontent.com/assets/74699/21151432/576e9f20-c117-11e6-8f22-d2a0a46c1e43.png)

There might be more, but these two seemed like a good start.

Fixes #1064.