### PR TITLE
handle duplicate permissions error messages

### DIFF
--- a/src/collector.js
+++ b/src/collector.js
@@ -69,10 +69,14 @@ export default class Collector {
 
   isDuplicateMessage(message) {
     if (message.dataPath) {
-      var previousMessages = this.messagesAtDataPath(message.dataPath);
-      return previousMessages.some((prevMessage) => {
-        return prevMessage.matches(message);
-      });
+      let previousMessages = this.messagesAtDataPath(message.dataPath);
+      if (message.file === 'manifest.json') {
+        return previousMessages.length > 0;
+      } else {
+        return previousMessages.some((prevMessage) => {
+          return prevMessage.matches(message);
+        });
+      }
     }
     return false;
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -62,7 +62,7 @@ export default class ManifestJSONParser extends JSONParser {
                typeof error.data !== 'undefined' &&
                typeof error.data !== 'string') {
       baseObject = messages.MANIFEST_BAD_PERMISSION;
-      overrides = {message: `Permissions ${error.message}.`};
+      overrides.message = `Permissions ${error.message}.`;
     } else if (error.keyword === 'type') {
       baseObject = messages.MANIFEST_FIELD_INVALID;
     }

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -89,6 +89,22 @@ describe('Collector', function() {
     });
   });
 
+  it('for manifest should add one message for dataPath', () => {
+    var collection = new Collector();
+    collection.addError({
+      ...fakeMessageData,
+      file: 'manifest.json',
+      dataPath: '/foo/1',
+    });
+    collection.addError({
+      ...fakeMessageData,
+      file: 'manifest.json',
+      dataPath: '/foo/1',
+      message: 'foo bar',
+    });
+    expect(collection.errors.length).toBe(1);
+  });
+
   it('should add a message that differs on line number', () => {
     var collection = new Collector();
     collection.addWarning({


### PR DESCRIPTION
Fixes #1240 

I did a first attemp, but I have a doubt about how to continue.

I saw that the [validator for the manifest relies on ajv](https://github.com/mozilla/addons-linter/blob/master/src/schema/validator.js#L21). Sadly I can't find a way to get the line where the error occurs from ajv's response. But looking to the response I think that `dataPath` is the most near reference to where the error occurs.

I added a check for `dataPath` for the manifest in order to add just one error to the collector.
But testing a new build with the patch, the error continues because the `dataPath` is [removed](https://github.com/mozilla/addons-linter/blob/master/src/parsers/manifestjson.js#L65) when come from permissions in the parser.

So I'm not sure why is the `dataPath` removed in this case? This is the desired functionality?

If we can't get the `dataPath`, I think the other alternative to solve this could be get the line where the error occurs, then we just need give the line to the collector since the collector already [handle that case](https://github.com/mozilla/addons-linter/blob/master/tests/test.collector.js#L78). But should do that patch in [`ajv`](https://github.com/epoberezkin/ajv), right?

Do you have any advice on this?