### PR TITLE
Import Firefox 55 schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "semver": "5.3.0",
     "source-map-support": "0.4.15",
     "strip-bom-stream": "3.0.0",
-    "url-parse": "1.1.9",
+    "whatwg-url": "5.0.0",
     "xmldom": "0.1.27",
     "yargs": "8.0.1",
     "yauzl": "2.8.0"

--- a/src/schema/imported/bookmarks.json
+++ b/src/schema/imported/bookmarks.json
@@ -533,7 +533,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -545,9 +545,9 @@
     }
   },
   "refs": {
-    "bookmarks#/definitions/Permission": {
+    "bookmarks#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -1,0 +1,104 @@
+{
+  "id": "chrome_settings_overrides",
+  "definitions": {
+    "WebExtensionManifest": {
+      "properties": {
+        "chrome_settings_overrides": {
+          "type": "object",
+          "properties": {
+            "homepage": {
+              "type": "string",
+              "format": "relativeUrl",
+              "preprocess": "localize"
+            },
+            "search_provider": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "preprocess": "localize"
+                },
+                "keyword": {
+                  "type": "string",
+                  "preprocess": "localize"
+                },
+                "search_url": {
+                  "type": "string",
+                  "format": "url",
+                  "pattern": "^https://.*$",
+                  "preprocess": "localize"
+                },
+                "favicon_url": {
+                  "type": "string",
+                  "format": "url",
+                  "preprocess": "localize"
+                },
+                "suggest_url": {
+                  "type": "string",
+                  "format": "url",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "instant_url": {
+                  "type": "string",
+                  "format": "url",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "image_url": {
+                  "type": "string",
+                  "format": "url",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "search_url_post_params": {
+                  "type": "string",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "instant_url_post_params": {
+                  "type": "string",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "image_url_post_params": {
+                  "type": "string",
+                  "preprocess": "localize",
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "alternate_urls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "url",
+                    "preprocess": "localize"
+                  },
+                  "deprecated": "Unsupported on Firefox at this time."
+                },
+                "prepopulated_id": {
+                  "type": "integer",
+                  "deprecated": "Unsupported on Firefox."
+                },
+                "is_default": {
+                  "type": "boolean",
+                  "deprecated": "Unsupported on Firefox at this time."
+                }
+              },
+              "required": [
+                "name",
+                "search_url"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "refs": {
+    "chrome_settings_overrides#/definitions/WebExtensionManifest": {
+      "namespace": "manifest",
+      "type": "WebExtensionManifest"
+    }
+  },
+  "types": {}
+}

--- a/src/schema/imported/cookies.json
+++ b/src/schema/imported/cookies.json
@@ -315,7 +315,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -327,9 +327,9 @@
     }
   },
   "refs": {
-    "cookies#/definitions/Permission": {
+    "cookies#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/devtools.json
+++ b/src/schema/imported/devtools.json
@@ -749,6 +749,10 @@
               "description": "Sources panel."
             }
           ]
+        },
+        "themeName": {
+          "type": "string",
+          "description": "The name of the current devtools theme."
         }
       },
       "functions": [
@@ -848,9 +852,24 @@
           ]
         }
       ],
+      "events": [
+        {
+          "name": "onThemeChanged",
+          "type": "function",
+          "description": "Fired when the devtools theme changes.",
+          "parameters": [
+            {
+              "name": "themeName",
+              "type": "string",
+              "description": "The name of the current devtools theme."
+            }
+          ]
+        }
+      ],
       "required": [
         "elements",
-        "sources"
+        "sources",
+        "themeName"
       ]
     }
   }

--- a/src/schema/imported/extension.json
+++ b/src/schema/imported/extension.json
@@ -72,13 +72,17 @@
                   "$ref": "#/types/ViewType"
                 },
                 {
-                  "description": "The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'notification', 'popup'."
+                  "description": "The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'popup', 'sidebar'."
                 }
               ]
             },
             "windowId": {
               "type": "integer",
               "description": "The window to restrict the search to. If omitted, returns all views."
+            },
+            "tabId": {
+              "type": "integer",
+              "description": "Find a view according to a tab id. If this field is omitted, returns all views."
             }
           }
         }
@@ -226,7 +230,6 @@
       "type": "string",
       "enum": [
         "tab",
-        "notification",
         "popup",
         "sidebar"
       ],

