### PR TITLE
Detect unknown browser API usage

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -388,4 +388,4 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | warning | Web extension | When default_locale is specified a matching messages.json must exist | | | null | NO_MESSAGES_FILE |
 | :white_check_mark: | warning | Web extension | When _locales directory exists, default_locale must exist | | | null | NO_DEFAULT_LOCALE |
 | :white_check_mark: | warning | Web extension | | | | | UNSAFE_VAR_ASSIGNMENT |
-| :white_check_mark: | warning | Web extension | Unsupported API | | | null | UNKNOWN_API |
+| :white_check_mark: | warning | Web extension | Unsupported or unknown browser API | | | null | UNSUPPORTED_API |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -388,3 +388,4 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | warning | Web extension | When default_locale is specified a matching messages.json must exist | | | null | NO_MESSAGES_FILE |
 | :white_check_mark: | warning | Web extension | When _locales directory exists, default_locale must exist | | | null | NO_DEFAULT_LOCALE |
 | :white_check_mark: | warning | Web extension | | | | | UNSAFE_VAR_ASSIGNMENT |
+| :white_check_mark: | warning | Web extension | Unsupported API | | | null | UNKNOWN_API |

--- a/src/const.js
+++ b/src/const.js
@@ -1,4 +1,7 @@
-import { UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT } from 'messages/javascript';
+import {
+  UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT,
+  UNSUPPORTED_API,
+} from 'messages/javascript';
 
 export const DEFLATE_COMPRESSION = 8;
 export const NO_COMPRESSION = 0;
@@ -21,6 +24,7 @@ export const ESLINT_RULE_MAPPING = {
   'opendialog-remote-uri': ESLINT_WARNING,
   'shallow-wrapper': ESLINT_WARNING,
   'webextension-api': ESLINT_WARNING,
+  'webextension-unsupported-api': ESLINT_WARNING,
   'widget-module': ESLINT_WARNING,
 
   // 3rd party / eslint-internal rules
@@ -30,6 +34,7 @@ export const ESLINT_RULE_MAPPING = {
 
 export const ESLINT_OVERWRITE_MESSAGE = {
   'no-unsafe-innerhtml/no-unsafe-innerhtml': UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT,
+  'webextension-unsupported-api': UNSUPPORTED_API,
 };
 
 export const VALIDATION_ERROR = 'error';

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,4 +1,4 @@
-import { apiToMessage, gettext as _, singleLineString } from 'utils';
+emport { apiToMessage, gettext as _, singleLineString } from 'utils';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
@@ -251,9 +251,10 @@ export const UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT = {
     serious performance degradation.`),
 };
 
-export const UNKNOWN_API = {
-  code: 'UNKNOWN_API',
-  message: _('{{api}} is not support by Firefox'),
+export const UNSUPPORTED_API = {
+  code: 'UNSUPPORTED_API',
+  message: null,
+  messageFormat: _('{{api}} is not supported'),
   description: _('This API has not been implemented by Firefox.'),
   legacyCode: null,
 };

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -251,6 +251,12 @@ export const UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT = {
     serious performance degradation.`),
 };
 
+export const UNKNOWN_API = {
+  code: 'UNKNOWN_API',
+  message: _('{{api}} is not support by Firefox'),
+  description: _('This API has not been implemented by Firefox.'),
+};
+
 function deprecatedAPI(api) {
   return {
     code: apiToMessage(api),

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,4 +1,4 @@
-emport { apiToMessage, gettext as _, singleLineString } from 'utils';
+import { apiToMessage, gettext as _, singleLineString } from 'utils';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -255,6 +255,7 @@ export const UNKNOWN_API = {
   code: 'UNKNOWN_API',
   message: _('{{api}} is not support by Firefox'),
   description: _('This API has not been implemented by Firefox.'),
+  legacyCode: null,
 };
 
 function deprecatedAPI(api) {

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -17,6 +17,8 @@ module.exports = {
     'opendialog-remote-uri': require('./opendialog-remote-uri').default,
     'shallow-wrapper': require('./shallow-wrapper').default,
     'webextension-api': require('./webextension-api').default,
+    'webextension-unsupported-api':
+      require('./webextension-unsupported-api').default,
     'widget-module': require('./widget-module').default,
   },
 };

--- a/src/rules/javascript/webextension-api.js
+++ b/src/rules/javascript/webextension-api.js
@@ -23,7 +23,7 @@ export default {
           }
 
           if (!hasBrowserApi(namespace, property)) {
-            context.report(node, '{{api}} is unsupported', { api });
+            context.report(node, '{{api}} is not supported', { api });
           }
         }
       },

--- a/src/rules/javascript/webextension-api.js
+++ b/src/rules/javascript/webextension-api.js
@@ -23,7 +23,7 @@ export default {
           }
 
           if (!hasBrowserApi(namespace, property)) {
-            context.report({ node, message: 'UNKNOWN_API', data: { api } });
+            context.report(node, '{{api}} is unsupported', { api });
           }
         }
       },

