### PR TITLE
Show all error messages and hide duplicates

### DIFF
--- a/src/collector.js
+++ b/src/collector.js
@@ -9,9 +9,11 @@ export default class Collector {
 
   constructor(config = {}) {
     this.config = config;
+    this.messageIndices = {};
 
     for (let type of constants.MESSAGE_TYPES) {
       this[`${type}s`] = [];
+      this.messageIndices[`${type}s`] = {};
     }
   }
 
@@ -39,6 +41,29 @@ export default class Collector {
     if (typeof list === 'undefined') {
       throw new Error(`Message type "${type}" not currently collected`);
     }
+
+    // Limit messages to one per dataPath per message type.
+    //
+    // Also, prioritise messages that are not about additionalProperties
+    // since a type or format error is generally more helpful.
+    var previousMessages = this.messageIndices[`${type}s`];
+    var previousMessageIndex = previousMessages[message.dataPath];
+    // Compare with undefined since previousMessageIndex can be 0.
+    if (message.dataPath && previousMessageIndex !== undefined) {
+      var previousMessage = list[previousMessageIndex];
+      if (previousMessage.keyword === 'additionalProperties') {
+        // This should be more informative, overwrite the old message.
+        list[previousMessageIndex] = message;
+        return;
+      }
+      // Skip this message, we only want one per dataPath.
+      return;
+    }
+    // Store the index so we can look it up if we get the same dataPath later.
+    if (message.dataPath) {
+      previousMessages[message.dataPath] = list.length;
+    }
+
     list.push(message);
   }
 

--- a/src/collector.js
+++ b/src/collector.js
@@ -51,7 +51,7 @@ export default class Collector {
 
   messagesAtDataPath(dataPath) {
     if (dataPath === undefined) {
-      throw new Error('message must have a dataPath');
+      throw new Error('dataPath is required');
     }
     if (!this.messagesByDataPath[dataPath]) {
       this.messagesByDataPath[dataPath] = [];

--- a/src/message.js
+++ b/src/message.js
@@ -11,6 +11,8 @@ export var props = [
   'column',
   'file',
   'line',
+  'keyword',
+  'dataPath',
 ];
 
 export var requiredProps = [

--- a/src/message.js
+++ b/src/message.js
@@ -57,7 +57,9 @@ export default class Message {
   }
 
   matches(other) {
-    return props.every((prop) => this[prop] === other[prop]);
+    return this.type === other.type && props.every((prop) => {
+      return this[prop] === other[prop];
+    });
   }
 
 }

--- a/src/message.js
+++ b/src/message.js
@@ -11,7 +11,6 @@ export var props = [
   'column',
   'file',
   'line',
-  'keyword',
   'dataPath',
 ];
 
@@ -55,6 +54,10 @@ export default class Message {
         is not one of ${MESSAGE_TYPES.join(', ')}`);
     }
     this._type = type;
+  }
+
+  matches(other) {
+    return props.every((prop) => this[prop] === other[prop]);
   }
 
 }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -51,6 +51,8 @@ export default class ManifestJSONParser extends JSONParser {
 
     var overrides = {
       message: `"${error.dataPath}" ${error.message}`,
+      keyword: error.keyword,
+      dataPath: error.dataPath,
     };
 
     if (error.keyword === 'required') {
@@ -87,18 +89,9 @@ export default class ManifestJSONParser extends JSONParser {
     this.isValid = validate(this.parsedJSON);
     if (!this.isValid) {
       log.debug('Schema Validation messages', validate.errors);
-      var errorsFound = [];
 
       for (let error of validate.errors) {
-        // Ensure that we only add one error on a field. This runs the risk
-        // of hiding errors, but means that we can aim to get to a more
-        // helpful error in the case of some rather verbose schema errors.
-        if (errorsFound.indexOf(error.dataPath) > -1) {
-          continue;
-        }
-
         var message = this.errorLookup(error);
-        errorsFound.push(error.dataPath);
 
         if (warnings.includes(message.code)) {
           this.collector.addWarning(message);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -51,7 +51,6 @@ export default class ManifestJSONParser extends JSONParser {
 
     var overrides = {
       message: `"${error.dataPath}" ${error.message}`,
-      keyword: error.keyword,
       dataPath: error.dataPath,
     };
 

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -5,7 +5,7 @@ import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import * as messages from 'messages';
 import { assertHasMatchingError, validManifestJSON } from '../helpers';
 
-describe.only('ManifestJSONParser', function() {
+describe('ManifestJSONParser', function() {
 
   it('should have empty metadata if bad JSON', () => {
     var addonLinter = new Linter({_: ['bar']});

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -5,7 +5,7 @@ import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import * as messages from 'messages';
 import { assertHasMatchingError, validManifestJSON } from '../helpers';
 
-describe('ManifestJSONParser', function() {
+describe.only('ManifestJSONParser', function() {
 
   it('should have empty metadata if bad JSON', () => {
     var addonLinter = new Linter({_: ['bar']});

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -43,10 +43,10 @@ describe('ManifestJSONParser', function() {
       var manifestJSONParser = new ManifestJSONParser(json,
                                                       addonLinter.collector);
       assert.equal(manifestJSONParser.isValid, false);
-      var errors = addonLinter.collector.errors;
-      assert.equal(errors.length, 1);
-      assert.equal(errors[0].code, messages.JSON_INVALID.code);
-      assert.include(errors[0].message, '/applications/gecko/id');
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.JSON_INVALID.code,
+        message: /"\/applications\/gecko\/id" should match pattern/,
+      });
     });
 
     it('should return null if undefined', () => {

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -1,7 +1,7 @@
 import { default as Collector } from 'collector';
 import { fakeMessageData } from './helpers';
 
-describe.only('Collector', function() {
+describe('Collector', function() {
 
   it('should be thrown an error if Message is created without a type', () => {
     assert.throws(() => {

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -75,6 +75,27 @@ describe('Collector', function() {
     assert.equal(collection.notices.length, 0);
   });
 
+  it('should add a message that differs on line number', () => {
+    var collection = new Collector();
+    collection.addWarning({
+      ...fakeMessageData,
+      dataPath: '/foo',
+      file: 'foo.js',
+      line: 25,
+    });
+    collection.addWarning({
+      ...fakeMessageData,
+      dataPath: '/foo',
+      file: 'foo.js',
+      line: 26,
+    });
+    assert.equal(collection.warnings.length, 2);
+    assert.equal(collection.warnings[0].line, 25);
+    assert.equal(collection.warnings[1].line, 26);
+    assert.equal(collection.errors.length, 0);
+    assert.equal(collection.notices.length, 0);
+  });
+
   it('should add a message that differs on one prop', () => {
     var collection = new Collector();
     collection.addWarning({ ...fakeMessageData, dataPath: '/foo' });

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -147,4 +147,11 @@ describe('Collector', function() {
     assert.equal(collection.notices[0].file, 'test.js');
   });
 
+  it('should throw when getting messages for an undefined dataPath', () => {
+    var collection = new Collector();
+    assert.throws(() => {
+      collection.messagesAtDataPath(undefined);
+    }, /dataPath is required/);
+  });
+
 });

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -1,7 +1,7 @@
 import { default as Collector } from 'collector';
 import { fakeMessageData } from './helpers';
 
-describe('Collector', function() {
+describe.only('Collector', function() {
 
   it('should be thrown an error if Message is created without a type', () => {
     assert.throws(() => {
@@ -65,7 +65,7 @@ describe('Collector', function() {
     assert.equal(collection.notices.length, 0);
   });
 
-  it('should not add a duplicate dataPath', () => {
+  it('should not add a duplicate message with a dataPath', () => {
     var collection = new Collector();
     collection.addWarning({ ...fakeMessageData, dataPath: '/foo' });
     collection.addWarning({ ...fakeMessageData, dataPath: '/foo' });
@@ -75,55 +75,16 @@ describe('Collector', function() {
     assert.equal(collection.notices.length, 0);
   });
 
-  it('should overwrite an old message about additionalProperties', () => {
+  it('should add a message that differs on one prop', () => {
     var collection = new Collector();
-    collection.addWarning({
-      ...fakeMessageData,
-      keyword: 'additionalProperties',
-      dataPath: '/foo',
-    });
-    collection.addWarning({
-      ...fakeMessageData,
-      keyword: 'type',
-      dataPath: '/foo',
-    });
-    assert.equal(collection.warnings.length, 1);
-    assert.equal(collection.warnings[0].keyword, 'type');
-    assert.equal(collection.errors.length, 0);
-    assert.equal(collection.notices.length, 0);
-  });
-
-  it('should allow the same dataPath in different message types', () => {
-    var collection = new Collector();
+    collection.addWarning({ ...fakeMessageData, dataPath: '/foo' });
     collection.addWarning({
       ...fakeMessageData,
       dataPath: '/foo',
+      message: 'Foo message',
     });
-    collection.addError({
-      ...fakeMessageData,
-      dataPath: '/foo',
-    });
-    assert.equal(collection.warnings.length, 1);
-    assert.equal(collection.errors.length, 1);
-    assert.equal(collection.notices.length, 0);
-  });
-
-  it('should handle multiple messages and uniqueness', () => {
-    var messageOverrides = [
-      { dataPath: '/foo' },
-      { dataPath: '/foo/bar', keyword: 'format' },
-      { dataPath: '/bar' },
-      { dataPath: '/foo/bar', keyword: 'type' },
-    ];
-    var collection = new Collector();
-    messageOverrides.forEach((overrides) => {
-      collection.addWarning({ ...fakeMessageData, ...overrides });
-    });
-    assert.equal(collection.warnings.length, 3);
-    assert.equal(collection.warnings[0].dataPath, '/foo');
-    assert.equal(collection.warnings[1].dataPath, '/foo/bar');
-    assert.equal(collection.warnings[1].keyword, 'format');
-    assert.equal(collection.warnings[2].dataPath, '/bar');
+    assert.equal(collection.warnings.length, 2);
+    assert.equal(collection.warnings[1].message, 'Foo message');
     assert.equal(collection.errors.length, 0);
     assert.equal(collection.notices.length, 0);
   });

--- a/tests/test.message.js
+++ b/tests/test.message.js
@@ -48,5 +48,37 @@ describe('Message', function() {
     }, Error, /The key for the file is "file"/);
   });
 
+  describe('matches', () => {
+    let fakeData;
+
+    before(() => {
+      fakeData = props.reduce((obj, prop) => ({
+        ...obj,
+        [prop]: prop,
+      }), {});
+    });
+
+    it('is a match if the props are all the same', () => {
+      var message = new Message('error', { ...fakeData });
+      var other = new Message('error', { ...fakeData });
+      assert.ok(message.matches(other));
+    });
+
+    it('is not a match with props the same except type', () => {
+      var message = new Message('error', { ...fakeData });
+      var other = new Message('warning', { ...fakeData });
+      assert.notOk(message.matches(other));
+    });
+
+    it('is not a match with different props', () => {
+      var message = new Message('error', { ...fakeData });
+      var other = new Message('error', {
+        ...fakeData,
+        message: 'different message',
+      });
+      assert.notOk(message.matches(other));
+    });
+  });
+
 });
 


### PR DESCRIPTION
With `"background": { "scripts": "foo.js" }` in the schema, an invalid permission and an invalid extension id...

Error messages using Firefox schemas:

```
errors          7              
notices         0              
warnings        3              

ERRORS:

Code                      Message                                Description                                                   File            Line   Column
JSON_INVALID              "/applications/gecko/id" should        Your JSON file could not be parsed.                                                        
                          match pattern                                                                                                                     
                          "^\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f…                                                                                              
                          ]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}$"                                                                                                 
JSON_INVALID              "/applications/gecko/id" should        Your JSON file could not be parsed.                                                        
                          match pattern                                                                                                                     
                          "^[a-z0-9-._]*@[a-z0-9-._]+$"                                                                                                     
JSON_INVALID              "/applications/gecko/id" should        Your JSON file could not be parsed.                                                        
                          match some schema in anyOf                                                                                                        
JSON_INVALID              "/background/scripts" is not a valid   Your JSON file could not be parsed.                                                        
                          key or has invalid extra properties                                                                                               
MANIFEST_FIELD_REQUIRED   "/background/page" is a required       See https://mzl.la/1ZOhoEN (MDN Docs) for more information.   manifest.json                
                          property                                                                                                                          
MANIFEST_FIELD_INVALID    "/background/scripts" should be        See https://mzl.la/1ZOhoEN (MDN Docs) for more information.   manifest.json                
                          array                                                                                                                             
JSON_INVALID              "/background" should match some        Your JSON file could not be parsed.                                                        
                          schema in anyOf                                                                                                                   
WARNINGS:

Code                   Message                             Description                                                              File                   Line   Column
MANIFEST_PERMISSIONS   /permissions: Unknown permissions   See https://mzl.la/1R1n1t0 (MDN Docs) for more information.              manifest.json                       
                       "wat" at 5.                                                                                                                                      
APP_GETDETAILS         "app.getDetails" is deprecated or   This API has been deprecated by Chrome and has not been implemented by   archive.js             36     13    
                       unimplemented                       Firefox.                                                                                                     
ALREADY_SIGNED         Package already signed              Add-ons which are already signed will be re-signed when published on     META-INF/manifest.mf                
                                                           AMO. This will replace any existing signatures on the add-on.                                                

```

Fixes #1194.