### PR TITLE
Require icons defined in the manifest to exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "babel-istanbul-loader": "0.1.0",
     "babel-loader": "7.0.0",
     "babel-plugin-transform-class-properties": "6.24.1",
-    "babel-preset-env": "1.5.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+    "babel-preset-env": "1.5.1",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
     "chai": "4.0.1",
@@ -63,9 +63,9 @@
     "request": "2.81.0",
     "shelljs": "0.7.7",
     "sinon": "2.3.2",
+    "tar": "3.1.5",
     "webpack": "2.6.1",
-    "webpack-dev-server": "2.4.5",
-    "tar": "3.1.5"
+    "webpack-dev-server": "2.4.5"
   },
   "dependencies": {
     "ajv": "5.0.1",
@@ -81,6 +81,7 @@
     "eslint-plugin-no-unsafe-innerhtml": "1.0.16",
     "esprima": "3.1.3",
     "first-chunk-stream": "2.0.0",
+    "jed": "1.1.1",
     "postcss": "6.0.1",
     "relaxed-json": "1.0.1",
     "semver": "5.3.0",

--- a/src/linter.js
+++ b/src/linter.js
@@ -269,7 +269,7 @@ export default class Linter {
               var manifestParser = new ManifestJSONParser(
                 json,
                 this.collector,
-                {selfHosted: this.config.selfHosted, io: this.io, files},
+                {selfHosted: this.config.selfHosted, io: this.io},
               );
               return manifestParser.getMetadata();
             });

--- a/src/linter.js
+++ b/src/linter.js
@@ -269,7 +269,7 @@ export default class Linter {
               var manifestParser = new ManifestJSONParser(
                 json,
                 this.collector,
-                {selfHosted: this.config.selfHosted, io: this.io},
+                {selfHosted: this.config.selfHosted, io: this.io, files},
               );
               return manifestParser.getMetadata();
             });

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,4 +1,4 @@
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _, singleLineString, sprintf } from 'utils';
 import { MANIFEST_JSON } from 'const';
 
 
@@ -102,6 +102,20 @@ export function manifestPropMissing(property) {
     legacyCode: null,
     message: _(`No "${property}" property found in manifest.json`),
     description: _(`"${property}" is required`),
+    file: MANIFEST_JSON,
+  };
+}
+
+export const MANIFEST_ICON_NOT_FOUND = 'MANIFEST_ICON_NOT_FOUND';
+export function manifestIconMissing(path) {
+  return {
+    code: MANIFEST_ICON_NOT_FOUND,
+    legacyCode: null,
+    message: _(
+      'An icon defined in the manifest could not be found in the package.'),
+    description: sprintf(
+      _('Icon could not be found at "%(path)s".'),
+      {path}),
     file: MANIFEST_JSON,
   };
 }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -114,6 +114,10 @@ export default class ManifestJSONParser extends JSONParser {
       this.collector.addNotice(messages.MANIFEST_UNUSED_UPDATE);
     }
 
+    if (this.parsedJSON.icons) {
+      this.validateIcons();
+    }
+
     if (!this.selfHosted && this.parsedJSON.applications &&
         this.parsedJSON.applications.gecko &&
         this.parsedJSON.applications.gecko.update_url) {
@@ -144,6 +148,17 @@ export default class ManifestJSONParser extends JSONParser {
         }
       }
     }
+  }
+
+  validateIcons() {
+    const { icons } = this.parsedJSON;
+    Object.keys(icons).forEach((size) => {
+      const path = icons[size];
+      if (!this.io.files.hasOwnProperty(path)) {
+        this.collector.addError(messages.manifestIconMissing(path));
+        this.isValid = false;
+      }
+    });
   }
 
   getAddonId() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 import url from 'url';
 
+import jed from 'jed';
+
 import semver from 'semver';
 import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
 
@@ -138,6 +140,11 @@ export function gettext(str) {
   return str;
 }
 
+/*
+ * An sprintf to use with gettext. Imported from Jed for when we have a proper
+ * l10n solution.
+ */
+export const sprintf = jed.sprintf;
 
 /*
  * Check the minimum node version is met

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -477,4 +477,54 @@ describe('ManifestJSONParser', function() {
       });
     }
   });
+
+  describe('icons', () => {
+    it('does not add errors if there are no icons', () => {
+      const linter = new Linter({_: ['bar']});
+      const json = validManifestJSON();
+      delete json.icons;
+      const manifestJSONParser = new ManifestJSONParser(
+        json, linter.collector, {io: {files: []}});
+      assert.ok(manifestJSONParser.isValid);
+    });
+
+    it('does not add errors if the icons are in the package', () => {
+      const addonLinter = new Linter({_: ['bar']});
+      const json = validManifestJSON({
+        icons: {
+          32: 'icons/icon-32.png',
+          64: 'icons/icon-64.png',
+        },
+      });
+      const files = {
+        'icons/icon-32.png': '89<PNG>thisistotallysomebinary',
+        'icons/icon-64.png': '89<PNG>thisistotallysomebinary',
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, {io: {files}});
+      assert.ok(manifestJSONParser.isValid);
+    });
+
+    it('adds an error if the icon is not in the package', () => {
+      const addonLinter = new Linter({_: ['bar']});
+      const json = validManifestJSON({
+        icons: {
+          32: 'icons/icon-32.png',
+          64: 'icons/icon-64.png',
+        },
+      });
+      const files = {
+        'icons/icon-32.png': '89<PNG>thisistotallysomebinary',
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, {io: {files}});
+      assert.notOk(manifestJSONParser.isValid);
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/icon-64.png".',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Icons weren't being validated at all before, so if you defined an icon but it didn't exist Firefox would try to use it. This makes browser action buttons buggy and shows a broken image next to the add-on name.

We should likely validate the size of the icons and possibly check if they're valid, too. I'll file some more issues.

Fixes #1026.