### PR TITLE
Set explicit caching when watching

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   buildwatch: {
     watch: true,
+    cache: true,
     keepalive: true,
     resolve: buildResolve,
   },


### PR DESCRIPTION
Fix #1280.

https://webpack.js.org/configuration/other-options/#cache says
`Caching is enabled by default while in watch mode.`
Looks like it isn't in our config or there is a bug in grunt-webpack, so setting it explicitly.