### PR TITLE
Expose total size of "code" files in metadata.

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -283,6 +283,7 @@ export default class Linter {
       })
       .then((addonMetadata) => {
         this.addonMetadata = addonMetadata;
+        this.addonMetadata.totalScannedFileSize = 0;
 
         // The type must be explicitly defined. This behaviour differs the
         // historical approach by the amo-validator.
@@ -373,6 +374,10 @@ export default class Linter {
             linterMessages: [filesizeError],
             scannedFiles: [filename],
           });
+        }
+
+        if (this.addonMetadata) {
+          this.addonMetadata.totalScannedFileSize += fileSize;
         }
 
         let scanner = new ScannerClass(fileData, filename, {

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -1256,22 +1256,22 @@ describe('Linter.extractMetadata()', function() {
   // scanned.
 
   // Archive:  tests/fixtures/empty-with-library.zip
-  // Length   Date       Time   Name
-  // -------  ---------- -----  ----
-  //   593    2015-11-28 19:46  bootstrap.js -> scanned
-  //     0    2017-05-09 15:09  data/
-  //  6148    2017-05-09 15:09  data/.DS_Store -> scanned (binary)
-  //     0    2017-05-09 15:09  __MACOSX/
-  //     0    2017-05-09 15:09  __MACOSX/data/
-  //   120    2017-05-09 15:09  __MACOSX/data/._.DS_Store -> scanned
-  //  1420    2015-11-28 19:46  data/change-text.js -> scanned
-  //     0    2015-11-28 19:46  data/empty.js -> scanned
-  // 86659    2017-03-20 20:01  data/jquery-3.2.1.min.js
-  //   195    2017-03-20 20:01  __MACOSX/data/._jquery-3.2.1.min.js -> scanned
-  //   421    2015-11-28 19:46  index.js -> scanned
-  //   218    2016-06-30 16:10  manifest.json -> scanned
-  //   277    2015-11-28 19:46  package.json -> scanned
-  //    29    2015-11-28 19:46  README.md
+  // Skipped Length   Date       Time   Name
+  // ------- -------  ---------- -----  ----
+  //           593    2015-11-28 19:46  bootstrap.js
+  //   X         0    2017-05-09 15:09  data/
+  //          6148    2017-05-09 15:09  data/.DS_Store
+  //   X         0    2017-05-09 15:09  __MACOSX/
+  //   X         0    2017-05-09 15:09  __MACOSX/data/
+  //           120    2017-05-09 15:09  __MACOSX/data/._.DS_Store
+  //          1420    2015-11-28 19:46  data/change-text.js
+  //             0    2015-11-28 19:46  data/empty.js
+  //   X     86659    2017-03-20 20:01  data/jquery-3.2.1.min.js
+  //           195    2017-03-20 20:01  __MACOSX/data/._jquery-3.2.1.min.js
+  //           421    2015-11-28 19:46  index.js
+  //           218    2016-06-30 16:10  manifest.json
+  //           277    2015-11-28 19:46  package.json
+  //   X        29    2015-11-28 19:46  README.md
   // -------                   -------
   //  96080                    14 files
 

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import chalk from 'chalk';
 
 import Linter from 'linter';
 
@@ -1253,6 +1252,41 @@ describe('Linter.extractMetadata()', function() {
       });
   });
 
+  // Total zip size is 96080 but only a handful of files are actually
+  // scanned.
+
+  // Archive:  tests/fixtures/empty-with-library.zip
+  // Length   Date       Time   Name
+  // -------  ---------- -----  ----
+  //   593    2015-11-28 19:46  bootstrap.js -> scanned
+  //     0    2017-05-09 15:09  data/
+  //  6148    2017-05-09 15:09  data/.DS_Store -> scanned (binary)
+  //     0    2017-05-09 15:09  __MACOSX/
+  //     0    2017-05-09 15:09  __MACOSX/data/
+  //   120    2017-05-09 15:09  __MACOSX/data/._.DS_Store -> scanned
+  //  1420    2015-11-28 19:46  data/change-text.js -> scanned
+  //     0    2015-11-28 19:46  data/empty.js -> scanned
+  // 86659    2017-03-20 20:01  data/jquery-3.2.1.min.js
+  //   195    2017-03-20 20:01  __MACOSX/data/._jquery-3.2.1.min.js -> scanned
+  //   421    2015-11-28 19:46  index.js -> scanned
+  //   218    2016-06-30 16:10  manifest.json -> scanned
+  //   277    2015-11-28 19:46  package.json -> scanned
+  //    29    2015-11-28 19:46  README.md
+  // -------                   -------
+  //  96080                    14 files
+
+  it('should collect total size of all scanned files', () => {
+    var addonLinter = new Linter({
+      _: ['tests/fixtures/empty-with-library.zip'],
+    });
+
+    addonLinter.print = sinon.stub();
+
+    return addonLinter.scan({_console: fakeConsole})
+      .then(() => {
+        expect(addonLinter.output.metadata.totalScannedFileSize).toEqual(9421);
+      });
+  });
 });
 
 describe('Linter.run()', function() {


### PR DESCRIPTION
There is now a new `totalScannedFileSize` property in `addonMetadata`.

Fixes #1304