--- a/src/schema/imported/extension_types.json
+++ b/src/schema/imported/extension_types.json
@@ -82,6 +82,7 @@
               "$ref": "#/types/RunAt"
             },
             {
+              "default": "document_idle",
               "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -1,0 +1,144 @@
+{
+  "id": "geckoProfiler",
+  "description": "Exposes the browser's profiler.",
+  "permissions": [
+    "geckoProfiler"
+  ],
+  "functions": [
+    {
+      "name": "start",
+      "type": "function",
+      "description": "Starts the profiler with the specified settings.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "settings",
+          "type": "object",
+          "properties": {
+            "bufferSize": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The size in bytes of the buffer used to store profiling data. A larger value allows capturing a profile that covers a greater amount of time."
+            },
+            "interval": {
+              "type": "number",
+              "description": "Interval in milliseconds between samples of profiling data. A smaller value will increase the detail of the profiles captured."
+            },
+            "features": {
+              "type": "array",
+              "description": "A list of active features for the profiler.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "js",
+                  "stackwalk",
+                  "tasktracer",
+                  "leaf",
+                  "threads"
+                ]
+              }
+            },
+            "threads": {
+              "type": "array",
+              "description": "A list of thread names for which to capture profiles.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "bufferSize",
+            "interval",
+            "features"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "stop",
+      "type": "function",
+      "description": "Stops the profiler and discards any captured profile data.",
+      "async": true,
+      "parameters": []
+    },
+    {
+      "name": "pause",
+      "type": "function",
+      "description": "Pauses the profiler, keeping any profile data that is already written.",
+      "async": true,
+      "parameters": []
+    },
+    {
+      "name": "resume",
+      "type": "function",
+      "description": "Resumes the profiler with the settings that were initially used to start it.",
+      "async": true,
+      "parameters": []
+    },
+    {
+      "name": "getProfile",
+      "type": "function",
+      "description": "Gathers the profile data from the current profiling session.",
+      "async": true,
+      "parameters": []
+    },
+    {
+      "name": "getProfileAsArrayBuffer",
+      "type": "function",
+      "description": "Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that contains a JSON string.",
+      "async": true,
+      "parameters": []
+    },
+    {
+      "name": "getSymbols",
+      "type": "function",
+      "description": "Gets the debug symbols for a particular library.",
+      "async": true,
+      "parameters": [
+        {
+          "type": "string",
+          "name": "debugName",
+          "description": "The name of the library's debug file. For example, 'xul.pdb"
+        },
+        {
+          "type": "string",
+          "name": "breakpadId",
+          "description": "The Breakpad ID of the library"
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "onRunning",
+      "type": "function",
+      "description": "Fires when the profiler starts/stops running.",
+      "parameters": [
+        {
+          "name": "isRunning",
+          "type": "boolean",
+          "description": "Whether the profiler is running or not. Pausing the profiler will not affect this value."
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "Permission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "geckoProfiler"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "geckoProfiler#/definitions/Permission": {
+      "namespace": "manifest",
+      "type": "Permission"
+    }
+  },
+  "types": {}
+}

--- a/src/schema/imported/history.json
+++ b/src/schema/imported/history.json
@@ -277,10 +277,35 @@
           ]
         }
       ]
+    },
+    {
+      "name": "onTitleChanged",
+      "type": "function",
+      "description": "Fired when the title of a URL is changed in the browser history.",
+      "parameters": [
+        {
+          "name": "changed",
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL for which the title has changed"
+            },
+            "title": {
+              "type": "string",
+              "description": "The new title for the URL."
+            }
+          },
+          "required": [
+            "url",
+            "title"
+          ]
+        }
+      ]
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -292,9 +317,9 @@
     }
   },
   "refs": {
-    "history#/definitions/Permission": {
+    "history#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -4,9 +4,8 @@ import alarms from './alarms.json';
 import bookmarks from './bookmarks.json';
 import browserAction from './browser_action.json';
 import browsingData from './browsing_data.json';
+import chrome_settings_overrides from './chrome_settings_overrides.json';
 import commands from './commands.json';
-import contextMenus from './context_menus.json';
-import contextMenusInternal from './context_menus_internal.json';
 import contextualIdentities from './contextual_identities.json';
 import cookies from './cookies.json';
 import devtools from './devtools.json';
@@ -16,16 +15,21 @@ import experiments from './experiments.json';
 import extension from './extension.json';
 import extension_protocol_handlers from './extension_protocol_handlers.json';
 import extensionTypes from './extension_types.json';
+import geckoProfiler from './geckoProfiler.json';
 import history from './history.json';
 import i18n from './i18n.json';
 import identity from './identity.json';
 import idle from './idle.json';
 import management from './management.json';
 import manifest from './manifest.json';
+import menus from './menus.json';
+import menusInternal from './menus_internal.json';
 import notifications from './notifications.json';
 import omnibox from './omnibox.json';
 import pageAction from './page_action.json';
+import permissions from './permissions.json';
 import privacy from './privacy.json';
+import proxy from './proxy.json';
 import runtime from './runtime.json';
 import sessions from './sessions.json';
 import sidebarAction from './sidebar_action.json';
@@ -44,9 +48,8 @@ export default [
   bookmarks,
   browserAction,
   browsingData,
+  chrome_settings_overrides,
   commands,
-  contextMenus,
-  contextMenusInternal,
   contextualIdentities,
   cookies,
   devtools,
@@ -56,16 +59,21 @@ export default [
   extension,
   extension_protocol_handlers,
   extensionTypes,
+  geckoProfiler,
   history,
   i18n,
   identity,
   idle,
   management,
   manifest,
+  menus,
+  menusInternal,
   notifications,
   omnibox,
   pageAction,
+  permissions,
   privacy,
+  proxy,
   runtime,
   sessions,
   sidebarAction,

--- a/src/schema/imported/management.json
+++ b/src/schema/imported/management.json
@@ -8,7 +8,6 @@
       "permissions": [
         "management"
       ],
-      "unsupported": true,
       "description": "Returns a list of information about installed extensions.",
       "async": "callback",
       "parameters": [
@@ -119,6 +118,115 @@
           "type": "function",
           "optional": true,
           "parameters": []
+        }
+      ]
+    },
+    {
+      "name": "setEnabled",
+      "type": "function",
+      "permissions": [
+        "management"
+      ],
+      "description": "Enables or disables the given add-on.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "id",
+          "type": "string",
+          "description": "ID of the add-on to enable/disable."
+        },
+        {
+          "name": "enabled",
+          "type": "boolean",
+          "description": "Whether to enable or disable the add-on."
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "optional": true,
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "onDisabled",
+      "type": "function",
+      "permissions": [
+        "management"
+      ],
+      "description": "Fired when an addon has been disabled.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ExtensionInfo"
+            },
+            {
+              "name": "info"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onEnabled",
+      "type": "function",
+      "permissions": [
+        "management"
+      ],
+      "description": "Fired when an addon has been enabled.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ExtensionInfo"
+            },
+            {
+              "name": "info"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onInstalled",
+      "type": "function",
+      "permissions": [
+        "management"
+      ],
+      "description": "Fired when an addon has been installed.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ExtensionInfo"
+            },
+            {
+              "name": "info"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onUninstalled",
+      "type": "function",
+      "permissions": [
+        "management"
+      ],
+      "description": "Fired when an addon has been uninstalled.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ExtensionInfo"
+            },
+            {
+              "name": "info"
+            }
+          ]
         }
       ]
     }
