### PR TITLE
Handle allOf with optional

### DIFF
--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -68,7 +68,18 @@ export function rewriteOptionalToRequired(schema) {
     const value = schema[key];
     if (!Array.isArray(value) && typeof value === 'object') {
       const { optional, ...rest } = value;
-      if (!optional) {
+      if (Array.isArray(rest.allOf)) {
+        let someOptional = false;
+        rest.allOf = rest.allOf.map((inner) => {
+          someOptional = someOptional || inner.optional;
+          const innerCopy = { ...inner };
+          delete innerCopy.optional;
+          return innerCopy;
+        });
+        if (!someOptional) {
+          required.push(key);
+        }
+      } else if (!optional) {
         required.push(key);
       }
       return { ...obj, [key]: rest };

--- a/src/schema/imported/bookmarks.json
+++ b/src/schema/imported/bookmarks.json
@@ -596,7 +596,6 @@
               "$ref": "#/types/BookmarkTreeNodeUnmodifiable"
             },
             {
-              "optional": true,
               "description": "Indicates the reason why this node is unmodifiable. The <var>managed</var> value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default)."
             }
           ]
@@ -611,8 +610,7 @@
       },
       "required": [
         "id",
-        "title",
-        "unmodifiable"
+        "title"
       ]
     },
     "CreateDetails": {

--- a/src/schema/imported/browsing_data.json
+++ b/src/schema/imported/browsing_data.json
@@ -424,7 +424,6 @@
               "$ref": "extensionTypes#/types/Date"
             },
             {
-              "optional": true,
               "description": "Remove data accumulated on or after this date, represented in milliseconds since the epoch (accessible via the <code>getTime</code> method of the JavaScript <code>Date</code> object). If absent, defaults to 0 (which would remove all browsing data)."
             }
           ]
@@ -447,10 +446,7 @@
             }
           }
         }
-      },
-      "required": [
-        "since"
-      ]
+      }
     },
     "DataTypeSet": {
       "type": "object",

--- a/src/schema/imported/context_menus.json
+++ b/src/schema/imported/context_menus.json
@@ -37,7 +37,6 @@
                   "$ref": "#/types/ItemType"
                 },
                 {
-                  "optional": true,
                   "description": "The type of menu item. Defaults to 'normal' if not specified."
                 }
               ]
@@ -119,10 +118,7 @@
               "type": "boolean",
               "description": "Whether this context menu item is enabled or disabled. Defaults to true."
             }
-          },
-          "required": [
-            "type"
-          ]
+          }
         },
         {
           "type": "function",

--- a/src/schema/imported/downloads.json
+++ b/src/schema/imported/downloads.json
@@ -395,8 +395,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>url</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>url</code>."
                 }
               ]
             },
@@ -406,8 +405,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>filename</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>filename</code>."
                 }
               ]
             },
@@ -417,8 +415,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>danger</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>danger</code>."
                 }
               ]
             },
@@ -428,8 +425,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>mime</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>mime</code>."
                 }
               ]
             },
@@ -439,8 +435,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>startTime</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>startTime</code>."
                 }
               ]
             },
@@ -450,8 +445,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>endTime</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>endTime</code>."
                 }
               ]
             },
@@ -461,8 +455,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>state</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>state</code>."
                 }
               ]
             },
@@ -475,8 +468,7 @@
                   "$ref": "#/types/BooleanDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>paused</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>paused</code>."
                 }
               ]
             },
@@ -486,8 +478,7 @@
                   "$ref": "#/types/StringDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>error</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>error</code>."
                 }
               ]
             },
@@ -497,8 +488,7 @@
                   "$ref": "#/types/DoubleDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>totalBytes</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>totalBytes</code>."
                 }
               ]
             },
@@ -508,8 +498,7 @@
                   "$ref": "#/types/DoubleDelta"
                 },
                 {
-                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>fileSize</code>.",
-                  "optional": true
+                  "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>fileSize</code>."
                 }
               ]
             },
@@ -518,18 +507,7 @@
             }
           },
           "required": [
-            "id",
-            "url",
-            "filename",
-            "danger",
-            "mime",
-            "startTime",
-            "endTime",
-            "state",
-            "paused",
-            "error",
-            "totalBytes",
-            "fileSize"
+            "id"
           ]
         }
       ],