--- a/src/rules/javascript/webextension-api.js
+++ b/src/rules/javascript/webextension-api.js
@@ -1,7 +1,5 @@
-import { DEPRECATED_APIS, TEMPORARY_APIS } from 'const';
-import { apiToMessage } from '../../utils';
-
-import { hasBrowserApi } from 'schema/browser-apis';
+import { isDeprecatedApi, isTemporaryApi } from 'schema/browser-apis';
+import { apiToMessage } from 'utils';
 
 export default {
   create(context) {
@@ -13,17 +11,13 @@ export default {
           let property = node.property.name;
           let api = `${namespace}.${property}`;
 
-          if (DEPRECATED_APIS.includes(api)) {
+          if (isDeprecatedApi(namespace, property)) {
             return context.report(node, apiToMessage(api));
           }
 
           if (!context.settings.addonMetadata.id &&
-              TEMPORARY_APIS.includes(api)) {
+              isTemporaryApi(namespace, property)) {
             return context.report(node, apiToMessage(api));
-          }
-
-          if (!hasBrowserApi(namespace, property)) {
-            context.report(node, '{{api}} is not supported', { api });
           }
         }
       },

--- a/src/rules/javascript/webextension-api.js
+++ b/src/rules/javascript/webextension-api.js
@@ -1,13 +1,17 @@
 import { DEPRECATED_APIS, TEMPORARY_APIS } from 'const';
 import { apiToMessage } from '../../utils';
 
+import { hasBrowserApi } from 'schema/browser-apis';
+
 export default {
   create(context) {
     return {
       MemberExpression: function(node) {
         if (node.object.object &&
             ['chrome', 'browser'].includes(node.object.object.name)) {
-          let api = `${node.object.property.name}.${node.property.name}`;
+          let namespace = node.object.property.name;
+          let property = node.property.name;
+          let api = `${namespace}.${property}`;
 
           if (DEPRECATED_APIS.includes(api)) {
             return context.report(node, apiToMessage(api));
@@ -16,6 +20,10 @@ export default {
           if (!context.settings.addonMetadata.id &&
               TEMPORARY_APIS.includes(api)) {
             return context.report(node, apiToMessage(api));
+          }
+
+          if (!hasBrowserApi(namespace, property)) {
+            context.report({ node, message: 'UNKNOWN_API', data: { api } });
           }
         }
       },

--- a/src/rules/javascript/webextension-unsupported-api.js
+++ b/src/rules/javascript/webextension-unsupported-api.js
@@ -1,0 +1,21 @@
+import { UNSUPPORTED_API } from 'messages/javascript';
+import { hasBrowserApi } from 'schema/browser-apis';
+
+export default {
+  create(context) {
+    return {
+      MemberExpression: function(node) {
+        if (node.object.object &&
+            ['chrome', 'browser'].includes(node.object.object.name)) {
+          let namespace = node.object.property.name;
+          let property = node.property.name;
+          let api = `${namespace}.${property}`;
+
+          if (!hasBrowserApi(namespace, property)) {
+            context.report(node, UNSUPPORTED_API.messageFormat, { api });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/schema/browser-apis.js
+++ b/src/schema/browser-apis.js
@@ -1,4 +1,5 @@
-import schemaList from './firefox-schemas';
+import { DEPRECATED_APIS, TEMPORARY_APIS } from 'const';
+import schemaList from 'schema/firefox-schemas';
 
 const schemaArrayNames = ['functions', 'events'];
 const schemaObjectNames = ['types', 'properties'];
@@ -9,15 +10,30 @@ const schemas = schemaList.reduce((all, current) => ({
 
 export function hasBrowserApi(namespace, property) {
   const schema = schemas[namespace];
-  return Boolean(schema)
-    && (
-      schemaObjectNames.some(
-        (schemaProperty) =>
-          schema[schemaProperty] && property in schema[schemaProperty])
-      || schemaArrayNames.some((schemaProperty) => {
-        const namespaceProperties = schema[schemaProperty];
-        return Array.isArray(namespaceProperties) &&
-          namespaceProperties.some(
-            (schemaItem) => schemaItem.name === property);
-      }));
+  // We "have" the API if it's deprecated or temporary so
+  // we don't double warn.
+  if (isDeprecatedApi(namespace, property)
+    || isTemporaryApi(namespace, property)) {
+    return true;
+  }
+  if (!schema) {
+    return false;
+  }
+  return schemaObjectNames.some((schemaProperty) => {
+    return schema[schemaProperty] && property in schema[schemaProperty];
+  }) || schemaArrayNames.some((schemaProperty) => {
+    const namespaceProperties = schema[schemaProperty];
+    return Array.isArray(namespaceProperties) &&
+      namespaceProperties.some((schemaItem) => {
+        return schemaItem.name === property;
+      });
+  });
+}
+
+export function isDeprecatedApi(namespace, property) {
+  return DEPRECATED_APIS.includes(`${namespace}.${property}`);
+}
+
+export function isTemporaryApi(namespace, property) {
+  return TEMPORARY_APIS.includes(`${namespace}.${property}`);
 }

--- a/src/schema/browser-apis.js
+++ b/src/schema/browser-apis.js
@@ -16,15 +16,8 @@ export function hasBrowserApi(namespace, property) {
           schema[schemaProperty] && property in schema[schemaProperty])
       || schemaArrayNames.some((schemaProperty) => {
         const namespaceProperties = schema[schemaProperty];
-        if (namespaceProperties) {
-          if (Array.isArray(namespaceProperties)) {
-            return namespaceProperties.some(
-              (schemaItem) => schemaItem.name === property);
-          }
-          // eslint-disable-next-line no-console
-          console.log(
-            `${namespaceProperties} is not Array `, namespaceProperties);
-        }
-        return false;
+        return Array.isArray(namespaceProperties) &&
+          namespaceProperties.some(
+            (schemaItem) => schemaItem.name === property);
       }));
 }

--- a/src/schema/browser-apis.js
+++ b/src/schema/browser-apis.js
@@ -1,0 +1,30 @@
+import schemaList from './firefox-schemas';
+
+const schemaArrayNames = ['functions', 'events'];
+const schemaObjectNames = ['types', 'properties'];
+const schemas = schemaList.reduce((all, current) => ({
+  ...all,
+  [current.id]: current,
+}), {});
+
+export function hasBrowserApi(namespace, property) {
+  const schema = schemas[namespace];
+  return Boolean(schema)
+    && (
+      schemaObjectNames.some(
+        (schemaProperty) =>
+          schema[schemaProperty] && property in schema[schemaProperty])
+      || schemaArrayNames.some((schemaProperty) => {
+        const namespaceProperties = schema[schemaProperty];
+        if (namespaceProperties) {
+          if (Array.isArray(namespaceProperties)) {
+            return namespaceProperties.some(
+              (schemaItem) => schemaItem.name === property);
+          }
+          // eslint-disable-next-line no-console
+          console.log(
+            `${namespaceProperties} is not Array `, namespaceProperties);
+        }
+        return false;
+      }));
+}

--- a/src/schema/browser-apis.js
+++ b/src/schema/browser-apis.js
@@ -19,9 +19,18 @@ export function hasBrowserApi(namespace, property) {
   if (!schema) {
     return false;
   }
+  return hasObjectProperty(schema, property)
+    || hasArrayProperty(schema, property);
+}
+
+function hasObjectProperty(schema, property) {
   return schemaObjectNames.some((schemaProperty) => {
     return schema[schemaProperty] && property in schema[schemaProperty];
-  }) || schemaArrayNames.some((schemaProperty) => {
+  });
+}
+
+function hasArrayProperty(schema, property) {
+  return schemaArrayNames.some((schemaProperty) => {
     const namespaceProperties = schema[schemaProperty];
     return Array.isArray(namespaceProperties) &&
       namespaceProperties.some((schemaItem) => {

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -11,7 +11,9 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'gcm.register is not supported');
+        assert.equal(
+          validationMessages[0].code,
+          'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
@@ -25,7 +27,9 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'gcm.register is not supported');
+        assert.equal(
+          validationMessages[0].code,
+          'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -11,8 +11,9 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
+        assert.equal(validationMessages[0].code, 'UNSUPPORTED_API');
         assert.equal(
-          validationMessages[0].code,
+          validationMessages[0].message,
           'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
@@ -27,8 +28,9 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
+        assert.equal(validationMessages[0].code, 'UNSUPPORTED_API');
         assert.equal(
-          validationMessages[0].code,
+          validationMessages[0].message,
           'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -1,0 +1,43 @@
+import { VALIDATION_WARNING } from 'const';
+import JavaScriptScanner from 'scanners/javascript';
+
+describe('unsupported browser APIs', () => {
+  it('flags gcm usage on chrome', () => {
+    const code = 'chrome.gcm.register(["foo"], function() {})';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { id: '@unsupported-api' },
+    });
+    return jsScanner.scan()
+      .then((validationMessages) => {
+        assert.equal(
+          validationMessages.length, 1);
+        assert.equal(validationMessages[0].code, 'UNKNOWN_API');
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+      });
+  });
+
+  it('flags gcm usage on browser', () => {
+    const code = 'browser.gcm.register(["foo"], function() {})';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { id: '@unsupported-api' },
+    });
+    return jsScanner.scan()
+      .then((validationMessages) => {
+        assert.equal(
+          validationMessages.length, 1);
+        assert.equal(validationMessages[0].code, 'UNKNOWN_API');
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+      });
+  });
+
+  it('does not flag gcm usage on some other object', () => {
+    const code = 'gcmLib.gcm.register(["foo"], function() {})';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { id: '@unsupported-api' },
+    });
+    return jsScanner.scan()
+      .then((validationMessages) => {
+        assert.equal(validationMessages.length, 0);
+      });
+  });
+});

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -11,7 +11,7 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'UNKNOWN_API');
+        assert.equal(validationMessages[0].code, 'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
@@ -25,7 +25,7 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'UNKNOWN_API');
+        assert.equal(validationMessages[0].code, 'gcm.register is not supported');
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -11,7 +11,6 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'UNSUPPORTED_API');
         assert.equal(
           validationMessages[0].message,
           'gcm.register is not supported');
@@ -28,7 +27,6 @@ describe('unsupported browser APIs', () => {
       .then((validationMessages) => {
         assert.equal(
           validationMessages.length, 1);
-        assert.equal(validationMessages[0].code, 'UNSUPPORTED_API');
         assert.equal(
           validationMessages[0].message,
           'gcm.register is not supported');

--- a/tests/schema/test.browser-apis.js
+++ b/tests/schema/test.browser-apis.js
@@ -1,0 +1,13 @@
+import { hasBrowserApi } from 'schema/browser-apis';
+
+describe('browserApis', () => {
+  describe('hasBrowserApi', () => {
+    it('is false when the API is unknown', () => {
+      assert.notOk(hasBrowserApi('foo', 'notAnApi'));
+    });
+
+    it('is true when it supports an API', () => {
+      assert.ok(hasBrowserApi('cookies', 'get'));
+    });
+  });
+});

--- a/tests/schema/test.browser-apis.js
+++ b/tests/schema/test.browser-apis.js
@@ -1,4 +1,9 @@
-import { hasBrowserApi } from 'schema/browser-apis';
+import { DEPRECATED_APIS, TEMPORARY_APIS } from 'const';
+import {
+  hasBrowserApi,
+  isDeprecatedApi,
+  isTemporaryApi,
+} from 'schema/browser-apis';
 
 describe('browserApis', () => {
   describe('hasBrowserApi', () => {
@@ -8,6 +13,38 @@ describe('browserApis', () => {
 
     it('is true when it supports an API', () => {
       assert.ok(hasBrowserApi('cookies', 'get'));
+    });
+
+    it('has the API when it is temporary', () => {
+      const [namespace, property] = TEMPORARY_APIS[0].split('.');
+      assert.ok(hasBrowserApi(namespace, property));
+    });
+
+    it('has the API when it is deprecated', () => {
+      const [namespace, property] = DEPRECATED_APIS[0].split('.');
+      assert.ok(hasBrowserApi(namespace, property));
+    });
+  });
+
+  describe('isDeprecatedApi', () => {
+    it('is not deprecated if it is unknown', () => {
+      assert.notOk(isDeprecatedApi('foo', 'notAnApi'));
+    });
+
+    it('is deprecated if it is in DEPRECATED_APIS', () => {
+      assert.include(DEPRECATED_APIS, 'app.getDetails');
+      assert.ok(isDeprecatedApi('app', 'getDetails'));
+    });
+  });
+
+  describe('isTemporaryApi', () => {
+    it('is not temporary if it is unknown', () => {
+      assert.notOk(isTemporaryApi('foo', 'notAnApi'));
+    });
+
+    it('is temporary if it is in TEMPORARY_APIS', () => {
+      assert.include(TEMPORARY_APIS, 'identity.getRedirectURL');
+      assert.ok(isTemporaryApi('identity', 'getRedirectURL'));
     });
   });
 });


### PR DESCRIPTION
This is branched off of the metadata stuff since it has all the data we need. Not ready to be used but it's working so I thought I'd throw it up here.

I added these lines to an XPI I downloaded off AMO and this is the output:

```js
browser.notathing.get('foo');
chrome.storage.google('wat');
browser.app.getDetails('deprecated');
```

```
Validation Summary:

errors          0              
notices         0              
warnings        4              

WARNINGS:

Code              Message                             Description                                                              File                   Line   Column
UNSUPPORTED_API   notathing.get is not supported      This API has not been implemented by Firefox.                            archive.js             34     13    
UNSUPPORTED_API   storage.google is not supported     This API has not been implemented by Firefox.                            archive.js             35     13    
APP_GETDETAILS    "app.getDetails" is deprecated or   This API has been deprecated by Chrome and has not been implemented by   archive.js             36     13    
                  unimplemented                       Firefox.                                                                                                     
ALREADY_SIGNED    Package already signed              Add-ons which are already signed will be re-signed when published on     META-INF/manifest.mf                
                                                      AMO. This will replace any existing signatures on the add-on.                                                
```

Fixes #1168.