### PR TITLE
Don't validate computed properties for WE APIs

### DIFF
--- a/src/rules/javascript/webextension-api.js
+++ b/src/rules/javascript/webextension-api.js
@@ -1,12 +1,12 @@
 import { isDeprecatedApi, isTemporaryApi } from 'schema/browser-apis';
-import { apiToMessage } from 'utils';
+import { apiToMessage, isBrowserNamespace } from 'utils';
 
 export default {
   create(context) {
     return {
       MemberExpression: function(node) {
         if (node.object.object &&
-            ['chrome', 'browser'].includes(node.object.object.name)) {
+            isBrowserNamespace(node.object.object.name)) {
           let namespace = node.object.property.name;
           let property = node.property.name;
           let api = `${namespace}.${property}`;

--- a/src/rules/javascript/webextension-unsupported-api.js
+++ b/src/rules/javascript/webextension-unsupported-api.js
@@ -5,7 +5,8 @@ export default {
   create(context) {
     return {
       MemberExpression: function(node) {
-        if (node.object.object &&
+        if (!node.computed &&
+            node.object.object &&
             ['chrome', 'browser'].includes(node.object.object.name)) {
           let namespace = node.object.property.name;
           let property = node.property.name;

--- a/src/rules/javascript/webextension-unsupported-api.js
+++ b/src/rules/javascript/webextension-unsupported-api.js
@@ -1,5 +1,6 @@
 import { UNSUPPORTED_API } from 'messages/javascript';
 import { hasBrowserApi } from 'schema/browser-apis';
+import { isBrowserNamespace } from 'utils';
 
 export default {
   create(context) {
@@ -7,7 +8,7 @@ export default {
       MemberExpression: function(node) {
         if (!node.computed &&
             node.object.object &&
-            ['chrome', 'browser'].includes(node.object.object.name)) {
+            isBrowserNamespace(node.object.object.name)) {
           let namespace = node.object.property.name;
           let property = node.property.name;
           let api = `${namespace}.${property}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -231,3 +231,7 @@ export function apiToMessage(string) {
     .toUpperCase()
     .substr(0, 25);
 }
+
+export function isBrowserNamespace(string) {
+  return ['browser', 'chrome'].includes(string);
+}

--- a/tests/rules/javascript/test.unsupported_browser_api.js
+++ b/tests/rules/javascript/test.unsupported_browser_api.js
@@ -55,6 +55,20 @@ describe('unsupported browser APIs', () => {
       });
   });
 
+  it('does not flag if the property is in a variable', () => {
+    const code = `
+      const AREA = 'local';
+      browser.storage[AREA].set('foo', 'FOO');
+    `;
+    const jsScanner = new JavaScriptScanner(code, 'goodcode.js', {
+      addonMetadata: { id: '@supported-api' },
+    });
+    return jsScanner.scan()
+      .then(({linterMessages}) => {
+        expect(linterMessages.length).toEqual(0);
+      });
+  });
+
   // We only test the first two levels for now.
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('flags when 3 levels of nesting is unsupported', () => {

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -353,3 +353,20 @@ describe('utils.isLocalUrl', () => {
     expect(utils.isLocalUrl('bar')).toBeTruthy();
   });
 });
+
+describe('utils.isBrowserNamespace', () => {
+  it('is true for browser', () => {
+    expect(utils.isBrowserNamespace('browser')).toEqual(true);
+  });
+
+  it('is true for chrome', () => {
+    expect(utils.isBrowserNamespace('chrome')).toEqual(true);
+  });
+
+  it('is not true for other strings', () => {
+    expect(utils.isBrowserNamespace('foo')).toEqual(false);
+    expect(utils.isBrowserNamespace('bar')).toEqual(false);
+    expect(utils.isBrowserNamespace('BROWSER')).toEqual(false);
+    expect(utils.isBrowserNamespace('chrOme')).toEqual(false);
+  });
+});


### PR DESCRIPTION
We won't be able to validate that the member expression is correct since it is computed, so don't check it rather than treating the name of the variable as the property.

Fixes #1309.