@@ -288,15 +396,12 @@
       "required": [
         "id",
         "name",
-        "shortName",
         "description",
         "version",
         "mayDisable",
         "enabled",
         "type",
         "optionsUrl",
-        "permissions",
-        "hostPermissions",
         "installType"
       ]
     }

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -160,6 +160,7 @@
             },
             "permissions": {
               "type": "array",
+              "default": [],
               "items": {
                 "anyOf": [
                   {
@@ -173,6 +174,21 @@
                 ]
               },
               "uniqueItems": true
+            },
+            "optional_permissions": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/types/OptionalPermission"
+                  },
+                  {
+                    "type": "string",
+                    "deprecated": "Unknown optional permission ${value}"
+                  }
+                ]
+              },
+              "default": []
             },
             "web_accessible_resources": {
               "type": "array",
@@ -204,6 +220,9 @@
           "$ref": "browserAction#/definitions/WebExtensionManifest"
         },
         {
+          "$ref": "chrome_settings_overrides#/definitions/WebExtensionManifest"
+        },
+        {
           "$ref": "commands#/definitions/WebExtensionManifest"
         },
         {
@@ -232,37 +251,61 @@
         }
       ]
     },
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
           "enum": [
-            "alarms",
             "clipboardRead",
             "clipboardWrite",
             "geolocation",
             "idle",
-            "notifications",
-            "storage"
+            "notifications"
           ]
         },
         {
           "$ref": "#/types/MatchPattern"
         },
         {
-          "$ref": "bookmarks#/definitions/Permission"
+          "$ref": "bookmarks#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "cookies#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "history#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "tabs#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "topSites#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "webNavigation#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "webRequest#/definitions/OptionalPermission"
+        }
+      ]
+    },
+    "Permission": {
+      "anyOf": [
+        {
+          "$ref": "#/types/OptionalPermission"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "alarms",
+            "storage"
+          ]
         },
         {
           "$ref": "browsingData#/definitions/Permission"
         },
         {
-          "$ref": "contextMenus#/definitions/Permission"
-        },
-        {
           "$ref": "contextualIdentities#/definitions/Permission"
-        },
-        {
-          "$ref": "cookies#/definitions/Permission"
         },
         {
           "$ref": "downloads#/definitions/Permission"
@@ -271,7 +314,7 @@
           "$ref": "experiments#/definitions/Permission"
         },
         {
-          "$ref": "history#/definitions/Permission"
+          "$ref": "geckoProfiler#/definitions/Permission"
         },
         {
           "$ref": "identity#/definitions/Permission"
@@ -280,7 +323,13 @@
           "$ref": "management#/definitions/Permission"
         },
         {
+          "$ref": "menus#/definitions/Permission"
+        },
+        {
           "$ref": "privacy#/definitions/Permission"
+        },
+        {
+          "$ref": "proxy#/definitions/Permission"
         },
         {
           "$ref": "runtime#/definitions/Permission"
@@ -289,16 +338,7 @@
           "$ref": "sessions#/definitions/Permission"
         },
         {
-          "$ref": "tabs#/definitions/Permission"
-        },
-        {
-          "$ref": "topSites#/definitions/Permission"
-        },
-        {
-          "$ref": "webNavigation#/definitions/Permission"
-        },
-        {
-          "$ref": "webRequest#/definitions/Permission"
+          "$ref": "theme#/definitions/Permission"
         }
       ]
     },
