### PR TITLE
Add parserOptions in eslint options

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -43,6 +43,7 @@ export default class JavaScriptScanner {
 
       var report = eslint.verify(this.code, {
         env: { es6: true },
+        parserOptions: { ecmaVersion: 2017 },
         ignore: false,
         rules: _ruleMapping,
         settings: {

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -30,7 +30,7 @@ describe('JavaScript Scanner', function() {
   });
 
   it('should not throw when async/await is used', () => {
-    var code = singleLineString`var foo = async a => a;`;
+    var code = 'var foo = async a => a;';
     var jsScanner = new JavaScriptScanner(code, 'code.js');
 
     return jsScanner.scan()

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -29,6 +29,16 @@ describe('JavaScript Scanner', function() {
     assert.equal(jsScannerWithOptions.options.foo, 'bar');
   });
 
+  it('should not throw when async/await is used', () => {
+    var code = singleLineString`var foo = async a => a;`;
+    var jsScanner = new JavaScriptScanner(code, 'code.js');
+
+    return jsScanner.scan()
+      .then((validationMessages) => {
+        assert.equal(validationMessages.length, 0);
+      });
+  });
+
   // TODO: Not sure how to test for this one yet; it's pretty messy.
   it.skip(singleLineString`should warn when mozIndexedDB is assembled into
     literal with +=`,


### PR DESCRIPTION
Fix [#1091](https://github.com/mozilla/addons-linter/issues/1091)
