### PR TITLE
Setup sinon sandbox, convert first batch of tests to use sinon.assert api

### DIFF
--- a/tests/io/test.base.js
+++ b/tests/io/test.base.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { IOBase } from 'io/base';
 import { unexpectedSuccess } from '../helpers';
 

--- a/tests/io/test.crx.js
+++ b/tests/io/test.crx.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { ZipFile } from 'yauzl';
 
 import { Crx } from 'io';

--- a/tests/io/test.directory.js
+++ b/tests/io/test.directory.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { EventEmitter } from 'events';
 
 import { Directory } from 'io';

--- a/tests/io/test.xpi.js
+++ b/tests/io/test.xpi.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { Readable } from 'stream';
 import { EventEmitter } from 'events';
 

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -1,6 +1,5 @@
 import Linter from 'linter';
 import JSONParser from 'parsers/json';
-import sinon from 'sinon';
 
 import * as messages from 'messages';
 import { singleLineString } from 'utils';

--- a/tests/scanners/test.base.js
+++ b/tests/scanners/test.base.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import BaseScanner from 'scanners/base';
 import { ignorePrivateFunctions } from 'utils';
 import { metadataPassCheck, validMetadata } from '../helpers';

--- a/tests/scanners/test.css.js
+++ b/tests/scanners/test.css.js
@@ -45,7 +45,7 @@ describe('CSSScanner', () => {
 
     return scanner.scan(fakeRules)
       .then(({linterMessages}) => {
-        expect(fakeRules.metadataPassCheck.called).toBeTruthy();
+        sinon.assert.calledTwice(fakeRules.metadataPassCheck);
         expect(linterMessages.length).toEqual(0);
       });
   });

--- a/tests/scanners/test.css.js
+++ b/tests/scanners/test.css.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import * as messages from 'messages';
 import { VALIDATION_WARNING } from 'const';
 import CSSScanner from 'scanners/css';

--- a/tests/scanners/test.html.js
+++ b/tests/scanners/test.html.js
@@ -1,5 +1,4 @@
 import cheerio from 'cheerio';
-import sinon from 'sinon';
 
 import { VALIDATION_WARNING } from 'const';
 import { getRuleFiles, validHTML } from '../helpers';

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -1,5 +1,4 @@
 import ESLint from 'eslint';
-import sinon from 'sinon';
 
 import {
   DEPRECATED_APIS, ESLINT_ERROR, ESLINT_RULE_MAPPING, TEMPORARY_APIS,

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -228,7 +228,7 @@ describe('JavaScript Scanner', function() {
       _ruleMapping: fakeESLintMapping,
       _messages: fakeMessages,
     }).then(() => {
-      expect(fakeRules['metadata-not-passed'].create.called).toBeTruthy();
+      sinon.assert.calledOnce(fakeRules['metadata-not-passed'].create);
     });
   });
 

--- a/tests/scanners/test.json.js
+++ b/tests/scanners/test.json.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import Linter from 'linter';
 import JSONScanner from 'scanners/json';
 

