### PR TITLE
improve message on a duplicated permission

### DIFF
--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -22,9 +22,8 @@ export const MANIFEST_BAD_PERMISSION = {
   code: 'MANIFEST_BAD_PERMISSION',
   legacyCode: null,
   message: _('The permission type is unsupported.'),
-  description: _(singleLineString`Permissions must be strings. If a permission
-    is an object, it's likely from a Chrome App Extension and will not work in
-    Firefox. See https://mzl.la/1R1n1t0 (MDN Docs) for more information.`),
+  description: _(singleLineString`See https://mzl.la/1R1n1t0
+    (MDN Docs) for more information.`),
   file: MANIFEST_JSON,
 };
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -61,10 +61,8 @@ export default class ManifestJSONParser extends JSONParser {
     } else if (error.dataPath.startsWith('/permissions') &&
                typeof error.data !== 'undefined' &&
                typeof error.data !== 'string') {
-      // Check for non-strings in the manifest permissions; these indicate
-      // a Chrome app extension. This means an error.
       baseObject = messages.MANIFEST_BAD_PERMISSION;
-      overrides = {};
+      overrides = {message: `Permissions ${error.message}.`};
     } else if (error.keyword === 'type') {
       baseObject = messages.MANIFEST_FIELD_INVALID;
     }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -136,7 +136,24 @@ describe('ManifestJSONParser', function() {
       assert.equal(manifestJSONParser.isValid, false);
       var errors = addonLinter.collector.errors;
       assert.equal(errors[0].code, messages.MANIFEST_BAD_PERMISSION.code);
-      assert.include(errors[0].message, 'permission type is unsupported');
+      assert.include(errors[0].message, 'should be equal to one');
+    });
+
+    it('should error if permission is duplicated', () => {
+      var addonLinter = new Linter({_: ['bar']});
+      var json = validManifestJSON({
+        permissions: [
+          'identity',
+          'identity',
+        ],
+      });
+
+      var manifestJSONParser = new ManifestJSONParser(json,
+                                                      addonLinter.collector);
+      assert.equal(manifestJSONParser.isValid, false);
+      var errors = addonLinter.collector.errors;
+      assert.equal(errors[0].code, messages.MANIFEST_BAD_PERMISSION.code);
+      assert.include(errors[0].message, 'should NOT have duplicate items');
     });
 
   });


### PR DESCRIPTION
it now says:

![screenshot 2017-04-13 17 08 21](https://cloud.githubusercontent.com/assets/74699/25028791/d33ddbb2-206b-11e7-8e22-52e282ccfce9.png)

When you try and do a non-string, its gets quite mean:

![screenshot 2017-04-13 17 09 25](https://cloud.githubusercontent.com/assets/74699/25028809/f9d7dfde-206b-11e7-944b-f65496aa5c5d.png)

But that's the JSON schema code, we should probably try and compact that down. Anyway combining the error the JSON schema returns and simplifying the description down to "go read the docs" seems ok to me.

Supports #1152 