### PR TITLE
Mozilla greenkeeper/tar 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "comment-json": "1.1.3",
     "coveralls": "2.13.1",
     "deepmerge": "1.3.2",
-    "fstream": "1.0.11",
     "gfm.css": "1.1.1",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.1.0",
@@ -66,7 +65,7 @@
     "sinon": "2.3.1",
     "webpack": "2.6.1",
     "webpack-dev-server": "2.4.5",
-    "tar": "2.2.1"
+    "tar": "3.0.1"
   },
   "dependencies": {
     "ajv": "5.0.1",


### PR DESCRIPTION
So things changed a bit with the rewrite. Not too bad except it now seems to include null bytes in filenames when using the `Parse` class which breaks `fs.createWriteStream` and took me some time to figure out. Also the parsing won't chain off the stream from `request` anymore so it now writes to file and uses that.

Closes #1277.