### PR TITLE
chore(package): update markdown-it-anchor to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "load-grunt-tasks": "3.5.2",
     "lodash.clonedeep": "4.5.0",
     "markdown-it": "8.2.2",
-    "markdown-it-anchor": "2.6.0",
+    "markdown-it-anchor": "3.0.0",
     "markdown-it-emoji": "1.3.0",
     "mocha": "3.1.2",
     "mocha-multi": "0.10.0",


### PR DESCRIPTION
Closes #1117

https://greenkeeper.io/