@@ -687,8 +665,7 @@
               "$ref": "#/types/InterruptReason"
             },
             {
-              "description": "Number indicating why a download was interrupted.",
-              "optional": true
+              "description": "Number indicating why a download was interrupted."
             }
           ]
         },
@@ -726,7 +703,6 @@
         "state",
         "paused",
         "canResume",
-        "error",
         "bytesReceived",
         "totalBytes",
         "fileSize",
@@ -795,8 +771,7 @@
               "$ref": "#/types/DownloadTime"
             },
             {
-              "description": "Limits results to downloads that started before the given ms since the epoch.",
-              "optional": true
+              "description": "Limits results to downloads that started before the given ms since the epoch."
             }
           ]
         },
@@ -806,8 +781,7 @@
               "$ref": "#/types/DownloadTime"
             },
             {
-              "description": "Limits results to downloads that started after the given ms since the epoch.",
-              "optional": true
+              "description": "Limits results to downloads that started after the given ms since the epoch."
             }
           ]
         },
@@ -817,8 +791,7 @@
               "$ref": "#/types/DownloadTime"
             },
             {
-              "description": "Limits results to downloads that ended before the given ms since the epoch.",
-              "optional": true
+              "description": "Limits results to downloads that ended before the given ms since the epoch."
             }
           ]
         },
@@ -828,8 +801,7 @@
               "$ref": "#/types/DownloadTime"
             },
             {
-              "description": "Limits results to downloads that ended after the given ms since the epoch.",
-              "optional": true
+              "description": "Limits results to downloads that ended after the given ms since the epoch."
             }
           ]
         },
@@ -877,8 +849,7 @@
               "$ref": "#/types/DangerType"
             },
             {
-              "description": "Indication of whether this download is thought to be safe or known to be suspicious.",
-              "optional": true
+              "description": "Indication of whether this download is thought to be safe or known to be suspicious."
             }
           ]
         },
@@ -898,8 +869,7 @@
               "$ref": "#/types/State"
             },
             {
-              "description": "Indicates whether the download is progressing, interrupted, or complete.",
-              "optional": true
+              "description": "Indicates whether the download is progressing, interrupted, or complete."
             }
           ]
         },
@@ -913,8 +883,7 @@
               "$ref": "#/types/InterruptReason"
             },
             {
-              "description": "Why a download was interrupted.",
-              "optional": true
+              "description": "Why a download was interrupted."
             }
           ]
         },
@@ -933,16 +902,7 @@
         "exists": {
           "type": "boolean"
         }
-      },
-      "required": [
-        "startedBefore",
-        "startedAfter",
-        "endedBefore",
-        "endedAfter",
-        "danger",
-        "state",
-        "error"
-      ]
+      }
     }
   }
 }

--- a/src/schema/imported/extension.json
+++ b/src/schema/imported/extension.json
@@ -72,7 +72,6 @@
                   "$ref": "#/types/ViewType"
                 },
                 {
-                  "optional": true,
                   "description": "The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'notification', 'popup'."
                 }
               ]
@@ -81,10 +80,7 @@
               "type": "integer",
               "description": "The window to restrict the search to. If omitted, returns all views."
             }
-          },
-          "required": [
-            "type"
-          ]
+          }
         }
       ],
       "returns": {

--- a/src/schema/imported/extension_types.json
+++ b/src/schema/imported/extension_types.json
@@ -22,7 +22,6 @@
               "$ref": "#/types/ImageFormat"
             },
             {
-              "optional": true,
               "description": "The format of the resulting image.  Default is <code>\"jpeg\"</code>."
             }
           ]
@@ -33,10 +32,7 @@
           "maximum": 100,
           "description": "When format is <code>\"jpeg\"</code>, controls the quality of the resulting image.  This value is ignored for PNG images.  As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease."
         }
-      },
-      "required": [
-        "format"
-      ]
+      }
     },
     "RunAt": {
       "type": "string",
@@ -86,7 +82,6 @@
               "$ref": "#/types/RunAt"
             },
             {
-              "optional": true,
               "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]
@@ -97,16 +92,11 @@
               "$ref": "#/types/CSSOrigin"
             },
             {
-              "optional": true,
               "description": "The css origin of the stylesheet to inject. Defaults to \"author\"."
             }
           ]
         }