@@ -357,7 +397,7 @@
         },
         {
           "type": "string",
-          "pattern": "^(https?|file|ftp|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$"
+          "pattern": "^(https?|wss?|file|ftp|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$"
         },
         {
           "type": "string",
@@ -423,6 +463,7 @@
               "$ref": "extensionTypes#/types/RunAt"
             },
             {
+              "default": "document_idle",
               "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]

--- a/src/schema/imported/menus.json
+++ b/src/schema/imported/menus.json
@@ -1,9 +1,9 @@
 {
-  "id": "contextMenus",
-  "description": "Use the <code>browser.contextMenus</code> API to add items to the browser's context menu. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.",
+  "id": "menus",
   "permissions": [
-    "contextMenus"
+    "menus"
   ],
+  "description": "Use the browser.menus API to add items to the browser's menus. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.",
   "properties": {
     "ACTION_MENU_TOP_LEVEL_LIMIT": {
       "value": 6,
@@ -117,6 +117,10 @@
             "enabled": {
               "type": "boolean",
               "description": "Whether this context menu item is enabled or disabled. Defaults to true."
+            },
+            "command": {
+              "type": "string",
+              "description": "Specifies a command to issue for the context click.  Currently supports internal commands _execute_page_action, _execute_browser_action and _execute_sidebar_action."
             }
           }
         },
@@ -125,83 +129,6 @@
           "name": "callback",
           "optional": true,
           "description": "Called when the item has been created in the browser. If there were any problems creating the item, details will be available in $(ref:runtime.lastError).",
-          "parameters": []
-        }
-      ]
-    },
-    {
-      "name": "createInternal",
-      "type": "function",
-      "allowedContexts": [
-        "addon_parent_only"
-      ],
-      "async": "callback",
-      "description": "Identical to contextMenus.create, except: the 'id' field is required and allows an integer, 'onclick' is not allowed, and the method is async (and the return value is not a menu item ID).",
-      "parameters": [
-        {
-          "type": "object",
-          "name": "createProperties",
-          "properties": {
-            "type": {
-              "$ref": "#/types/ItemType"
-            },
-            "id": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "title": {
-              "type": "string"
-            },
-            "checked": {
-              "type": "boolean"
-            },
-            "contexts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/types/ContextType"
-              },
-              "minItems": 1
-            },
-            "parentId": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "documentUrlPatterns": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "targetUrlPatterns": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "enabled": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "id"
-          ]
-        },
-        {
-          "type": "function",
-          "name": "callback",
-          "optional": true,
           "parameters": []
         }
       ]
