### PR TITLE
Add warning about use of unsafe innerHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dispensary": "0.10.3",
     "es6-promisify": "5.0.0",
     "eslint": "3.16.0",
+    "eslint-plugin-no-unsafe-innerhtml": "1.0.15",
     "esprima": "3.1.3",
     "first-chunk-stream": "2.0.0",
     "postcss": "5.2.15",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dispensary": "0.10.3",
     "es6-promisify": "5.0.0",
     "eslint": "3.16.0",
-    "eslint-plugin-no-unsafe-innerhtml": "1.0.15",
+    "eslint-plugin-no-unsafe-innerhtml": "EnTeQuAk/eslint-plugin-no-unsafe-innerhtml#4b6b606d50",
     "esprima": "3.1.3",
     "first-chunk-stream": "2.0.0",
     "postcss": "5.2.15",

--- a/src/const.js
+++ b/src/const.js
@@ -20,6 +20,7 @@ export const ESLINT_RULE_MAPPING = {
   'shallow-wrapper': ESLINT_WARNING,
   'webextension-api': ESLINT_WARNING,
   'widget-module': ESLINT_WARNING,
+  'no-unsafe-innerhtml/no-unsafe-innerhtml': ESLINT_WARNING,
 };
 
 export const VALIDATION_ERROR = 'error';

--- a/src/rules/javascript/only-prefs-in-defaults.js
+++ b/src/rules/javascript/only-prefs-in-defaults.js
@@ -1,12 +1,15 @@
+import path from 'path';
+
 import { ONLY_PREFS_IN_DEFAULTS } from 'messages/javascript';
 import { getRootExpression } from 'utils';
 
