### PR TITLE
Add no-eval rule linting.

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -21,7 +21,7 @@ export const ESLINT_RULE_MAPPING = {
   'webextension-api': ESLINT_WARNING,
   'widget-module': ESLINT_WARNING,
 
-  // 3rd party rules
+  // 3rd party / eslint-internal rules
   'no-unsafe-innerhtml/no-unsafe-innerhtml': ESLINT_WARNING,
   'no-eval': [ESLINT_WARNING, {allowIndirect: true}],
 };

--- a/src/const.js
+++ b/src/const.js
@@ -23,7 +23,7 @@ export const ESLINT_RULE_MAPPING = {
 
   // 3rd party / eslint-internal rules
   'no-unsafe-innerhtml/no-unsafe-innerhtml': ESLINT_WARNING,
-  'no-eval': [ESLINT_WARNING, {allowIndirect: true}],
+  'no-eval': [ESLINT_WARNING, {allowIndirect: false}],
 };
 
 export const VALIDATION_ERROR = 'error';

--- a/src/const.js
+++ b/src/const.js
@@ -20,7 +20,10 @@ export const ESLINT_RULE_MAPPING = {
   'shallow-wrapper': ESLINT_WARNING,
   'webextension-api': ESLINT_WARNING,
   'widget-module': ESLINT_WARNING,
+
+  // 3rd party rules
   'no-unsafe-innerhtml/no-unsafe-innerhtml': ESLINT_WARNING,
+  'no-eval': [ESLINT_WARNING, {allowIndirect: true}],
 };
 
 export const VALIDATION_ERROR = 'error';

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -31,8 +31,8 @@ export default class JavaScriptScanner {
   }={}) {
     return new Promise((resolve) => {
       var cli = new _ESLint.CLIEngine({
-        env: { es6: true },
         baseConfig: {
+          env: { es6: true, webextension: true, browser: true },
           parserOptions: { ecmaVersion: 2017 },
           settings: {
             addonMetadata: this.options.addonMetadata,

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -33,11 +33,11 @@ export default class JavaScriptScanner {
       var cli = new _ESLint.CLIEngine({
         baseConfig: {
           env: { es6: true, webextension: true, browser: true },
-          parserOptions: { ecmaVersion: 2017 },
           settings: {
             addonMetadata: this.options.addonMetadata,
           },
         },
+        parserOptions: { ecmaVersion: 2017 },
         ignore: false,
         rules: _ruleMapping,
         plugins: ['no-unsafe-innerhtml'],

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -32,12 +32,18 @@ export default class JavaScriptScanner {
     return new Promise((resolve) => {
       var cli = new _ESLint.CLIEngine({
         baseConfig: {
-          env: { es6: true, webextension: true, browser: true },
+          env: {
+            es6: true,
+            webextension: true,
+            browser: true,
+          },
           settings: {
             addonMetadata: this.options.addonMetadata,
           },
         },
-        parserOptions: { ecmaVersion: 2017 },
+        parserOptions: {
+          ecmaVersion: 2017,
+        },
         ignore: false,
         rules: _ruleMapping,
         plugins: ['no-unsafe-innerhtml'],

--- a/tests/rules/javascript/test.no_eval.js
+++ b/tests/rules/javascript/test.no_eval.js
@@ -1,0 +1,101 @@
+import { VALIDATION_WARNING } from 'const';
+import JavaScriptScanner from 'scanners/javascript';
+
+// These rules were mostly copied and adapted from
+// https://github.com/eslint/eslint/blob/master/tests/lib/rules/no-eval.js
+// Please make sure to keep them up-to-date and report upstream errors.
+describe('no_eval', () => {
+  var validCodes = [
+    'Eval(foo)',
+
+    // User-defined eval methods.
+    'window.eval("foo")',
+    'window.eval("foo")',
+    'window.noeval("foo")',
+    'function foo() { var eval = "foo"; window[eval]("foo") }',
+    'global.eval("foo")',
+    'global.eval("foo")',
+    'global.noeval("foo")',
+    'function foo() { var eval = "foo"; global[eval]("foo") }',
+    'this.noeval("foo");',
+    'function foo() { "use strict"; this.eval("foo"); }',
+    'function foo() { this.eval("foo"); }',
+    'function foo() { this.eval("foo"); }',
+    'var obj = {foo: function() { this.eval("foo"); }}',
+    'var obj = {}; obj.foo = function() { this.eval("foo"); }',
+    'class A { foo() { this.eval(); } }',
+    'class A { static foo() { this.eval(); } }',
+
+    // Allows indirect eval
+    '(0, eval)("foo")',
+    '(0, window.eval)("foo")',
+    '(0, window["eval"])("foo")',
+    'var EVAL = eval; EVAL("foo")',
+    'var EVAL = this.eval; EVAL("foo")',
+    '(function(exe){ exe("foo") })(eval);',
+    'window.eval("foo")',
+    'window.window.eval("foo")',
+    'window.window["eval"]("foo")',
+    'global.eval("foo")',
+    'global.global.eval("foo")',
+    'this.eval("foo")',
+    'function foo() { this.eval("foo") }',
+  ];
+
+  for (const code of validCodes) {
+    it(`should allow the use of user defined / indirect eval: ${code}`, () => {
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 0);
+        });
+    });
+  }
+
+
+  var invalidCodes = [
+    {
+      code: 'eval(foo)',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'function foo(eval) { eval("foo") }',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'eval(foo)',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'function foo(eval) { eval("foo") }',
+      message: ['eval can be harmful.'],
+    },
+  ];
+
+  for (const code of invalidCodes) {
+    it(`should not allow the use of global eval: ${code.code}`, () => {
+      var jsScanner = new JavaScriptScanner(code.code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          validationMessages = validationMessages.sort();
+
+          assert.equal(validationMessages.length, code.message.length);
+
+          code.message.forEach((expectedMessage, idx) => {
+            assert.equal(validationMessages[idx].message, expectedMessage);
+            assert.equal(validationMessages[idx].type, VALIDATION_WARNING);
+          });
+        });
+    });
+  }
+});

--- a/tests/rules/javascript/test.no_eval.js
+++ b/tests/rules/javascript/test.no_eval.js
@@ -9,17 +9,17 @@ describe('no_eval', () => {
     'Eval(foo)',
 
     // User-defined eval methods.
-    'window.noeval("foo")',
+    'class A { foo() { this.eval(); } }',
+    'class A { static foo() { this.eval(); } }',
+    'function foo() { "use strict"; this.eval("foo"); }',
+    'function foo() { var eval = "foo"; global[eval]("foo") }',
     'function foo() { var eval = "foo"; window[eval]("foo") }',
     'global.eval("foo")',
     'global.noeval("foo")',
-    'function foo() { var eval = "foo"; global[eval]("foo") }',
     'this.noeval("foo");',
-    'function foo() { "use strict"; this.eval("foo"); }',
     'var obj = {foo: function() { this.eval("foo"); }}',
     'var obj = {}; obj.foo = function() { this.eval("foo"); }',
-    'class A { foo() { this.eval(); } }',
-    'class A { static foo() { this.eval(); } }',
+    'window.noeval("foo")',
   ];
 
   for (const code of validCodes) {
@@ -36,18 +36,6 @@ describe('no_eval', () => {
 
   var invalidCodes = [
     {
-      code: 'eval(foo)',
-      message: ['eval can be harmful.'],
-    },
-    {
-      code: 'eval("foo")',
-      message: ['eval can be harmful.'],
-    },
-    {
-      code: 'function foo(eval) { eval("foo") }',
-      message: ['eval can be harmful.'],
-    },
-    {
       code: '(0, eval)("foo")',
       message: ['eval can be harmful.'],
     },
@@ -60,15 +48,35 @@ describe('no_eval', () => {
       message: ['eval can be harmful.'],
     },
     {
+      code: '(function(exe){ exe("foo") })(eval);',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'eval(foo)',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'function foo() { this.eval("foo") }',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'function foo(eval) { eval("foo") }',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'this.eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
       code: 'var EVAL = eval; EVAL("foo")',
       message: ['eval can be harmful.'],
     },
     {
       code: 'var EVAL = this.eval; EVAL("foo")',
-      message: ['eval can be harmful.'],
-    },
-    {
-      code: '(function(exe){ exe("foo") })(eval);',
       message: ['eval can be harmful.'],
     },
     {
@@ -83,15 +91,6 @@ describe('no_eval', () => {
       code: 'window.window["eval"]("foo")',
       message: ['eval can be harmful.'],
     },
-    {
-      code: 'this.eval("foo")',
-      message: ['eval can be harmful.'],
-    },
-    {
-      code: 'function foo() { this.eval("foo") }',
-      message: ['eval can be harmful.'],
-    },
-
   ];
 
   for (const code of invalidCodes) {

--- a/tests/rules/javascript/test.no_eval.js
+++ b/tests/rules/javascript/test.no_eval.js
@@ -9,41 +9,21 @@ describe('no_eval', () => {
     'Eval(foo)',
 
     // User-defined eval methods.
-    'window.eval("foo")',
-    'window.eval("foo")',
     'window.noeval("foo")',
     'function foo() { var eval = "foo"; window[eval]("foo") }',
-    'global.eval("foo")',
     'global.eval("foo")',
     'global.noeval("foo")',
     'function foo() { var eval = "foo"; global[eval]("foo") }',
     'this.noeval("foo");',
     'function foo() { "use strict"; this.eval("foo"); }',
-    'function foo() { this.eval("foo"); }',
-    'function foo() { this.eval("foo"); }',
     'var obj = {foo: function() { this.eval("foo"); }}',
     'var obj = {}; obj.foo = function() { this.eval("foo"); }',
     'class A { foo() { this.eval(); } }',
     'class A { static foo() { this.eval(); } }',
-
-    // Allows indirect eval
-    '(0, eval)("foo")',
-    '(0, window.eval)("foo")',
-    '(0, window["eval"])("foo")',
-    'var EVAL = eval; EVAL("foo")',
-    'var EVAL = this.eval; EVAL("foo")',
-    '(function(exe){ exe("foo") })(eval);',
-    'window.eval("foo")',
-    'window.window.eval("foo")',
-    'window.window["eval"]("foo")',
-    'global.eval("foo")',
-    'global.global.eval("foo")',
-    'this.eval("foo")',
-    'function foo() { this.eval("foo") }',
   ];
 
   for (const code of validCodes) {
-    it(`should allow the use of user defined / indirect eval: ${code}`, () => {
+    it(`should allow the use of user defined eval: ${code}`, () => {
       var jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
       return jsScanner.scan()
@@ -68,21 +48,54 @@ describe('no_eval', () => {
       message: ['eval can be harmful.'],
     },
     {
-      code: 'eval(foo)',
+      code: '(0, eval)("foo")',
       message: ['eval can be harmful.'],
     },
     {
-      code: 'eval("foo")',
+      code: '(0, window.eval)("foo")',
       message: ['eval can be harmful.'],
     },
     {
-      code: 'function foo(eval) { eval("foo") }',
+      code: '(0, window["eval"])("foo")',
       message: ['eval can be harmful.'],
     },
+    {
+      code: 'var EVAL = eval; EVAL("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'var EVAL = this.eval; EVAL("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: '(function(exe){ exe("foo") })(eval);',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'window.eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'window.window.eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'window.window["eval"]("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'this.eval("foo")',
+      message: ['eval can be harmful.'],
+    },
+    {
+      code: 'function foo() { this.eval("foo") }',
+      message: ['eval can be harmful.'],
+    },
+
   ];
 
   for (const code of invalidCodes) {
-    it(`should not allow the use of global eval: ${code.code}`, () => {
+    it(`should not allow the use of eval: ${code.code}`, () => {
       var jsScanner = new JavaScriptScanner(code.code, 'badcode.js');
 
       return jsScanner.scan()

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -290,7 +290,7 @@ describe('JavaScript Scanner', function() {
   it('should export all rules in rules/javascript', () => {
     // We skip the "run" check here for now as that's handled by ESLint.
     var ruleFiles = getRuleFiles('javascript');
-    var externalRules = 1;
+    var externalRules = 2;
 
     assert.equal(
       ruleFiles.length + externalRules,


### PR DESCRIPTION
This essentially mirrors what amo-validators does, only caring about
global eval() calls so we set allowIndirect to true. This can easily
be changed in case we want it though (which is actually the default
of the eslint rule).

Fixes #1047