@@ -251,7 +178,7 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "contextMenusInternal#/types/OnClickData"
+                      "$ref": "menusInternal#/types/OnClickData"
                     },
                     {
                       "name": "info"
@@ -389,6 +316,7 @@
         {
           "type": "string",
           "enum": [
+            "menus",
             "contextMenus"
           ]
         }
@@ -396,7 +324,7 @@
     }
   },
   "refs": {
-    "contextMenus#/definitions/Permission": {
+    "menus#/definitions/Permission": {
       "namespace": "manifest",
       "type": "Permission"
     }

--- a/src/schema/imported/menus_internal.json
+++ b/src/schema/imported/menus_internal.json
@@ -1,5 +1,8 @@
 {
-  "id": "contextMenusInternal",
+  "id": "menusInternal",
+  "allowedContexts": [
+    "addon_parent_only"
+  ],
   "description": "Use the <code>browser.contextMenus</code> API to add items to the browser's context menu. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.",
   "definitions": {},
   "refs": {},

--- a/src/schema/imported/permissions.json
+++ b/src/schema/imported/permissions.json
@@ -1,0 +1,194 @@
+{
+  "id": "permissions",
+  "permissions": [
+    "manifest:optional_permissions"
+  ],
+  "functions": [
+    {
+      "name": "getAll",
+      "type": "function",
+      "async": "callback",
+      "description": "Get a list of all the extension's permissions.",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/AnyPermissions"
+                },
+                {
+                  "name": "permissions"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "contains",
+      "type": "function",
+      "async": "callback",
+      "description": "Check if the extension has the given permissions.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/AnyPermissions"
+            },
+            {
+              "name": "permissions"
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "result",
+              "type": "boolean"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "request",
+      "type": "function",
+      "allowedContexts": [
+        "content"
+      ],
+      "async": "callback",
+      "description": "Request the given permissions.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/Permissions"
+            },
+            {
+              "name": "permissions"
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "granted",
+              "type": "boolean"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "remove",
+      "type": "function",
+      "async": "callback",
+      "description": "Relinquish the given permissions.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/Permissions"
+            },
+            {
+              "name": "permissions"
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "onAdded",
+      "type": "function",
+      "unsupported": true,
+      "description": "Fired when the extension acquires new permissions.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/Permissions"
+            },
+            {
+              "name": "permissions"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onRemoved",
+      "type": "function",
+      "unsupported": true,
+      "description": "Fired when permissions are removed from the extension.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/Permissions"
+            },
+            {
+              "name": "permissions"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {},
+  "refs": {},
+  "types": {
+    "Permissions": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/OptionalPermission"
+          },
+          "default": []
+        },
+        "origins": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/MatchPattern"
+          },
+          "default": []
+        }
+      }
+    },
+    "AnyPermissions": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/Permission"
+          },
+          "default": []
+        },
+        "origins": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/MatchPattern"
+          },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -20,6 +20,16 @@
             }
           ]
         },
+        "peerConnectionEnabled": {
+          "allOf": [
+            {
+              "$ref": "types#/types/Setting"
+            },
+            {
+              "description": "Allow users to enable and disable RTCPeerConnections (aka WebRTC)."
+            }
+          ]
+        },
         "webRTCIPHandlingPolicy": {
           "allOf": [
             {
@@ -33,6 +43,7 @@
       },
       "required": [
         "networkPredictionEnabled",
+        "peerConnectionEnabled",
         "webRTCIPHandlingPolicy"
       ]
     },

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -1,0 +1,54 @@
+{
+  "id": "proxy",
+  "description": "Use the browser.proxy API to register proxy scripts in Firefox. Proxy scripts in Firefox are proxy auto-config files with extra contextual information and support for additional return types.",
+  "permissions": [
+    "proxy"
+  ],
+  "functions": [
+    {
+      "name": "registerProxyScript",
+      "type": "function",
+      "description": "Registers the proxy script for the extension.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "url",
+          "type": "string",
+          "format": "strictRelativeUrl"
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "onProxyError",
+      "type": "function",
+      "description": "Notifies about proxy script errors.",
+      "parameters": [
+        {
+          "name": "error",
+          "type": "object"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "Permission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "proxy"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "proxy#/definitions/Permission": {
+      "namespace": "manifest",
+      "type": "Permission"
+    }
+  },
+  "types": {}
+}

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -2,7 +2,8 @@
   "id": "runtime",
   "allowedContexts": [
     "content",
-    "devtools"
+    "devtools",
+    "proxy"
   ],
   "description": "Use the <code>browser.runtime</code> API to retrieve the background page, return details about the manifest, and listen for and respond to events in the app or extension lifecycle. You can also use this API to convert the relative path of URLs to fully-qualified URLs.",
   "properties": {
@@ -252,7 +253,8 @@
       "allowAmbiguousOptionalArguments": true,
       "allowedContexts": [
         "content",
-        "devtools"
+        "devtools",
+        "proxy"
       ],
       "description": "Sends a single message to event listeners within your extension/app or a different extension/app. Similar to $(ref:runtime.connect) but only sends a single message, with an optional response. If sending to your extension, the $(ref:runtime.onMessage) event will be fired in each page, or $(ref:runtime.onMessageExternal), if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use $(ref:tabs.sendMessage).",
       "async": "responseCallback",
@@ -272,7 +274,12 @@
           "properties": {
             "includeTlsChannelId": {
               "type": "boolean",
+              "unsupported": true,
               "description": "Whether the TLS channel ID will be passed into onMessageExternal for processes that are listening for the connection event."
+            },
+            "toProxyScript": {
+              "type": "boolean",
+              "description": "If true, the message will be directed to the extension's proxy sandbox."
             }
           },
           "optional": true
@@ -420,8 +427,11 @@
             },
             "previousVersion": {
               "type": "string",
-              "unsupported": true,
               "description": "Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'."
+            },
+            "temporary": {
+              "type": "boolean",
+              "description": "Indicates whether the addon is installed as a temporary extension."
             },
             "id": {
               "type": "string",
@@ -430,7 +440,8 @@
             }
           },
           "required": [
-            "reason"
+            "reason",
+            "temporary"
           ]
         }
       ]