+
 export default {
   create(context) {
-    var filename = context.getFilename();
+    var relPath = path.relative(process.cwd(), context.getFilename());
 
     // This rule only applies to files in defaults/preferences
-    if (filename.indexOf('defaults/preferences/') === 0) {
+    if (path.dirname(relPath).startsWith('defaults/preferences')) {
       return {
         CallExpression: function(node) {
           var root = getRootExpression(node);

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -34,13 +34,15 @@ export default class JavaScriptScanner {
       // pass it the entire source file as a string.
       var cli = new _ESLint.CLIEngine({
         env: { es6: true },
-        parserOptions: { ecmaVersion: 2017 },
-        ignore: false,
-        plugins: ['no-unsafe-innerhtml'],
-        rules: _ruleMapping,
-        settings: {
-          addonMetadata: this.options.addonMetadata,
+        baseConfig: {
+          parserOptions: { ecmaVersion: 2017 },
+          settings: {
+            addonMetadata: this.options.addonMetadata,
+          },
         },
+        ignore: false,
+        rules: _ruleMapping,
+        plugins: ['no-unsafe-innerhtml'],
         allowInlineConfig: false,
         filename: this.filename,
         // Avoid loading the addons-linter .eslintrc file

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -30,8 +30,6 @@ export default class JavaScriptScanner {
     _messages=messages,
   }={}) {
     return new Promise((resolve) => {
-      // ESLint is synchronous and doesn't accept streams, so we need to
-      // pass it the entire source file as a string.
       var cli = new _ESLint.CLIEngine({
         env: { es6: true },
         baseConfig: {
@@ -54,6 +52,8 @@ export default class JavaScriptScanner {
         _ESLint.linter.defineRule(name, _rules[name]);
       }
 
+      // ESLint is synchronous and doesn't accept streams, so we need to
+      // pass it the entire source file as a string.
       var report = cli.executeOnText(this.code, this.filename, true);
 
       for (const result of report.results) {

--- a/tests/rules/javascript/test.deprecated_entities.js
+++ b/tests/rules/javascript/test.deprecated_entities.js
@@ -14,6 +14,8 @@ describe('deprecated_entities', () => {
 
       return jsScanner.scan()
         .then((validationMessages) => {
+          validationMessages = validationMessages.sort();
+
           assert.equal(validationMessages.length, 1);
           assert.equal(validationMessages[0].code,
                        entity.error.code);

--- a/tests/rules/javascript/test.no_unsafe_innerhtml.js
+++ b/tests/rules/javascript/test.no_unsafe_innerhtml.js
@@ -1,0 +1,49 @@
+import { VALIDATION_WARNING } from 'const';
+import JavaScriptScanner from 'scanners/javascript';
+
+// These rules were mostly copied and adapted from
+// https://github.com/mozfreddyb/eslint-plugin-no-unsafe-innerhtml/
+// Please make sure to keep them up-to-date and report upstream errors.
+
+describe('no_unsafe_innerhtml', () => {
+  var validCodes = [
+    "a.innerHTML = '';",
+    'c.innerHTML = ``;',
+    'g.innerHTML = Sanitizer.escapeHTML``;',
+    'h.innerHTML = Sanitizer.escapeHTML`foo`;',
+    'i.innerHTML = Sanitizer.escapeHTML`foo${bar}baz`;',
+  ];
+
+  for (const code of validCodes) {
+    it(`should allow the use innerHTML equals ${code}`, () => {
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 0);
+        });
+    });
+  }
+
+
+  var invalidCodes = [
+    {
+      code: 'm.innerHTML = htmlString;',
+      message: 'Unsafe assignment to innerHTML',
+      type: VALIDATION_WARNING,
+    },
+  ];
+
+  for (const code of invalidCodes) {
+    it(`should not allow the use of innerHTML examples ${code.code}`, () => {
+      var jsScanner = new JavaScriptScanner(code.code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code, code.message);
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+  }
+});

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -128,18 +128,27 @@ describe('JavaScript Scanner', function() {
   });
 
   it('should reject on missing message code', () => {
+    var FakeCLIEngine = function() {};
+    FakeCLIEngine.prototype = {
+      constructor: function() {},
+      executeOnText: () => {
+        return {
+          results: [{
+            messages: [{
+              fatal: false,
+            }],
+          }],
+        };
+      },
+    };
 
     var FakeESLint = {
       linter: {
         defineRule: () => {
           // no-op
         },
-        verify: () => {
-          return [{
-            fatal: false,
-          }];
-        },
       },
+      CLIEngine: FakeCLIEngine,
     };
 
     var jsScanner = new JavaScriptScanner('whatever', 'badcode.js');
@@ -281,14 +290,21 @@ describe('JavaScript Scanner', function() {
   it('should export all rules in rules/javascript', () => {
     // We skip the "run" check here for now as that's handled by ESLint.
     var ruleFiles = getRuleFiles('javascript');
-    assert.equal(ruleFiles.length, Object.keys(ESLINT_RULE_MAPPING).length);
+    var externalRules = 1;
+
+    assert.equal(
+      ruleFiles.length + externalRules,
+      Object.keys(ESLINT_RULE_MAPPING).length
+    );
 
     var jsScanner = new JavaScriptScanner('', 'badcode.js');
 
     return jsScanner.scan()
       .then(() => {
-        assert.equal(jsScanner._rulesProcessed,
-                     Object.keys(rules).length);
+        assert.equal(
+          jsScanner._rulesProcessed,
+          Object.keys(rules).length
+        );
       });
   });
 


### PR DESCRIPTION
Fixes #811 and references (but doesn't fix it yet imho) https://github.com/mozilla/addons-linter/issues/1113

This PR improves 3rd party rule support where needed along the way. Also adapts other rules a bit, e.g to correctly resolve the current working directory. See the actual commits for more details.

This now uses `CLIEngine.executeOnText` instead of `eslint.verify` to make sure plugins and processors are properly loaded. We could have done that ourselves but it felt more appropriate to just use that API. This messes a bit with the current working directory (now absolute paths are present in `context.getFilename`) but that's reasonable.