### PR TITLE
Import schemas 55+ and nightly

### DIFF
--- a/bin/firefox-schema-import
+++ b/bin/firefox-schema-import
@@ -20,7 +20,7 @@ try {
   fs.statSync(arg);
   filePath = arg;
 } catch (e) {
-  if (/^[0-9]+$/.test(arg)) {
+  if (/^[0-9]+$/.test(arg) || arg === 'nightly') {
     version = arg;
   }
 }

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -495,8 +495,13 @@ export function importSchemas(firefoxPath, ourPath, importedPath) {
   writeSchemasToFile(firefoxPath, importedPath, updatedSchemas);
 }
 
-function downloadUrl(version) {
-  return `https://hg.mozilla.org/mozilla-central/archive/FIREFOX_AURORA_${version}_BASE.tar.gz`;
+export function downloadUrl(version) {
+  const base = 'https://hg.mozilla.org/mozilla-central/archive/';
+  if (version === 'nightly') {
+    return `${base}tip.tar.gz`;
+  } else {
+    return `${base}FIREFOX_AURORA_${version}_BASE.tar.gz`;
+  }
 }
 
 inner.isBrowserSchema = (path) => {

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -499,6 +499,8 @@ export function downloadUrl(version) {
   const base = 'https://hg.mozilla.org/mozilla-central/archive/';
   if (version === 'nightly') {
     return `${base}tip.tar.gz`;
+  } else if (parseInt(version, 10) >= 55) {
+    return `${base}FIREFOX_BETA_${version}_BASE.tar.gz`;
   } else {
     return `${base}FIREFOX_AURORA_${version}_BASE.tar.gz`;
   }

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -1398,9 +1398,18 @@ describe('firefox schema import', () => {
   });
 
   describe('downloadUrl', () => {
-    it('uses a version', () => {
+    it('uses aurora if version is < 55', () => {
+      expect(downloadUrl(48)).toMatch(
+        /archive\/FIREFOX_AURORA_48_BASE.tar.gz$/);
       expect(downloadUrl(54)).toMatch(
         /archive\/FIREFOX_AURORA_54_BASE.tar.gz$/);
+    });
+
+    it('uses beta if version is >= 55', () => {
+      expect(downloadUrl(55)).toMatch(
+        /archive\/FIREFOX_BETA_55_BASE.tar.gz$/);
+      expect(downloadUrl(60)).toMatch(
+        /archive\/FIREFOX_BETA_60_BASE.tar.gz$/);
     });
 
     it('uses tip for nightly', () => {

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -8,6 +8,7 @@ import tar from 'tar';
 
 import {
   FLAG_PATTERN_REWRITES,
+  downloadUrl,
   fetchSchemas,
   filterSchemas,
   foldSchemas,
@@ -1393,6 +1394,18 @@ describe('firefox schema import', () => {
     it('handles empty strings', () => {
       const str = '';
       expect(stripTrailingNullByte(str)).toBe(str);
+    });
+  });
+
+  describe('downloadUrl', () => {
+    it('uses a version', () => {
+      expect(downloadUrl(54)).toMatch(
+        /archive\/FIREFOX_AURORA_54_BASE.tar.gz$/);
+    });
+
+    it('uses tip for nightly', () => {
+      expect(downloadUrl('nightly')).toMatch(
+        /archive\/tip.tar.gz$/);
     });
   });
 });


### PR DESCRIPTION
I wanted to verify that the schemas would import once the 55 cut over happens so I ran the import against nightly. This seems like it could be worth keeping around.

Just looked into it some more and importing 55 didn't work because the tag is now called BETA instead of AURORA (of course). So this now supports 55+ and nightly.