### PR TITLE
Error on small icons and warn about smallish icons

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -352,6 +352,8 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | :white_check_mark: | error | Web extension | Bad permission | manifest.json | | null | MANIFEST_BAD_PERMISSION |
 | :white_check_mark: | warning | Web extension | Unknown permission | manifest.json | | null | MANIFEST_PERMISSIONS |
 | :white_check_mark: | error | Web extension | Block Comments are not allowed in JSON | manifest.json | | null | JSON_BLOCK_COMMENTS |
+| :white_check_mark: | error | Web extension | Icons must be at least 16x16 pixels. | manifest.json | | null | MIN_ICON_SIZE |
+| :white_check_mark: | warning | Web extension | Icons should be at least 48x48 pixels. | manifest.json | | null | RECOMMENDED_ICON_SIZE |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.getSelected | | | null | TABS_GETSELECTED |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.sendRequest | | | null | TABS_SENDREQUEST |
 | :white_check_mark: | warning | Web extension | Deprecated API tabs.getAllInWindow | | | null | TABS_GETALLINWINDOW |

--- a/src/const.js
+++ b/src/const.js
@@ -163,3 +163,7 @@ export const TEMPORARY_APIS = [
   'storage.local',
   'storage.sync',
 ];
+
+// Minimum sizes for icons in pixels.
+export const MIN_ICON_SIZE = 16;
+export const RECOMMENDED_ICON_SIZE = 48;

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,5 +1,7 @@
 import { gettext as _, singleLineString, sprintf } from 'utils';
-import { MANIFEST_JSON } from 'const';
+import * as constants from 'const';
+
+const { MANIFEST_JSON } = constants;
 
 
 export const MANIFEST_FIELD_REQUIRED = {
@@ -119,6 +121,26 @@ export function manifestIconMissing(path) {
     file: MANIFEST_JSON,
   };
 }
+
+export const MIN_ICON_SIZE = {
+  code: 'MIN_ICON_SIZE',
+  legacyCode: null,
+  message: _('The icon defined in the manifest is too small.'),
+  description: sprintf(
+    _('Icons should be at least %(size)sx%(size)s pixels.'),
+    {size: constants.MIN_ICON_SIZE}),
+  file: MANIFEST_JSON,
+};
+
+export const RECOMMENDED_ICON_SIZE = {
+  code: 'RECOMMENDED_ICON_SIZE',
+  legacyCode: null,
+  message: _('Consider adding a larger icon.'),
+  description: sprintf(
+    _('The smallest recommended size for an icon is %(size)sx%(size)s pixels.'),
+    {size: constants.RECOMMENDED_ICON_SIZE}),
+  file: MANIFEST_JSON,
+};
 
 export const PROP_NAME_MISSING = manifestPropMissing('name');
 export const PROP_VERSION_MISSING = manifestPropMissing('version');

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -166,13 +166,11 @@ export default class ManifestJSONParser extends JSONParser {
     });
     const hasIconOfSize = (size) =>
       Object.keys(icons).some((iconSize) => parseInt(iconSize, 10) >= size);
-    const hasMinSizeIcon = hasIconOfSize(MIN_ICON_SIZE);
-    const hasRecommendedSizeIcon = hasIconOfSize(RECOMMENDED_ICON_SIZE);
-    if (!hasMinSizeIcon) {
+    if (!hasIconOfSize(MIN_ICON_SIZE)) {
       this.collector.addError(messages.MIN_ICON_SIZE);
       this.isValid = false;
     }
-    if (!hasRecommendedSizeIcon) {
+    if (!hasIconOfSize(RECOMMENDED_ICON_SIZE)) {
       this.collector.addWarning(messages.RECOMMENDED_ICON_SIZE);
     }
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -4,7 +4,12 @@ import RJSON from 'relaxed-json';
 import validate from 'schema/validator';
 
 import { getConfig } from 'cli';
-import { MANIFEST_JSON, PACKAGE_EXTENSION } from 'const';
+import {
+  MANIFEST_JSON,
+  MIN_ICON_SIZE,
+  PACKAGE_EXTENSION,
+  RECOMMENDED_ICON_SIZE,
+} from 'const';
 import log from 'logger';
 import * as messages from 'messages';
 import JSONParser from 'parsers/json';
@@ -159,6 +164,17 @@ export default class ManifestJSONParser extends JSONParser {
         this.isValid = false;
       }
     });
+    const hasIconOfSize = (size) =>
+      Object.keys(icons).some((iconSize) => parseInt(iconSize, 10) >= size);
+    const hasMinSizeIcon = hasIconOfSize(MIN_ICON_SIZE);
+    const hasRecommendedSizeIcon = hasIconOfSize(RECOMMENDED_ICON_SIZE);
+    if (!hasMinSizeIcon) {
+      this.collector.addError(messages.MIN_ICON_SIZE);
+      this.isValid = false;
+    }
+    if (!hasRecommendedSizeIcon) {
+      this.collector.addWarning(messages.RECOMMENDED_ICON_SIZE);
+    }
   }
 
   getAddonId() {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -526,5 +526,51 @@ describe('ManifestJSONParser', function() {
         description: 'Icon could not be found at "icons/icon-64.png".',
       });
     });
+
+    it('notifies the developer of the recommended icon size', () => {
+      const addonLinter = new Linter({_: ['bar']});
+      const json = validManifestJSON({
+        icons: {
+          10: 'icons/icon-10.png',
+          16: 'icons/icon-16.png',
+        },
+      });
+      const files = {
+        'icons/icon-10.png': '89<PNG>thisistotallysomebinary',
+        'icons/icon-16.png': '89<PNG>thisistotallysomebinary',
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, {io: {files}});
+      assert.ok(manifestJSONParser.isValid);
+      assertHasMatchingError(addonLinter.collector.warnings, {
+        code: messages.RECOMMENDED_ICON_SIZE.code,
+        message: 'Consider adding a larger icon.',
+        description:
+        'The smallest recommended size for an icon is 48x48 pixels.',
+      });
+    });
+
+    it('adds an error if no icons are at least 16px', () => {
+      const addonLinter = new Linter({_: ['bar']});
+      const json = validManifestJSON({
+        icons: {
+          10: 'icons/icon-10.png',
+          15: 'icons/icon-15.png',
+        },
+      });
+      const files = {
+        'icons/icon-10.png': '89<PNG>thisistotallysomebinary',
+        'icons/icon-15.png': '89<PNG>thisistotallysomebinary',
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, {io: {files}});
+      assert.notOk(manifestJSONParser.isValid);
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MIN_ICON_SIZE.code,
+        message:
+          'The icon defined in the manifest is too small.',
+        description: 'Icons should be at least 16x16 pixels.',
+      });
+    });
   });
 });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -571,6 +571,12 @@ describe('ManifestJSONParser', function() {
           'The icon defined in the manifest is too small.',
         description: 'Icons should be at least 16x16 pixels.',
       });
+      assertHasMatchingError(addonLinter.collector.warnings, {
+        code: messages.RECOMMENDED_ICON_SIZE.code,
+        message: 'Consider adding a larger icon.',
+        description:
+        'The smallest recommended size for an icon is 48x48 pixels.',
+      });
     });
   });
 });


### PR DESCRIPTION
For now just validating the keys in the icons object. The UI gets wonky if an icon is less than 16 pixels so we need at least one icon of that size, if icons are provided.

The docs recommend an icon of 48x48 so add a warning if there is an icon specified less than that.

Fixes #1329.