### PR TITLE
fix: Linter.run should resolve to the linting results object

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -395,7 +395,7 @@ export default class Linter {
           }
           this.collector._addMessage(message.type, message);
         }
-        return this.output;
+        return;
       });
   }
 
@@ -521,6 +521,8 @@ export default class Linter {
           if (this.config.runAsBinary === true) {
             process.exit(this.output.errors.length > 0 ? 1 : 0);
           }
+
+          return this.output;
         })
         .catch((err) => {
           log.debug(err);
@@ -528,7 +530,7 @@ export default class Linter {
           throw err;
         });
     } else {
-      return this.scan(deps);
+      return this.scan(deps).then(() => this.output);
     }
   }
 

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -1313,4 +1313,28 @@ describe('Linter.run()', function() {
       });
   });
 
+  it('should resolve to the linting results object', () => {
+    var addonLinter = new Linter({_: ['foo'], metadata: false});
+
+    addonLinter.scan = sinon.stub();
+    addonLinter.scan.returns(Promise.resolve());
+
+    return addonLinter.run({_console: fakeConsole})
+      .then((result) => {
+        assert.deepEqual(result, addonLinter.output);
+      });
+  });
+
+  it('should resolve to the linting results when metadata is true', () => {
+    var addonLinter = new Linter({_: ['foo'], metadata: true});
+
+    addonLinter.extractMetadata = sinon.stub();
+    addonLinter.extractMetadata.returns(Promise.resolve());
+
+    return addonLinter.run({_console: fakeConsole})
+      .then((result) => {
+        assert.deepEqual(result, addonLinter.output);
+      });
+  });
+
 });


### PR DESCRIPTION
This PR introduces the changes needed to fix #1263 and adds two new small test cases to ensure that Linter.run resolves to the linting results object as expected (and documented in the README file).