-      },
-      "required": [
-        "runAt",
-        "cssOrigin"
-      ]
+      }
     },
     "Date": {
       "anyOf": [

--- a/src/schema/imported/history.json
+++ b/src/schema/imported/history.json
@@ -25,7 +25,6 @@
                   "$ref": "extensionTypes#/types/Date"
                 },
                 {
-                  "optional": true,
                   "description": "Limit results to those visited after this date. If not specified, this defaults to 24 hours in the past."
                 }
               ]
@@ -36,7 +35,6 @@
                   "$ref": "extensionTypes#/types/Date"
                 },
                 {
-                  "optional": true,
                   "description": "Limit results to those visited before this date."
                 }
               ]
@@ -48,9 +46,7 @@
             }
           },
           "required": [
-            "text",
-            "startTime",
-            "endTime"
+            "text"
           ]
         },
         {
@@ -126,7 +122,6 @@
                   "$ref": "#/types/TransitionType"
                 },
                 {
-                  "optional": true,
                   "description": "The $(topic:transition-types)[transition type] for this visit from its referrer."
                 }
               ]
@@ -137,16 +132,13 @@
                   "$ref": "extensionTypes#/types/Date"
                 },
                 {
-                  "optional": true,
                   "description": "The date when this visit occurred."
                 }
               ]
             }
           },
           "required": [
-            "url",
-            "transition",
-            "visitTime"
+            "url"
           ]
         },
         {

--- a/src/schema/imported/management.json
+++ b/src/schema/imported/management.json
@@ -227,8 +227,7 @@
               "$ref": "#/types/ExtensionDisabledReason"
             },
             {
-              "description": "A reason the item is disabled.",
-              "optional": true
+              "description": "A reason the item is disabled."
             }
           ]
         },
@@ -294,7 +293,6 @@
         "version",
         "mayDisable",
         "enabled",
-        "disabledReason",
         "type",
         "optionsUrl",
         "permissions",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -423,15 +423,13 @@
               "$ref": "extensionTypes#/types/RunAt"
             },
             {
-              "optional": true,
               "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]
         }
       },
       "required": [
-        "matches",
-        "run_at"
+        "matches"
       ]
     },
     "IconPath": {

--- a/src/schema/imported/notifications.json
+++ b/src/schema/imported/notifications.json
@@ -358,7 +358,6 @@
               "$ref": "#/types/TemplateType"
             },
             {
-              "optional": true,
               "description": "Which type of notification to display."
             }
           ]
@@ -433,10 +432,7 @@
           "description": "Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.",
           "type": "boolean"
         }
-      },
-      "required": [
-        "type"
-      ]
+      }
     }
   }
 }

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -651,7 +651,6 @@
               "$ref": "#/types/MessageSender"
             },
             {
-              "optional": true,
               "description": "This property will <b>only</b> be present on ports passed to onConnect/onConnectExternal listeners."
             }
           ]
@@ -663,8 +662,7 @@
         "disconnect",
         "onDisconnect",
         "onMessage",
-        "postMessage",
-        "sender"
+        "postMessage"
       ]
     },
     "MessageSender": {
@@ -681,7 +679,6 @@
               "$ref": "tabs#/types/Tab"
             },
             {
-              "optional": true,
               "description": "The $(ref:tabs.Tab) which opened the connection, if any. This property will <strong>only</strong> be present when the connection was opened from a tab (including content scripts), and <strong>only</strong> if the receiver is an extension, not an app."
             }
           ]
@@ -703,10 +700,7 @@
           "type": "string",
           "description": "The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available."
         }
-      },
-      "required": [
-        "tab"
-      ]
+      }
     },
     "PlatformOs": {
       "type": "string",

--- a/src/schema/imported/sessions.json
+++ b/src/schema/imported/sessions.json
@@ -162,7 +162,6 @@
               "$ref": "tabs#/types/Tab"
             },
             {
-              "optional": true,
               "description": "The $(ref:tabs.Tab), if this entry describes a tab. Either this or $(ref:sessions.Session.window) will be set."
             }
           ]
@@ -173,16 +172,13 @@
               "$ref": "windows#/types/Window"
             },
             {
-              "optional": true,
               "description": "The $(ref:windows.Window), if this entry describes a window. Either this or $(ref:sessions.Session.tab) will be set."
             }
           ]
         }
       },
       "required": [
-        "lastModified",
-        "tab",
-        "window"
+        "lastModified"
       ]
     },
     "Device": {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -377,7 +377,6 @@
                   "$ref": "#/types/TabStatus"
                 },
                 {
-                  "optional": true,
                   "description": "Whether the tabs have completed loading."
                 }
               ]