@@ -520,7 +531,8 @@
       "type": "function",
       "allowedContexts": [
         "content",
-        "devtools"
+        "devtools",
+        "proxy"
       ],
       "description": "Fired when a message is sent from either an extension process or a content script.",
       "parameters": [

--- a/src/schema/imported/sessions.json
+++ b/src/schema/imported/sessions.json
@@ -6,6 +6,37 @@
   ],
   "functions": [
     {
+      "name": "forgetClosedTab",
+      "type": "function",
+      "description": "Forget a recently closed tab.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "windowId",
+          "type": "integer",
+          "description": "The windowId of the window to which the recently closed tab to be forgotten belongs."
+        },
+        {
+          "name": "sessionId",
+          "type": "string",
+          "description": "The sessionId (closedId) of the recently closed tab to be forgotten."
+        }
+      ]
+    },
+    {
+      "name": "forgetClosedWindow",
+      "type": "function",
+      "description": "Forget a recently closed window.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "sessionId",
+          "type": "string",
+          "description": "The sessionId (closedId) of the recently closed window to be forgotten."
+        }
+      ]
+    },
+    {
       "name": "getRecentlyClosed",
       "type": "function",
       "description": "Gets the list of recently closed tabs and/or windows.",

--- a/src/schema/imported/sidebar_action.json
+++ b/src/schema/imported/sidebar_action.json
@@ -155,6 +155,9 @@
             "default_icon": {
               "$ref": "manifest#/types/IconPath"
             },
+            "browser_style": {
+              "type": "boolean"
+            },
             "default_panel": {
               "type": "string",
               "format": "strictRelativeUrl",

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -1394,7 +1394,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -1407,9 +1407,9 @@
     }
   },
   "refs": {
-    "tabs#/definitions/Permission": {
+    "tabs#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -2,7 +2,7 @@
   "id": "theme",
   "description": "The theme API allows customizing of visual elements of the browser.",
   "permissions": [
-    "manifest:theme"
+    "theme"
   ],
   "functions": [
     {
@@ -26,6 +26,16 @@
     }
   ],
   "definitions": {
+    "Permission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "theme"
+          ]
+        }
+      ]
+    },
     "WebExtensionManifest": {
       "properties": {
         "theme": {
@@ -35,6 +45,10 @@
     }
   },
   "refs": {
+    "theme#/definitions/Permission": {
+      "namespace": "manifest",
+      "type": "Permission"
+    },
     "theme#/definitions/WebExtensionManifest": {
       "namespace": "manifest",
       "type": "WebExtensionManifest"
@@ -47,11 +61,17 @@
         "images": {
           "type": "object",
           "properties": {
+            "additional_backgrounds": {
+              "type": "array",
+              "items": {
+                "$ref": "manifest#/types/ExtensionURL"
+              }
+            },
             "headerURL": {
-              "type": "string"
+              "$ref": "manifest#/types/ExtensionURL"
             },
             "theme_frame": {
-              "type": "string"
+              "$ref": "manifest#/types/ExtensionURL"
             }
           }
         },
@@ -75,6 +95,293 @@
             },
             "textcolor": {
               "type": "string"
+            }
+          }
+        },
+        "icons": {
+          "type": "object",
+          "properties": {
+            "back": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "forward": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "reload": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "stop": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "bookmark_star": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "bookmark_menu": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "downloads": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "home": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "app_menu": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "cut": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "copy": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "paste": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "new_window": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "new_private_window": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "save_page": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "print": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "history": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "full_screen": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "find": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "options": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "addons": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "developer": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "synced_tabs": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "open_file": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "sidebars": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "share_page": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "subscribe": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "text_encoding": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "email_link": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "forget": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "pocket": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "getmsg": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newmsg": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "address": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "reply": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "replyall": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "replylist": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "forwarding": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "delete": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "junk": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "file": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "nextUnread": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "prevUnread": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "mark": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "tag": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "compact": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "archive": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "chat": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "nextMsg": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "prevMsg": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "QFB": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "conversation": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newcard": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newlist": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "editcard": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newim": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "send": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "spelling": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "attach": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "security": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "save": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "quote": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "buddy": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "join_chat": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "chat_accounts": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "calendar": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "tasks": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "synchronize": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newevent": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "newtask": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "editevent": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "today": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "category": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "complete": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "priority": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "saveandclose": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "attendees": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "privacy": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "status": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "freebusy": {
+              "$ref": "manifest#/types/ExtensionURL"
+            },
+            "timezones": {
+              "$ref": "manifest#/types/ExtensionURL"
+            }
+          }
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "additional_backgrounds_alignment": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "bottom",
+                  "center",
+                  "left",
+                  "right",
+                  "top",
+                  "center bottom",
+                  "center center",
+                  "center top",
+                  "left bottom",
+                  "left center",
+                  "left top",
+                  "right bottom",
+                  "right center",
+                  "right top"
+                ]
+              }
+            },
+            "additional_backgrounds_tiling": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "no-repeat",
+                  "repeat",
+                  "repeat-x",
+                  "repeat-y"
+                ]
+              }
             }
           }
         }

