### PR TITLE
Drop tests on node4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
 - '6'
 script: npm test
 notifications:


### PR DESCRIPTION
```
<TheOne> muffinresearch: have you folks talked about dropping tests on node4, now that node6 has been on LTS for a while? Tests on node4 take significantly longer
<@muffinresearch> yeah we already have elsewhere
<@muffinresearch> So feel free to do that anywhere that needs it.
```