@@ -411,7 +410,6 @@
                   "$ref": "#/types/WindowType"
                 },
                 {
-                  "optional": true,
                   "description": "The type of window the tabs are in."
                 }
               ]
@@ -425,11 +423,7 @@
               "type": "string",
               "description": "The CookieStoreId used for the tab."
             }
-          },
-          "required": [
-            "status",
-            "windowType"
-          ]
+          }
         },
         {
           "type": "function",
@@ -1053,7 +1047,6 @@
                   "$ref": "#/types/MutedInfo"
                 },
                 {
-                  "optional": true,
                   "description": "The tab's new muted state and the reason for the change."
                 }
               ]
@@ -1062,10 +1055,7 @@
               "type": "string",
               "description": "The tab's new favicon URL."
             }
-          },
-          "required": [
-            "mutedInfo"
-          ]
+          }
         },
         {
           "allOf": [
@@ -1455,7 +1445,6 @@
               "$ref": "#/types/MutedInfoReason"
             },
             {
-              "optional": true,
               "description": "The reason the tab was muted or unmuted. Not set if the tab's mute state has never been changed."
             }
           ]
@@ -1466,8 +1455,7 @@
         }
       },
       "required": [
-        "muted",
-        "reason"
+        "muted"
       ]
     },
     "Tab": {
@@ -1522,7 +1510,6 @@
               "$ref": "#/types/MutedInfo"
             },
             {
-              "optional": true,
               "description": "Current tab muted state and the reason for the last state change."
             }
           ]
@@ -1581,7 +1568,6 @@
         "highlighted",
         "active",
         "pinned",
-        "mutedInfo",
         "incognito",
         "cookieStoreId"
       ]
@@ -1628,8 +1614,7 @@
               "$ref": "#/types/ZoomSettingsMode"
             },
             {
-              "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>.",
-              "optional": true
+              "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>."
             }
           ]
         },
@@ -1639,8 +1624,7 @@
               "$ref": "#/types/ZoomSettingsScope"
             },
             {
-              "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise.",
-              "optional": true
+              "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise."
             }
           ]
         },
@@ -1648,11 +1632,7 @@
           "type": "number",
           "description": "Used to return the default zoom level for the current tab in calls to tabs.getZoomSettings."
         }
-      },
-      "required": [
-        "mode",
-        "scope"
-      ]
+      }
     },
     "TabStatus": {
       "type": "string",

--- a/src/schema/imported/types.json
+++ b/src/schema/imported/types.json
@@ -100,15 +100,13 @@
                       "$ref": "#/types/SettingScope"
                     },
                     {
-                      "optional": true,
                       "description": "Where to set the setting (default: regular)."
                     }
                   ]
                 }
               },
               "required": [
-                "value",
-                "scope"
+                "value"
               ]
             },
             {
@@ -137,15 +135,11 @@
                       "$ref": "#/types/SettingScope"
                     },
                     {
-                      "optional": true,
                       "description": "Where to clear the setting (default: regular)."
                     }
                   ]
                 }
-              },
-              "required": [
-                "scope"
-              ]
+              }
             },
             {
               "name": "callback",

--- a/src/schema/imported/url_overrides.json
+++ b/src/schema/imported/url_overrides.json
@@ -12,7 +12,6 @@
                   "$ref": "manifest#/types/ExtensionURL"
                 },
                 {
-                  "optional": true,
                   "preprocess": "localize"
                 }
               ]
@@ -23,7 +22,6 @@
                   "$ref": "manifest#/types/ExtensionURL"
                 },
                 {
-                  "optional": true,
                   "preprocess": "localize"
                 }
               ]
@@ -35,7 +33,6 @@
                 },
                 {
                   "unsupported": true,
-                  "optional": true,
                   "preprocess": "localize"
                 }
               ]
@@ -47,18 +44,11 @@
                 },
                 {
                   "unsupported": true,
-                  "optional": true,
                   "preprocess": "localize"
                 }
               ]
             }