--- a/src/schema/imported/top_sites.json
+++ b/src/schema/imported/top_sites.json
@@ -12,6 +12,20 @@
       "async": "callback",
       "parameters": [
         {
+          "type": "object",
+          "name": "options",
+          "properties": {
+            "providers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Which providers to get top sites from. Possible values are \"places\" and \"activityStream\"."
+            }
+          },
+          "optional": true
+        },
+        {
           "name": "callback",
           "type": "function",
           "parameters": [
@@ -28,7 +42,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -40,9 +54,9 @@
     }
   },
   "refs": {
-    "topSites#/definitions/Permission": {
+    "topSites#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/url_overrides.json
+++ b/src/schema/imported/url_overrides.json
@@ -16,16 +16,6 @@
                 }
               ]
             },
-            "home": {
-              "allOf": [
-                {
-                  "$ref": "manifest#/types/ExtensionURL"
-                },
-                {
-                  "preprocess": "localize"
-                }
-              ]
-            },
             "bookmarks": {
               "allOf": [
                 {

--- a/src/schema/imported/web_navigation.json
+++ b/src/schema/imported/web_navigation.json
@@ -684,7 +684,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -696,9 +696,9 @@
     }
   },
   "refs": {
-    "webNavigation#/definitions/Permission": {
+    "webNavigation#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1116,7 +1116,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -1129,9 +1129,9 @@
     }
   },
   "refs": {
-    "webRequest#/definitions/Permission": {
+    "webRequest#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {
@@ -1144,6 +1144,7 @@
         "script",
         "image",
         "object",
+        "object_subrequest",
         "xmlhttprequest",
         "xbl",
         "xslt",

--- a/src/schema/imported/windows.json
+++ b/src/schema/imported/windows.json
@@ -195,6 +195,8 @@
         {
           "type": "object",
           "name": "createData",
+          "optional": true,
+          "default": {},
           "properties": {
             "url": {
               "description": "A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.",
@@ -268,8 +270,7 @@
               "type": "boolean",
               "description": "Allow scripts to close the window."
             }
-          },
-          "optional": true
+          }
         },
         {
           "type": "function",

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -1,73 +1,134 @@
-import { isRelativeURL, isValidVersionString } from 'schema/formats';
+import {
+  isAbsoluteUrl,
+  isAnyUrl,
+  isSecureUrl,
+  isStrictRelativeUrl,
+  isValidVersionString,
+} from 'schema/formats';
 
-describe('formats.isValidVersionString', () => {
+describe('formats', () => {
+  describe('isValidVersionString', () => {
+    var validVersionStrings = [
+      '0.1.12dev-cb31c51',
+      '1.0',
+      '1.0.0beta2',
+      '2.10.2',
+      '3.1.2.4567',
+      '3.1.2.65535',
+      '4.1pre1',
+      '4.1.1pre2',
+      '4.1.1dev-abcdef1',
+      '4.1.1.2pre3',
+    ];
 
-  var validVersionStrings = [
-    '0.1.12dev-cb31c51',
-    '1.0',
-    '1.0.0beta2',
-    '2.10.2',
-    '3.1.2.4567',
-    '3.1.2.65535',
-    '4.1pre1',
-    '4.1.1pre2',
-    '4.1.1dev-abcdef1',
-    '4.1.1.2pre3',
-  ];
-
-  var invalidVersionStrings = [
-    2,
-    '123e5',
-    '1.',
-    '.',
-    'a.b.c.d',
-    '1.2.2.2.4',
-    '01',
-    '1.000000',
-    '2.99999',
-    '3.65536',
-    '1.0.0-beta2',
-  ];
+    var invalidVersionStrings = [
+      2,
+      '123e5',
+      '1.',
+      '.',
+      'a.b.c.d',
+      '1.2.2.2.4',
+      '01',
+      '1.000000',
+      '2.99999',
+      '3.65536',
+      '1.0.0-beta2',
+    ];
 
 
-  for (let validVersionString of validVersionStrings) {
-    it(`should find ${validVersionString} to be valid`, () => {
-      expect(isValidVersionString(validVersionString)).toBeTruthy();
+    for (let validVersionString of validVersionStrings) {
+      it(`should find ${validVersionString} to be valid`, () => {
+        expect(isValidVersionString(validVersionString)).toEqual(true);
+      });
+    }
+
+    for (let invalidVersionString of invalidVersionStrings) {
+      it(`should find ${invalidVersionString} to be invalid`, () => {
+        expect(isValidVersionString(invalidVersionString)).toEqual(false);
+      });
+    }
+  });
+
+  describe('URL formats', () => {
+    it('domain', () => {
+      const value = 'https://example.com';
+
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isAbsoluteUrl(value)).toEqual(true);
+      expect(isSecureUrl(value)).toEqual(true);
+
+      expect(isStrictRelativeUrl(value)).toEqual(false);
     });
-  }
 
-  for (let invalidVersionString of invalidVersionStrings) {
-    it(`should find ${invalidVersionString} to be invalid`, () => {
-      expect(isValidVersionString(invalidVersionString)).toBeFalsy();
+    it('full URL', () => {
+      const value = 'https://example.com/something?like=true&this=that';
+
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isAbsoluteUrl(value)).toEqual(true);
+      expect(isSecureUrl(value)).toEqual(true);
+
+      expect(isStrictRelativeUrl(value)).toEqual(false);
     });
-  }
-});
 
-describe('formats.isRelativeURL', () => {
+    it('invalid URLs', () => {
+      const value = 'https://foo bar.com';
 
-  const notRelativeURLs = [
-    'http://foo',
-    'Https://foo.com/bar',
-    'moz-extension://wat',
-    '//foo',
-  ];
-
-  for (let notRelativeURL of notRelativeURLs) {
-    it(`${notRelativeURL} should be invalid`, () => {
-      expect(isRelativeURL(notRelativeURL)).toBeFalsy();
+      expect(isAnyUrl(value)).toEqual(false);
+      expect(isAbsoluteUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
+      expect(isStrictRelativeUrl(value)).toEqual(false);
     });
-  }
 
-  const relativeURLs = [
-    'something.png',
-    'js/jquery.js',
-    '/js/jquery.js',
-  ];
+    it('path only', () => {
+      const value = '/some/path';
 
-  for (let relativeURL of relativeURLs) {
-    it(`${relativeURL} should be valid`, () => {
-      expect(isRelativeURL(relativeURL)).toBeTruthy();
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isStrictRelativeUrl(value)).toEqual(true);
+
+      expect(isAbsoluteUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
     });
-  }
 
+    it('protocol relative', () => {
+      const value = '//example.net/foo/bar';
+
+      expect(isAnyUrl(value)).toEqual(true);
+
+      expect(isAbsoluteUrl(value)).toEqual(false);
+      expect(isStrictRelativeUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
+    });
+
+    it('ftp: scheme', () => {
+      const value = 'ftp://example.org/favicon.ico';
+
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isAbsoluteUrl(value)).toEqual(true);
+
+      expect(isStrictRelativeUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
+    });
+
+    it('http: scheme', () => {
+      const value = 'http://example.net/foo/bar';
+
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isAbsoluteUrl(value)).toEqual(true);
+
+      expect(isStrictRelativeUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
+    });
+
+    it('cannot be fooled with hand-crafted URLs', () => {
+      // The isRelativeUrl function shouldn't have a magic string in it. If it
+      // does, this function should use a URL with said magic string.
+      const value = 'asdoiasjdpoaisjd://haha/this/is/absolute';
+
+      expect(isAnyUrl(value)).toEqual(true);
+      expect(isAbsoluteUrl(value)).toEqual(true);
+
+      expect(isStrictRelativeUrl(value)).toEqual(false);
+      expect(isSecureUrl(value)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
This includes an update to how URL formats are handled. Firefox has an interesting naming convention for these and when checking the new `chrome_settings_override` options I noticed our checks weren't quite the same.

The `url-parse` library will always parse whatever you give it as a valid URL even if it is obviously not valid (like `['lol', 10, 'you', 'CANNOT', 9.912, 'beserious']`), so I switched us to `whatwg-url` since Firefox is using the `URL` class that it polyfills.

Fixes #1345.