### PR TITLE
Test commands with Firefox schemas

### DIFF
--- a/src/schema/firefox-schemas.js
+++ b/src/schema/firefox-schemas.js
@@ -1,6 +1,10 @@
 import merge from 'deepmerge';
 
 const FLAG_PATTERN_REGEX = /^\(\?[im]*\)(.*)/;
+const UNRECOGNIZED_PROPERTY_REFS = [
+  'UnrecognizedProperty',
+  'manifest#/types/UnrecognizedProperty',
+];
 
 // Reference some functions on inner so they can be stubbed in tests.
 export const inner = {};
@@ -38,9 +42,9 @@ export function rewriteOptionalToRequired(schema) {
 function isUnrecognizedProperty(value) {
   if (typeof value === 'object') {
     const keys = Object.keys(value);
-    return keys.length === 1 &&
-      '$ref' in value &&
-      value.$ref === 'UnrecognizedProperty';
+    return keys.length === 1
+      && '$ref' in value
+      && UNRECOGNIZED_PROPERTY_REFS.includes(value.$ref);
   }
   return false;
 }

--- a/src/schema/imported/browser_action.json
+++ b/src/schema/imported/browser_action.json
@@ -396,9 +396,6 @@
       "properties": {
         "browser_action": {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "manifest#/types/UnrecognizedProperty"
-          },
           "properties": {
             "default_title": {
               "type": "string",

--- a/src/schema/imported/commands.json
+++ b/src/schema/imported/commands.json
@@ -49,9 +49,6 @@
           "type": "object",
           "additionalProperties": {
             "type": "object",
-            "additionalProperties": {
-              "$ref": "manifest#/types/UnrecognizedProperty"
-            },
             "properties": {
               "suggested_key": {
                 "type": "object",

--- a/src/schema/imported/omnibox.json
+++ b/src/schema/imported/omnibox.json
@@ -51,9 +51,6 @@
       "properties": {
         "omnibox": {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "manifest#/types/UnrecognizedProperty"
-          },
           "properties": {
             "keyword": {
               "type": "string",

--- a/src/schema/imported/page_action.json
+++ b/src/schema/imported/page_action.json
@@ -240,9 +240,6 @@
       "properties": {
         "page_action": {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "manifest#/types/UnrecognizedProperty"
-          },
           "properties": {
             "default_title": {
               "type": "string",

--- a/src/schema/imported/sidebar_action.json
+++ b/src/schema/imported/sidebar_action.json
@@ -147,9 +147,6 @@
       "properties": {
         "sidebar_action": {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "manifest#/types/UnrecognizedProperty"
-          },
           "properties": {
             "default_title": {
               "type": "string",

--- a/src/schema/manifest-schema.json
+++ b/src/schema/manifest-schema.json
@@ -150,6 +150,47 @@
         "author": {
             "description": "Legacy field from Chrome. Use \"developer\" instead.",
             "type": "string"
+        },
+        "commands": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "suggested_key": {
+                        "type": "object",
+                        "properties": {
+                            "default": {
+                                "$ref": "#/definitions/KeyName"
+                            },
+                            "mac": {
+                                "$ref": "#/definitions/KeyName"
+                            },
+                            "linux": {
+                                "$ref": "#/definitions/KeyName"
+                            },
+                            "windows": {
+                                "$ref": "#/definitions/KeyName"
+                            },
+                            "chromeos": {
+                                "type": "string"
+                            },
+                            "android": {
+                                "type": "string"
+                            },
+                            "ios": {
+                                "type": "string"
+                            },
+                            "additionalProperties": {
+                                "type": "string",
+                                "deprecated": "Unknown platform name"
+                            }
+                        }
+                    },
+                    "description": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "required": [
@@ -162,6 +203,22 @@
             "format": "versionString",
             "type": "string",
             "description": "Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3."
+        },
+        "KeyName": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "pattern": "^\\s*(Alt|Ctrl|Command|MacCtrl)\\s*\\+\\s*(Shift\\s*\\+\\s*)?([A-Z0-9]|Comma|Period|Home|End|PageUp|PageDown|Space|Insert|Delete|Up|Down|Left|Right)\\s*$"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^\\s*((Alt|Ctrl|Command|MacCtrl)\\s*\\+\\s*)?(Shift\\s*\\+\\s*)?(F[1-9]|F1[0-2])\\s*$"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^(MediaNextTrack|MediaPlayPause|MediaPrevTrack|MediaStop)$"
+                }
+            ]
         }
     }
 }

--- a/tests/schema/test.commands.js
+++ b/tests/schema/test.commands.js
@@ -1,0 +1,37 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import { assertHasMatchingError } from '../helpers';
+
+describe('/commands', () => {
+  it('should be valid with a default', () => {
+    const manifest = cloneDeep(validManifest);
+    manifest.commands = {
+      all: { suggested_key: { default: 'Ctrl+Shift+A' } },
+    };
+    validate(manifest);
+    assert.notOk(validate.errors);
+  });
+
+  it('should allow unknown platforms', () => {
+    const manifest = cloneDeep(validManifest);
+    manifest.commands = {
+      all: { suggested_key: { notAPlatform: 'Modifier+9' } },
+    };
+    validate(manifest);
+    assert.notOk(validate.errors);
+  });
+
+  it('should validate the key string', function() {
+    const manifest = cloneDeep(validManifest);
+    manifest.commands = {
+      up: { suggested_key: { mac: 'Command+ShiftUp' } },
+    };
+    validate(manifest);
+    assertHasMatchingError(validate.errors, {
+      dataPath: '/commands/up/suggested_key/mac',
+      message: /should match pattern/,
+    });
+  });
+});


### PR DESCRIPTION
Includes changes from #1169.

I copied the schema from commands.json into manifest-schema.json so the tests pass with both versions.

Depends on #1169.
Fixes #766.