-          },
-          "required": [
-            "newtab",
-            "home",
-            "bookmarks",
-            "history"
-          ]
+          }
         }
       }
     }

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -216,7 +216,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP request headers that are going to be sent out with this request."
                 }
               ]
@@ -230,8 +229,7 @@
             "parentFrameId",
             "tabId",
             "type",
-            "timeStamp",
-            "requestHeaders"
+            "timeStamp"
           ]
         }
       ],
@@ -329,7 +327,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP request headers that have been sent out with this request."
                 }
               ]
@@ -343,8 +340,7 @@
             "parentFrameId",
             "tabId",
             "type",
-            "timeStamp",
-            "requestHeaders"
+            "timeStamp"
           ]
         }
       ],
@@ -435,7 +431,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP response headers that have been received with this response."
                 }
               ]
@@ -455,7 +450,6 @@
             "type",
             "timeStamp",
             "statusLine",
-            "responseHeaders",
             "statusCode"
           ]
         }
@@ -582,7 +576,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP response headers that were received along with this response."
                 }
               ]
@@ -608,7 +601,6 @@
             "scheme",
             "challenger",
             "isProxy",
-            "responseHeaders",
             "statusLine",
             "statusCode"
           ]
@@ -737,7 +729,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP response headers that were received along with this response."
                 }
               ]
@@ -758,7 +749,6 @@
             "timeStamp",
             "fromCache",
             "statusCode",
-            "responseHeaders",
             "statusLine"
           ]
         }
@@ -862,7 +852,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP response headers that were received along with this redirect."
                 }
               ]
@@ -884,7 +873,6 @@
             "fromCache",
             "statusCode",
             "redirectUrl",
-            "responseHeaders",
             "statusLine"
           ]
         }
@@ -984,7 +972,6 @@
                   "$ref": "#/types/HttpHeaders"
                 },
                 {
-                  "optional": true,
                   "description": "The HTTP response headers that were received along with this response."
                 }
               ]
@@ -1005,7 +992,6 @@
             "timeStamp",
             "fromCache",
             "statusCode",
-            "responseHeaders",
             "statusLine"
           ]
         }
@@ -1302,7 +1288,6 @@
               "$ref": "#/types/HttpHeaders"
             },
             {
-              "optional": true,
               "description": "Only used as a response to the onBeforeSendHeaders event. If set, the request is made with these request headers instead."
             }
           ]
@@ -1313,7 +1298,6 @@
               "$ref": "#/types/HttpHeaders"
             },
             {
-              "optional": true,
               "description": "Only used as a response to the onHeadersReceived event. If set, the server is assumed to have responded with these response headers instead. Only return <code>responseHeaders</code> if you really want to modify the headers in order to limit the number of conflicts (only one extension may modify <code>responseHeaders</code> for each request)."
             }
           ]
@@ -1334,11 +1318,7 @@
             "password"
           ]
         }
-      },
-      "required": [
-        "requestHeaders",
-        "responseHeaders"
-      ]
+      }
     },
     "UploadData": {
       "type": "object",

--- a/src/schema/imported/windows.json
+++ b/src/schema/imported/windows.json
@@ -250,7 +250,6 @@
                   "$ref": "#/types/CreateType"
                 },
                 {
-                  "optional": true,
                   "description": "Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless the '--enable-panels' flag is set."
                 }
               ]
@@ -261,7 +260,6 @@
                   "$ref": "#/types/WindowState"
                 },
                 {
-                  "optional": true,
                   "description": "The initial state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'."
                 }
               ]
@@ -271,11 +269,7 @@
               "description": "Allow scripts to close the window."
             }
           },
-          "optional": true,
-          "required": [
-            "type",
-            "state"
-          ]
+          "optional": true
         },
         {
           "type": "function",
@@ -345,15 +339,11 @@
                   "$ref": "#/types/WindowState"
                 },
                 {
-                  "optional": true,
                   "description": "The new state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'."
                 }
               ]
             }
-          },
-          "required": [
-            "state"
-          ]
+          }
         },
         {
           "type": "function",
@@ -540,7 +530,6 @@
               "$ref": "#/types/WindowType"
             },
             {
-              "optional": true,
               "description": "The type of browser window this is."
             }
           ]
@@ -551,7 +540,6 @@
               "$ref": "#/types/WindowState"
             },
             {
-              "optional": true,
               "description": "The state of this browser window."
             }
           ]