--- a/tests/scanners/test.rdf.js
+++ b/tests/scanners/test.rdf.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 
-import sinon from 'sinon';
 import XMLDom from 'xmldom';
 
 import { RDF_DEFAULT_NAMESPACE } from 'const';

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -28,8 +28,6 @@ import {
 const { unlinkSync } = fs;
 
 describe('firefox schema import', () => {
-  let sandbox;
-
   function createDir(dirPath) {
     fs.mkdirSync(dirPath);
   }
@@ -39,14 +37,6 @@ describe('firefox schema import', () => {
       (file) => unlinkSync(path.join(dirPath, file)));
     fs.rmdirSync(dirPath);
   }
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   describe('rewriteOptionalToRequired', () => {
     it('handles non-objects ', () => {
@@ -426,11 +416,11 @@ describe('firefox schema import', () => {
 
   describe('loadSchema', () => {
     it('normalizes and rewrites the schema', () => {
-      sandbox
+      sinon
         .stub(inner, 'normalizeSchema')
         .withArgs({ the: 'schema' })
         .returns({ id: 'Foo', normalized: true });
-      sandbox
+      sinon
         .stub(inner, 'rewriteObject')
         .withArgs({ normalized: true })
         .returns({ rewritten: true });
@@ -440,11 +430,11 @@ describe('firefox schema import', () => {
     });
 
     it('adds a $ref for the manifest namespace', () => {
-      sandbox
+      sinon
         .stub(inner, 'normalizeSchema')
         .withArgs({ id: 'manifest' })
         .returns({ id: 'manifest', normalized: true });
-      sandbox
+      sinon
         .stub(inner, 'rewriteObject')
         .withArgs({ normalized: true })
         .returns({ rewritten: true });
@@ -460,17 +450,17 @@ describe('firefox schema import', () => {
     it('loads each schema and delegates to helpers', () => {
       const firstSchema = [{ id: 'manifest' }];
       const secondSchema = [{ id: 'manifest' }, { id: 'cookies' }];
-      const loadSchema = sandbox.stub(inner, 'loadSchema');
+      const loadSchema = sinon.stub(inner, 'loadSchema');
       loadSchema.withArgs(firstSchema).returns({ id: 'manifest', schema: 1 });
       loadSchema.withArgs(secondSchema).returns({ id: 'cookies', schema: 2 });
-      sandbox
+      sinon
         .stub(inner, 'mergeSchemas')
         .withArgs({
           manifest: [{ file: 'one', schema: { id: 'manifest', schema: 1 } }],
           cookies: [{ file: 'two', schema: { id: 'cookies', schema: 2 } }],
         })
         .returns({ mergeSchemas: 'done' });
-      sandbox
+      sinon
         .stub(inner, 'mapExtendToRef')
         .withArgs({ mergeSchemas: 'done' })
         .returns({ mapExtendToRef: 'done' });
@@ -1058,13 +1048,13 @@ describe('firefox schema import', () => {
       const cwd = 'tests/schema';
       const schemaPath = 'firefox';
       const tarball = tar.create({ cwd, gzip: true }, [schemaPath]);
-      sandbox
+      sinon
         .stub(inner, 'isBrowserSchema')
         .withArgs('firefox/cookies.json')
         .returns(false)
         .withArgs('firefox/manifest.json')
         .returns(true);
-      sandbox
+      sinon
         .stub(request, 'get')
         .withArgs('https://hg.mozilla.org/mozilla-central/archive/FIREFOX_AURORA_54_BASE.tar.gz')
         .returns(tarball);
@@ -1079,17 +1069,17 @@ describe('firefox schema import', () => {
       const cwd = 'tests/schema';
       const schemaPath = 'firefox';
       const tarball = tar.create({ cwd, gzip: true }, [schemaPath]);
-      sandbox
+      sinon
         .stub(inner, 'isBrowserSchema')
         .withArgs('firefox/cookies.json')
         .returns(false)
         .withArgs('firefox/manifest.json')
         .returns(true);
-      sandbox
+      sinon
         .stub(fs, 'createReadStream')
         .withArgs('mozilla-central.tgz')
         .returns(tarball);
-      sandbox
+      sinon
         .stub(fs, 'unlinkSync')
         .withArgs('mozilla-central.tgz')
         .returns(undefined);
@@ -1104,7 +1094,7 @@ describe('firefox schema import', () => {
       const cwd = 'tests/schema';
       const schemaPath = 'firefox';
       const tarball = tar.create({ cwd, gzip: true }, [schemaPath]);
-      sandbox
+      sinon
         .stub(fs, 'createReadStream')
         .withArgs('mozilla-central.tgz')
         .returns(tarball);
@@ -1113,7 +1103,7 @@ describe('firefox schema import', () => {
           this.emit('error', new Error('stream error'));
         },
       });
-      sandbox
+      sinon
         .stub(tar, 'Parse')
         .returns(extractedStream);
       expect(fs.readdirSync(outputPath)).toEqual([]);
@@ -1131,7 +1121,7 @@ describe('firefox schema import', () => {
           this.emit('error', new Error('stream error'));
         },
       });
-      sandbox
+      sinon
         .stub(request, 'get')
         .withArgs('https://hg.mozilla.org/mozilla-central/archive/FIREFOX_AURORA_54_BASE.tar.gz')
         .returns(mockStream);
@@ -1150,7 +1140,7 @@ describe('firefox schema import', () => {
       const cwd = 'tests/schema';
       const schemaPath = 'firefox';
       const tarball = tar.create({ cwd, gzip: true }, [schemaPath]);
-      sandbox
+      sinon
         .stub(request, 'get')
         .withArgs('https://hg.mozilla.org/mozilla-central/archive/FIREFOX_AURORA_54_BASE.tar.gz')
         .returns(tarball);
@@ -1162,7 +1152,7 @@ describe('firefox schema import', () => {
           this.emit('error', new Error('stream error'));
         },
       });
-      sandbox
+      sinon
         .stub(fs, 'createWriteStream')
         .withArgs('tmp/FIREFOX_AURORA_54_BASE.tar.gz')
         .returns(mockStream);

--- a/tests/schema/test.firefox-schemas-import.js
+++ b/tests/schema/test.firefox-schemas-import.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import stream from 'stream';
-import sinon from 'sinon';
 
 import request from 'request';
 import tar from 'tar';

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,13 @@
+import sinon from 'sinon';
+
+// Setup sinon global to be a sandbox which is restored
+// after each test.
+const realSinon = sinon;
+global.sinon = realSinon.sandbox.create();
+global.sinon.createStubInstance = realSinon.createStubInstance;
+global.sinon.format = realSinon.format;
+global.sinon.assert = realSinon.assert;
+
+afterEach(() => {
+  global.sinon.restore();
+});

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { getConfig, terminalWidth } from 'cli';
 
 

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import { default as Collector } from 'collector';
 import { fakeMessageData } from './helpers';
 

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -5,8 +5,6 @@ import Linter from 'linter';
 import * as constants from 'const';
 import * as messages from 'messages';
 
-import sinon from 'sinon';
-
 import ManifestJSONParser from 'parsers/manifestjson';
 import BinaryScanner from 'scanners/binary';
 import CSSScanner from 'scanners/css';

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -99,7 +99,7 @@ describe('Linter', function() {
       .catch((err) => {
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toContain('Path "bar" is not a file or directory');
-        expect(isFileSpy.callCount).toEqual(1);
+        sinon.assert.calledOnce(isFileSpy);
       });
   });
 
@@ -160,10 +160,11 @@ describe('Linter', function() {
 
     return addonLinter.scan()
       .then(() => {
-        expect(getFileSpy.calledWith('components/main.js')).toBeTruthy();
-        expect(getFileSpy.calledWith('components/secondary.js')).toBeTruthy();
-        expect(getFileSpy.calledWith('install.rdf')).toBeTruthy();
-        expect(getFileSpy.calledWith('prefs.html')).toBeTruthy();
+        sinon.assert.callOrder(
+          getFileSpy.withArgs('components/main.js'),
+          getFileSpy.withArgs('components/secondary.js'),
+          getFileSpy.withArgs('install.rdf'),
+          getFileSpy.withArgs('prefs.html'));
       });
   });
 
@@ -179,9 +180,9 @@ describe('Linter', function() {
 
     return addonLinter.scan()
       .then(() => {
-        expect(getFileSpy.calledWith('index.js')).toBeFalsy();
-        expect(getFileSpy.calledWith('manifest.json')).toBeTruthy();
-        expect(getFileSpy.calledWith('subdir/test.js')).toBeTruthy();
+        sinon.assert.callOrder(
+          getFileSpy.withArgs('manifest.json'),
+          getFileSpy.withArgs('subdir/test.js'));
       });
   });
 
@@ -216,10 +217,10 @@ describe('Linter', function() {
 
     return addonLinter.scan()
       .then(() => {
-        expect(getFileSpy.calledWith('index.js')).toBeFalsy();
-        expect(getFileSpy.calledWith('manifest.json')).toBeTruthy();
-        expect(getFileSpy.calledWith('subdir/test.js')).toBeTruthy();
-        expect(getFileSpy.calledWith('subdir/test2.js')).toBeTruthy();
+        sinon.assert.callOrder(
+          getFileSpy.withArgs('manifest.json'),
+          getFileSpy.withArgs('subdir/test.js'),
+          getFileSpy.withArgs('subdir/test2.js'));
       });
   });
 
@@ -303,9 +304,10 @@ describe('Linter', function() {
     return addonLinter.scan({_Xpi: FakeXpi})
       .then(unexpectedSuccess)
       .catch(() => {
-        expect(addonLinter.collector.addError.calledWith(
-          messages.DUPLICATE_XPI_ENTRY)).toBeTruthy();
-        expect(addonLinter.print.called).toBeTruthy();
+        sinon.assert.calledWith(
+          addonLinter.collector.addError,
+          messages.DUPLICATE_XPI_ENTRY);
+        sinon.assert.calledOnce(addonLinter.print);
       });
   });
 
@@ -376,7 +378,7 @@ describe('Linter.handleError()', function() {
       error: sinon.stub(),
     };
     addonLinter.handleError(fakeError, fakeConsole);
-    expect(fakeConsole.error.calledWith(fakeError.stack)).toBeTruthy();
+    sinon.assert.calledWith(fakeConsole.error, fakeError.stack);
   });
 
   it('should show colorized error ', () => {
@@ -389,8 +391,8 @@ describe('Linter.handleError()', function() {
       error: sinon.stub(),
     };
     addonLinter.handleError(fakeError, fakeConsole);
-    expect(fakeConsole.error.called).toBeTruthy();
-    expect(addonLinter.chalk.red.calledWith('Errol the error')).toBeTruthy();
+    sinon.assert.calledOnce(fakeConsole.error);
+    sinon.assert.calledWith(addonLinter.chalk.red, 'Errol the error');
   });
 });
 
@@ -405,8 +407,8 @@ describe('Linter.print()', function() {
       log: sinon.stub(),
     };
     addonLinter.print(fakeConsole);
-    expect(addonLinter.toJSON.called).toBeTruthy();
-    expect(fakeConsole.log.called).toBeTruthy();
+    sinon.assert.calledOnce(addonLinter.toJSON);
+    sinon.assert.calledOnce(fakeConsole.log);
   });
 
   it('should print as json when config.output is text', () => {
@@ -417,21 +419,22 @@ describe('Linter.print()', function() {
       log: sinon.stub(),
     };
     addonLinter.print(fakeConsole);
-    expect(addonLinter.textOutput.called).toBeTruthy();
-    expect(fakeConsole.log.called).toBeTruthy();
+    sinon.assert.calledOnce(addonLinter.textOutput);
+    sinon.assert.calledOnce(fakeConsole.log);
   });
 
   it('should not print anything if config.output is none', () => {
     var addonLinter = new Linter({_: ['foo']});
     addonLinter.textOutput = sinon.stub();
+    addonLinter.toJSON = sinon.stub();
     addonLinter.config.output = 'none';
     var fakeConsole = {
       log: sinon.stub(),
     };
     addonLinter.print(fakeConsole);
-    expect(!addonLinter.textOutput.called).toBeTruthy();
-    expect(!addonLinter.toJSON.called).toBeTruthy();
-    expect(!fakeConsole.log.called).toBeTruthy();
+    sinon.assert.notCalled(addonLinter.textOutput);
+    sinon.assert.notCalled(addonLinter.toJSON);
+    sinon.assert.notCalled(fakeConsole.log);
   });
 
   it('should print scanFile if any', () => {
@@ -448,8 +451,8 @@ describe('Linter.print()', function() {
       log: sinon.spy((...args) => logData += `${args.join(' ')}\n`),
     };
     addonLinter.print(fakeConsole);
-    expect(textOutputSpy.called).toBeTruthy();
-    expect(fakeConsole.log.called).toBeTruthy();
+    sinon.assert.calledOnce(textOutputSpy);
+    sinon.assert.calledOnce(fakeConsole.log);
     expect(logData).toContain('Selected files: testfile.js');
   });
 
@@ -464,9 +467,7 @@ describe('Linter.toJSON()', function() {
       stringify: sinon.stub(),
     };
     addonLinter.toJSON({pretty: true, _JSON: fakeJSON});
-    expect(
-      fakeJSON.stringify.calledWith(sinon.match.any, null, 4)
-    ).toBeTruthy();
+    sinon.assert.calledWith(fakeJSON.stringify, sinon.match.any, null, 4);
   });
 
   it('should output metadata when config.output is json', () => {
@@ -488,8 +489,8 @@ describe('Linter.toJSON()', function() {
       stringify: sinon.stub(),
     };
     addonLinter.toJSON({pretty: false, _JSON: fakeJSON});
-    expect(fakeJSON.stringify.getCall(0).args[1]).toEqual(undefined);
-    expect(fakeJSON.stringify.getCall(0).args[2]).toEqual(undefined);
+    sinon.assert.calledWith(
+      fakeJSON.stringify, sinon.match.any);
   });
 
   it('should provide JSON via toJSON()', () => {
@@ -664,14 +665,15 @@ describe('Linter.getAddonMetadata()', function() {
 
     return getMetadata()
       .then(() => {
-        expect(fakeLog.debug.called).toBe(false);
+        sinon.assert.notCalled(fakeLog.debug);
         expect(typeof addonLinter.addonMetadata).toBe('object');
       })
       .then(() => getMetadata())
       .then(() => {
-        expect(fakeLog.debug.called).toBe(true);
-        expect(fakeLog.debug.calledWith(
-          'Metadata already set; returning cached metadata.')).toBe(true);
+        sinon.assert.calledOnce(fakeLog.debug);
+        sinon.assert.calledWith(
+          fakeLog.debug,
+          'Metadata already set; returning cached metadata.');
       });
   });
 
@@ -711,7 +713,7 @@ describe('Linter.getAddonMetadata()', function() {
       ManifestJSONParser: FakeManifestParser,
     })
       .then(() => {
-        expect(FakeManifestParser.called).toEqual(true);
+        sinon.assert.calledOnce(FakeManifestParser);
         expect(FakeManifestParser.firstCall.args[2].selfHosted).toEqual(true);
       });
   });
@@ -866,13 +868,13 @@ describe('Linter.extractMetadata()', function() {
     return addonLinter.extractMetadata({_Directory: FakeDirectory})
       .then(() => {
         expect(addonLinter.io).toBeInstanceOf(FakeDirectory);
-        expect(setScanFileCallback.called).toEqual(true);
+        sinon.assert.calledOnce(setScanFileCallback);
         expect(typeof setScanFileCallback.firstCall.args[0]).toEqual(
           'function'
         );
-        expect(shouldScanFile.called).toEqual(false);
+        sinon.assert.notCalled(shouldScanFile);
         setScanFileCallback.firstCall.args[0]();
-        expect(shouldScanFile.called).toEqual(true);
+        sinon.assert.calledOnce(shouldScanFile);
       });
   });
 
@@ -938,7 +940,7 @@ describe('Linter.extractMetadata()', function() {
       _Xpi: FakeXpi,
       _console: fakeConsole,
     }).then(() => {
-      expect(addonLinter.toJSON.called).toBeTruthy();
+      sinon.assert.calledOnce(addonLinter.toJSON);
       var inputObject = addonLinter.toJSON.firstCall.args[0].input;
       expect(inputObject.hasErrors).toEqual(true);
       expect(inputObject.metadata).toEqual(fakeMetadata);
@@ -966,7 +968,7 @@ describe('Linter.extractMetadata()', function() {
 
     return addonLinter.extractMetadata({_console: fakeConsole})
       .then((metadata) => {
-        expect(markEmptyFilesSpy.called).toBeTruthy();
+        sinon.assert.calledOnce(markEmptyFilesSpy);
         expect(metadata.emptyFiles).toEqual(['data/empty.js']);
       });
   });
@@ -990,7 +992,7 @@ describe('Linter.extractMetadata()', function() {
 
     return addonLinter.extractMetadata({_console: fakeConsole})
       .then((metadata) => {
-        expect(markJSFilesSpy.called).toBeTruthy();
+        sinon.assert.calledOnce(markJSFilesSpy);
         expect(Object.keys(metadata.jsLibs).length).toEqual(1);
         expect(metadata.jsLibs).toEqual({
           'data/jquery-3.2.1.min.js': 'jquery.3.2.1.jquery.min.js',
@@ -1034,7 +1036,7 @@ describe('Linter.extractMetadata()', function() {
       _console: fakeConsole,
       _Xpi: FakeXpi,
     }).then((metadata) => {
-      expect(markJSFilesSpy.called).toBeTruthy();
+      sinon.assert.calledOnce(markJSFilesSpy);
       expect(Object.keys(metadata.jsLibs).length).toEqual(1);
       expect(metadata.jsLibs).toEqual({
         'my/nested/library/path/j.js': 'jquery.3.2.1.jquery.min.js',
@@ -1102,7 +1104,7 @@ describe('Linter.extractMetadata()', function() {
 
     return addonLinter.extractMetadata({_console: fakeConsole})
       .then((metadata) => {
-        expect(markBannedSpy.called).toBeTruthy();
+        sinon.assert.calledOnce(markBannedSpy);
         expect(Object.keys(metadata.jsLibs).length).toEqual(2);
         expect(metadata.jsLibs).toEqual({
           'data/angular-1.2.28.min.js': 'angularjs.1.2.28.angular.min.js',
@@ -1167,7 +1169,7 @@ describe('Linter.extractMetadata()', function() {
       _Directory: FakeDirectory,
       _console: fakeConsole,
     }).then((metadata) => {
-      expect(markEmptyFilesSpy.called).toBeTruthy();
+      sinon.assert.calledOnce(markEmptyFilesSpy);
       expect(metadata.emptyFiles).toEqual(['whatever']);
     });
   });
@@ -1189,7 +1191,7 @@ describe('Linter.extractMetadata()', function() {
     }
     return addonLinter.scan({_Xpi: FakeXpi, _console: fakeConsole})
       .catch((err) => {
-        expect(markEmptyFilesSpy.called).toBeTruthy();
+        sinon.assert.calledOnce(markEmptyFilesSpy);
         expect(err.message).toEqual('No size available for whatever');
       });
   });
@@ -1294,8 +1296,8 @@ describe('Linter.run()', function() {
 
     return addonLinter.run({_Xpi: FakeXpi, _console: fakeConsole})
       .then(() => {
-        expect(addonLinter.toJSON.called).toBeTruthy();
-        expect(addonLinter.markSpecialFiles.called).toBeTruthy();
+        sinon.assert.calledOnce(addonLinter.toJSON);
+        sinon.assert.calledOnce(addonLinter.markSpecialFiles);
         expect(addonLinter.toJSON.firstCall.args[0].input).toEqual(
           {hasErrors: false, metadata: fakeMetadata}
         );
@@ -1310,7 +1312,7 @@ describe('Linter.run()', function() {
 
     return addonLinter.run({_console: fakeConsole})
       .then(() => {
-        expect(addonLinter.scan.called).toBeTruthy();
+        sinon.assert.calledOnce(addonLinter.scan);
       });
   });
 
@@ -1335,7 +1337,7 @@ describe('Linter.run()', function() {
     return addonLinter.run({_Xpi: FakeXpi, _console: fakeConsole})
       .then(unexpectedSuccess)
       .catch((err) => {
-        expect(addonLinter.handleError.called).toBeTruthy();
+        sinon.assert.calledOnce(addonLinter.handleError);
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toContain('metadata explosion');
       });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -1,5 +1,4 @@
 import * as utils from 'utils';
-import sinon from 'sinon';
 import { unexpectedSuccess } from './helpers';
 
 


### PR DESCRIPTION
Only converts the first batch of tests to use sinon.assert api and sandbox, more will follow later. I'd like to avoid unnecessary huge PRs for reviews.

Fixes #1368