### PR TITLE
Fix pathing issues when importing schemas

### DIFF
--- a/bin/addons-linter
+++ b/bin/addons-linter
@@ -2,7 +2,7 @@
 
 var path = require('path');
 
-var absoluteAppRoot = path.resolve(__dirname);
+var absoluteAppRoot = path.resolve(path.join(__dirname, '..'));
 global.appRoot = path.relative(process.cwd(), absoluteAppRoot);
 
 require('../dist/addons-linter')

--- a/src/schema/firefox-schemas.js
+++ b/src/schema/firefox-schemas.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const schemaPath = 'src/schema/imported';
+const schemaPath = path.join(global.appRoot, 'src/schema/imported');
 const schemas = fs.readdirSync(schemaPath).map((filename) => {
   const filePath = path.join(schemaPath, filename);
   return JSON.parse(fs.readFileSync(filePath));

--- a/tasks/mochaTest.js
+++ b/tasks/mochaTest.js
@@ -26,6 +26,11 @@ const defaultOptions = {
   },
 };
 
+// global.appRoot should point to the repository root and is normaly defined
+// in bin/addons-linter.
+const absoluteAppRoot = path.join(path.resolve(__dirname), '..');
+global.appRoot = path.relative(process.cwd(), absoluteAppRoot);
+
 const allFiles = ['dist/tests.js'];
 const coverageReporterModulePath = path.resolve(
   path.join(__dirname, '../tests', 'coverage-reporter.js')


### PR DESCRIPTION
There was an issue where the paths for reading the schema files wouldn't work when invoked like `../addons-linter/bin/addons-linter my.xpi`. Unfortunately we can't use `__dirname` in firefox-schemas.js which I assume is a webpack issue since it's running from a bundle in dist.

This uses `global.appRoot` which was defined in bin/addons-linter but wasn't being used so I updated it to be the repository root rather than the bin folder since I think that makes more sense. I had to add the definition of `global.appRoot` to the tests as well to maintain coverage.

Fixes #1204.