@@ -568,8 +556,6 @@
       "required": [
         "focused",
         "incognito",
-        "type",
-        "state",
         "alwaysOnTop"
       ]
     },

--- a/tests/schema/test.content_scripts.js
+++ b/tests/schema/test.content_scripts.js
@@ -1,0 +1,50 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import validate from 'schema/validator';
+import { validManifest } from './helpers';
+import { assertHasMatchingError } from '../helpers';
+
+describe('/background', () => {
+
+  it('supports simple content scripts', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.content_scripts = [
+      {
+        matches: ['*://*.mozilla.org/*'],
+        js: ['borderify.js'],
+      },
+    ];
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('supports run_at', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.content_scripts = [
+      {
+        matches: ['*://*.mozilla.org/*'],
+        js: ['borderify.js'],
+        run_at: 'document_start',
+      },
+    ];
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('catches invalid run_at', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.content_scripts = [
+      {
+        matches: ['*://*.mozilla.org/*'],
+        js: ['borderify.js'],
+        run_at: 'whenever',
+      },
+    ];
+    validate(manifest);
+    assertHasMatchingError(validate.errors, {
+      dataPath: '/content_scripts/0/run_at',
+      message: 'should be equal to one of the allowed values',
+    });
+  });
+
+});

--- a/tests/schema/test.content_scripts.js
+++ b/tests/schema/test.content_scripts.js
@@ -4,7 +4,7 @@ import validate from 'schema/validator';
 import { validManifest } from './helpers';
 import { assertHasMatchingError } from '../helpers';
 
-describe('/background', () => {
+describe('/content_scripts', () => {
 
   it('supports simple content scripts', () => {
     var manifest = cloneDeep(validManifest);

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -83,7 +83,7 @@ describe('firefox schema import', () => {
       });
     });
 
-    it('handles an allOf with one being optional', () => {
+    it('handles an allOf with one nested schema being optional', () => {
       const obj = {
         foo: { type: 'string', optional: true },
         bar: {
@@ -96,16 +96,18 @@ describe('firefox schema import', () => {
       };
       assert.deepEqual(rewriteOptionalToRequired(obj), {
         foo: { type: 'string' },
-        bar: { allOf: [
-          { $ref: '#/types/Whatever' },
-          { description: 'a thing' },
-        ]},
+        bar: {
+          allOf: [
+            { $ref: '#/types/Whatever' },
+            { description: 'a thing' },
+          ],
+        },
         baz: { type: 'boolean' },
         required: ['baz'],
       });
     });
 
-    it('handles an allOf with none being optional', () => {
+    it('handles an allOf with no nested schemas being optional', () => {
       const obj = {
         foo: { type: 'string', optional: true },
         bar: {

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -82,6 +82,50 @@ describe('firefox schema import', () => {
         required: [],
       });
     });
+
+    it('handles an allOf with one being optional', () => {
+      const obj = {
+        foo: { type: 'string', optional: true },
+        bar: {
+          allOf: [
+            { $ref: '#/types/Whatever' },
+            { optional: true, description: 'a thing' },
+          ],
+        },
+        baz: { type: 'boolean' },
+      };
+      assert.deepEqual(rewriteOptionalToRequired(obj), {
+        foo: { type: 'string' },
+        bar: { allOf: [
+          { $ref: '#/types/Whatever' },
+          { description: 'a thing' },
+        ]},
+        baz: { type: 'boolean' },
+        required: ['baz'],
+      });
+    });
+
+    it('handles an allOf with none being optional', () => {
+      const obj = {
+        foo: { type: 'string', optional: true },
+        bar: {
+          allOf: [
+            { $ref: '#/types/Whatever' },
+            { type: 'string' },
+          ],
+        },
+        baz: { type: 'boolean' },
+      };
+      assert.deepEqual(rewriteOptionalToRequired(obj), {
+        foo: { type: 'string' },
+        bar: { allOf: [
+          { $ref: '#/types/Whatever' },
+          { type: 'string' },
+        ]},
+        baz: { type: 'boolean' },
+        required: ['bar', 'baz'],
+      });
+    });
   });
 
   describe('rewriteValue', () => {


### PR DESCRIPTION
This handles parsing schemas with an `allOf` that has an optional schema in it. This was causing an error on `content_scripts` without a `run_at` property.

Fixes #1245.