### PR TITLE
Parse and validate CSP rules more properly.

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -169,7 +169,7 @@ export const TEMPORARY_APIS = [
 // See https://mzl.la/2vwqbGU for more details and allowed options.
 export const CSP_KEYWORD_RE = new RegExp([
   '(self|none|strict-dynamic|',
-  'unsafe-inline|unsafe-eval|unsafe-hashed-attributes)',
+  'unsafe-inline|unsafe-hashed-attributes)',
   // Only match these keywords, anything else is forbidden
   '(?!.)',
   '|(sha(256|384|512)-|nonce-)',

--- a/src/const.js
+++ b/src/const.js
@@ -168,7 +168,8 @@ export const TEMPORARY_APIS = [
 // `script-src`. Used in manifest.json parser for validation.
 // See https://mzl.la/2vwqbGU for more details and allowed options.
 export const CSP_KEYWORD_RE = new RegExp([
-  '(self|none|strict-dynamic|unsafe-hashed-attributes)',
+  '(self|none|unsafe-inline|unsafe-eval|strict-dynamic|',
+  'unsafe-hashed-attributes)',
   // Only match these keywords, anything else is forbidden
   '(?!.)',
   '|(sha(256|384|512)-|nonce-)',

--- a/src/const.js
+++ b/src/const.js
@@ -163,3 +163,14 @@ export const TEMPORARY_APIS = [
   'storage.local',
   'storage.sync',
 ];
+
+// All valid CSP keywords that are options to keys like `default-src` and
+// `script-src`. Used in manifest.json parser for validation.
+// See https://mzl.la/2vwqbGU for more details and allowed options.
+export const CSP_KEYWORD_RE = new RegExp([
+  '(self|none|strict-dynamic|',
+  'unsafe-inline|unsafe-eval|unsafe-hashed-attributes)',
+  // Only match these keywords, anything else is forbidden
+  '(?!.)',
+  '|(sha(256|384|512)-|nonce-)',
+].join(''));

--- a/src/const.js
+++ b/src/const.js
@@ -168,8 +168,7 @@ export const TEMPORARY_APIS = [
 // `script-src`. Used in manifest.json parser for validation.
 // See https://mzl.la/2vwqbGU for more details and allowed options.
 export const CSP_KEYWORD_RE = new RegExp([
-  '(self|none|strict-dynamic|',
-  'unsafe-inline|unsafe-hashed-attributes)',
+  '(self|none|strict-dynamic|unsafe-hashed-attributes)',
   // Only match these keywords, anything else is forbidden
   '(?!.)',
   '|(sha(256|384|512)-|nonce-)',

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -48,7 +48,7 @@ export const MANIFEST_CSP = {
   // it depends on it to detect add-ons with a custom content security policy.
   code: 'MANIFEST_CSP',
   legacyCode: null,
-  message: _('"content_security_policy" is defined in the manifest.json'),
+  message: _('"content_security_policy" is not strict enough in manifest.json'),
   description: _('A custom content_security_policy needs additional review.'),
   file: MANIFEST_CSP,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -48,7 +48,8 @@ export const MANIFEST_CSP = {
   // it depends on it to detect add-ons with a custom content security policy.
   code: 'MANIFEST_CSP',
   legacyCode: null,
-  message: _('"content_security_policy" is not strict enough in manifest.json'),
+  message: _(singleLineString`
+    "content_security_policy" allows remote code execution in manifest.json`),
   description: _('A custom content_security_policy needs additional review.'),
   file: MANIFEST_CSP,
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -175,7 +175,7 @@ export default class ManifestJSONParser extends JSONParser {
 
     // Not sure about FTP here but CSP spec treats ws/wss as
     // equivalent to http/https.
-    const validProtocols = ['ftp:', 'http:', 'https:', 'ws:', 'wss'];
+    const validProtocols = ['ftp:', 'http:', 'https:', 'ws:', 'wss:'];
 
     for (const candidate of ['script-src', 'default-src']) {
       if (directives.hasOwnProperty(candidate)) {
@@ -197,25 +197,15 @@ export default class ManifestJSONParser extends JSONParser {
             // so we have to match this a bit wider. This will work since
             // 'self' and others are required to include the quotes (afair)
             // which results in an invalid URL.
+
             if (validProtocols.includes(url.protocol)) {
               this.collector.addWarning(messages.MANIFEST_CSP);
-              continue;
             }
           } catch (e) {
-            if (value.trim().includes('*')) {
-              this.collector.addWarning(messages.MANIFEST_CSP);
-
-              continue;
-            }
-
-            // values like 'ws:' or 'http:' are valid values but aren't correct
-            // URLs so the try/catch above will fail and we'll have to string
-            // manually.
-            if (validProtocols.includes(value.trim())) {
+            if (value.includes('*')) {
               this.collector.addWarning(messages.MANIFEST_CSP);
             }
           }
-
         }
       }
     }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -190,14 +190,17 @@ export default class ManifestJSONParser extends JSONParser {
           }
 
           try {
-            URL(value);
+            let url = new URL(value);
 
             // warn as soon we match a valid URL being whitelisted.
             // A user doesn't have to prepend a protocol/scheme to a host
             // so we have to match this a bit wider. This will work since
             // 'self' and others are required to include the quotes (afair)
             // which results in an invalid URL.
-            this.collector.addWarning(messages.MANIFEST_CSP);
+            if (validProtocols.includes(url.protocol)) {
+              this.collector.addWarning(messages.MANIFEST_CSP);
+              continue;
+            }
           } catch (e) {
             if (value.trim().includes('*')) {
               this.collector.addWarning(messages.MANIFEST_CSP);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -185,15 +185,14 @@ export default class ManifestJSONParser extends JSONParser {
         for (const value of values) {
           try {
             url = new URL(value);
+
+            if (validProtocols.includes(url.protocol)) {
+              this.collector.addWarning(messages.MANIFEST_CSP);
+            }
           } catch (e) {
             if (value.trim().includes('*')) {
               this.collector.addWarning(messages.MANIFEST_CSP);
             }
-            continue;
-          }
-
-          if (validProtocols.includes(url.protocol)) {
-            this.collector.addWarning(messages.MANIFEST_CSP);
           }
         }
       }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -177,7 +177,7 @@ export default class ManifestJSONParser extends JSONParser {
     // equivalent to http/https.
     const validProtocols = ['ftp:', 'http:', 'https:', 'ws:', 'wss:'];
 
-    for (const candidate of ['script-src', 'default-src']) {
+    for (const candidate of ['script-src', 'default-src', 'worker-src']) {
       if (directives.hasOwnProperty(candidate)) {
         const values = directives[candidate];
 

--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -84,6 +84,7 @@ function isRelativeUrl(value) {
     // URL is invalid.
     return false;
   }
+
   // If the URL is relative, then the protocol will stay the same, but host
   // could change due to protocol relative. Also check that the URL isn't
   // absolute, since then it is using the dummy protocol we defined.

--- a/src/utils.js
+++ b/src/utils.js
@@ -235,3 +235,30 @@ export function apiToMessage(string) {
 export function isBrowserNamespace(string) {
   return ['browser', 'chrome'].includes(string);
 }
+
+
+export function parseCspPolicy(policy) {
+  if (!policy) {
+    return {};
+  }
+
+  policy = policy.toLowerCase();
+
+  let parsedPolicy = {};
+  let directives = policy.split(';');
+
+  for (let directive of directives) {
+    directive = directive.trim();
+    const tokens = directive.split(/\s+/);
+
+    const name = tokens[0];
+
+    if (!name) {
+      continue;
+    }
+
+    parsedPolicy[name] = tokens.slice(1, tokens.length);
+  }
+
+  return parsedPolicy;
+}

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -345,8 +345,6 @@ describe('ManifestJSONParser', function() {
     });
 
     it('should warn on invalid values according to Add-On Policies', () => {
-      var addonLinter = new Linter({_: ['bar']});
-
       const invalidValues = [
         'default-src *',
         'default-src moz-extension: *',
@@ -355,8 +353,6 @@ describe('ManifestJSONParser', function() {
         'default-src http:',
         'default-src https:',
         'default-src ftp:',
-        'default-src web.example.com:443',
-        'default-src web.example.com:80',
         'default-src http://cdn.example.com/my.js',
         'default-src https://cdn.example.com/my.js',
 
@@ -367,8 +363,6 @@ describe('ManifestJSONParser', function() {
         'script-src http:',
         'script-src https:',
         'script-src ftp:',
-        'script-src web.example.com:443',
-        'script-src web.example.com:80',
         'script-src http://cdn.example.com/my.js',
         'script-src https://cdn.example.com/my.js',
 
@@ -377,23 +371,23 @@ describe('ManifestJSONParser', function() {
       ];
 
       for (const invalidValue of invalidValues) {
-        var json = validManifestJSON({
+        const addonLinter = new Linter({_: ['bar']});
+
+        const json = validManifestJSON({
           content_security_policy: invalidValue,
         });
 
-        var manifestJSONParser = new ManifestJSONParser(
+        const manifestJSONParser = new ManifestJSONParser(
           json, addonLinter.collector);
 
         expect(manifestJSONParser.isValid).toEqual(true);
-        var warnings = addonLinter.collector.warnings;
+        const warnings = addonLinter.collector.warnings;
         expect(warnings[0].code).toEqual(messages.MANIFEST_CSP.code);
         expect(warnings[0].message).toContain('content_security_policy');
       }
     });
 
     it('should not warn on valid values according to Add-On Policies', () => {
-      var addonLinter = new Linter({_: ['bar']});
-
       const validValues = [
         'default-src moz-extension:',
         'script-src moz-extension:',
@@ -404,6 +398,7 @@ describe('ManifestJSONParser', function() {
         'default-src web.example.com:80',
         'script-src web.example.com',
         'script-src web.example.com:80',
+        'default-src web.example.com:443',
 
         // Mix with other directives, properly match anyway.
         'script-src \'self\'; object-src \'self\'',
@@ -414,11 +409,13 @@ describe('ManifestJSONParser', function() {
       ];
 
       for (const validValue of validValues) {
-        var json = validManifestJSON({
+        const addonLinter = new Linter({_: ['bar']});
+
+        const json = validManifestJSON({
           content_security_policy: validValue,
         });
 
-        var manifestJSONParser = new ManifestJSONParser(
+        const manifestJSONParser = new ManifestJSONParser(
           json, addonLinter.collector);
 
         expect(manifestJSONParser.isValid).toEqual(true);

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -4,6 +4,7 @@ import ManifestJSONParser from 'parsers/manifestjson';
 import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import * as messages from 'messages';
 import { assertHasMatchingError, validManifestJSON } from '../helpers';
+import { singleLineString } from 'utils';
 
 describe('ManifestJSONParser', function() {
 
@@ -385,8 +386,9 @@ describe('ManifestJSONParser', function() {
 
       const validValues = [
         'default-src moz-extension:',
-
         'script-src moz-extension:',
+        'script-src \'self\'; object-src \'self\'',
+        'script-src \'self\' \'unsafe-eval\'; object-src \'self\'',
       ];
 
       for (const validValue of validValues) {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -347,7 +347,7 @@ describe('ManifestJSONParser', function() {
     it('should warn on invalid values according to Add-On Policies', () => {
       const invalidValues = [
         'default-src *',
-        'default-src moz-extension: *',
+        'default-src moz-extension: *', // mixed with * invalid
         'default-src ws:',
         'default-src wss:',
         'default-src http:',
@@ -360,7 +360,7 @@ describe('ManifestJSONParser', function() {
         'default-src web.example.com:443',
 
         'script-src *',
-        'script-src moz-extension: *',
+        'script-src moz-extension: *', // mixed with * invalid
         'script-src ws:',
         'script-src wss:',
         'script-src http:',
@@ -372,8 +372,24 @@ describe('ManifestJSONParser', function() {
         'script-src web.example.com:80',
         'script-src web.example.com:443',
 
+        'worker-src *',
+        'worker-src moz-extension: *', // mixed with * invalid
+        'worker-src ws:',
+        'worker-src wss:',
+        'worker-src http:',
+        'worker-src https:',
+        'worker-src ftp:',
+        'worker-src http://cdn.example.com/my.js',
+        'worker-src https://cdn.example.com/my.js',
+        'worker-src web.example.com',
+        'worker-src web.example.com:80',
+        'worker-src web.example.com:443',
+
         // Properly match mixed with other directives
-        'script-src https: \'unsafe-eval\'; object-src \'self\'',
+        "script-src https: 'unsafe-eval'; object-src 'self'",
+
+        // unsafe-eval is forbidden too.
+        "script-src 'self' 'unsafe-eval';",
       ];
 
       for (const invalidValue of invalidValues) {
@@ -400,7 +416,8 @@ describe('ManifestJSONParser', function() {
 
         // Mix with other directives, properly match anyway.
         "script-src 'self'; object-src 'self'",
-        "script-src 'self' 'unsafe-eval'; object-src 'self'",
+        "script-src 'unsafe-inline'; object-src 'self'",
+
 
         // We only walk through default-src and script-src
         'style-src http://by.cdn.com/',

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -415,10 +415,9 @@ describe('ManifestJSONParser', function() {
         'default-src moz-extension:',
         'script-src moz-extension:',
 
-        // Mix with other directives, properly match anyway.
+        // Mix with other directives
         "script-src 'self'; object-src 'self'",
-        "script-src 'unsafe-inline'; object-src 'self'",
-
+        "script-src 'none'; object-src 'self'",
 
         // We only walk through default-src and script-src
         'style-src http://by.cdn.com/',

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -358,6 +358,8 @@ describe('ManifestJSONParser', function() {
         'default-src web.example.com:443',
         'default-src web.example.com:80',
         'default-src web.example.com',
+        'default-src http://cdn.example.com/my.js',
+        'default-src https://cdn.example.com/my.js',
 
         'script-src *',
         'script-src moz-extension: *',
@@ -369,6 +371,8 @@ describe('ManifestJSONParser', function() {
         'script-src web.example.com:443',
         'script-src web.example.com:80',
         'script-src web.example.com',
+        'script-src http://cdn.example.com/my.js',
+        'script-src https://cdn.example.com/my.js',
       ];
 
       for (const invalidValue of invalidValues) {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -355,6 +355,9 @@ describe('ManifestJSONParser', function() {
         'default-src ftp:',
         'default-src http://cdn.example.com/my.js',
         'default-src https://cdn.example.com/my.js',
+        'default-src web.example.com',
+        'default-src web.example.com:80',
+        'default-src web.example.com:443',
 
         'script-src *',
         'script-src moz-extension: *',
@@ -365,6 +368,9 @@ describe('ManifestJSONParser', function() {
         'script-src ftp:',
         'script-src http://cdn.example.com/my.js',
         'script-src https://cdn.example.com/my.js',
+        'script-src web.example.com',
+        'script-src web.example.com:80',
+        'script-src web.example.com:443',
 
         // Properly match mixed with other directives
         'script-src https: \'unsafe-eval\'; object-src \'self\'',
@@ -391,14 +397,6 @@ describe('ManifestJSONParser', function() {
       const validValues = [
         'default-src moz-extension:',
         'script-src moz-extension:',
-
-        // We currently can't properly parse these without producing
-        // loads of false-positives.
-        'default-src web.example.com',
-        'default-src web.example.com:80',
-        'script-src web.example.com',
-        'script-src web.example.com:80',
-        'default-src web.example.com:443',
 
         // Mix with other directives, properly match anyway.
         'script-src \'self\'; object-src \'self\'',

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -357,7 +357,6 @@ describe('ManifestJSONParser', function() {
         'default-src ftp:',
         'default-src web.example.com:443',
         'default-src web.example.com:80',
-        'default-src web.example.com',
         'default-src http://cdn.example.com/my.js',
         'default-src https://cdn.example.com/my.js',
 
@@ -370,7 +369,6 @@ describe('ManifestJSONParser', function() {
         'script-src ftp:',
         'script-src web.example.com:443',
         'script-src web.example.com:80',
-        'script-src web.example.com',
         'script-src http://cdn.example.com/my.js',
         'script-src https://cdn.example.com/my.js',
 
@@ -399,6 +397,13 @@ describe('ManifestJSONParser', function() {
       const validValues = [
         'default-src moz-extension:',
         'script-src moz-extension:',
+
+        // We currently can't properly parse these without producing
+        // loads of false-positives.
+        'default-src web.example.com',
+        'default-src web.example.com:80',
+        'script-src web.example.com',
+        'script-src web.example.com:80',
 
         // Mix with other directives, properly match anyway.
         'script-src \'self\'; object-src \'self\'',

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -389,6 +389,9 @@ describe('ManifestJSONParser', function() {
         'script-src moz-extension:',
         'script-src \'self\'; object-src \'self\'',
         'script-src \'self\' \'unsafe-eval\'; object-src \'self\'',
+
+        // We only walk through default-src and script-src
+        'style-src http://by.cdn.com/',
       ];
 
       for (const validValue of validValues) {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -388,8 +388,9 @@ describe('ManifestJSONParser', function() {
         // Properly match mixed with other directives
         "script-src https: 'unsafe-eval'; object-src 'self'",
 
-        // unsafe-eval is forbidden too.
+        // unsafe-eval and unsafe-inline are forbidden too.
         "script-src 'self' 'unsafe-eval';",
+        "script-src 'self' 'unsafe-inline';",
       ];
 
       for (const invalidValue of invalidValues) {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -387,10 +387,6 @@ describe('ManifestJSONParser', function() {
 
         // Properly match mixed with other directives
         "script-src https: 'unsafe-eval'; object-src 'self'",
-
-        // unsafe-eval and unsafe-inline are forbidden too.
-        "script-src 'self' 'unsafe-eval';",
-        "script-src 'self' 'unsafe-inline';",
       ];
 
       for (const invalidValue of invalidValues) {
@@ -421,6 +417,11 @@ describe('ManifestJSONParser', function() {
 
         // We only walk through default-src and script-src
         'style-src http://by.cdn.com/',
+
+        // unsafe-eval and unsafe-inline are not forbidden yet and
+        // should be reviewed by a human.
+        "script-src 'self' 'unsafe-eval';",
+        "script-src 'self' 'unsafe-inline';",
       ];
 
       for (const validValue of validValues) {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -373,6 +373,9 @@ describe('ManifestJSONParser', function() {
         'script-src web.example.com',
         'script-src http://cdn.example.com/my.js',
         'script-src https://cdn.example.com/my.js',
+
+        // Properly match mixed with other directives
+        'script-src https: \'unsafe-eval\'; object-src \'self\'',
       ];
 
       for (const invalidValue of invalidValues) {
@@ -396,6 +399,8 @@ describe('ManifestJSONParser', function() {
       const validValues = [
         'default-src moz-extension:',
         'script-src moz-extension:',
+
+        // Mix with other directives, properly match anyway.
         'script-src \'self\'; object-src \'self\'',
         'script-src \'self\' \'unsafe-eval\'; object-src \'self\'',
 

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -332,7 +332,7 @@ describe('ManifestJSONParser', function() {
 
   describe('content security policy', function() {
 
-    it('dont warn on CSP not including default-src or script-src)', () => {
+    it('should warn on rules allowing remote code execution', () => {
       var addonLinter = new Linter({_: ['bar']});
       var json = validManifestJSON({
         content_security_policy: 'foo',
@@ -399,8 +399,8 @@ describe('ManifestJSONParser', function() {
         'script-src moz-extension:',
 
         // Mix with other directives, properly match anyway.
-        'script-src \'self\'; object-src \'self\'',
-        'script-src \'self\' \'unsafe-eval\'; object-src \'self\'',
+        "script-src 'self'; object-src 'self'",
+        "script-src 'self' 'unsafe-eval'; object-src 'self'",
 
         // We only walk through default-src and script-src
         'style-src http://by.cdn.com/',

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -4,7 +4,6 @@ import ManifestJSONParser from 'parsers/manifestjson';
 import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import * as messages from 'messages';
 import { assertHasMatchingError, validManifestJSON } from '../helpers';
-import { singleLineString } from 'utils';
 
 describe('ManifestJSONParser', function() {
 
@@ -356,6 +355,9 @@ describe('ManifestJSONParser', function() {
         'default-src http:',
         'default-src https:',
         'default-src ftp:',
+        'default-src web.example.com:443',
+        'default-src web.example.com:80',
+        'default-src web.example.com',
 
         'script-src *',
         'script-src moz-extension: *',
@@ -364,6 +366,9 @@ describe('ManifestJSONParser', function() {
         'script-src http:',
         'script-src https:',
         'script-src ftp:',
+        'script-src web.example.com:443',
+        'script-src web.example.com:80',
+        'script-src web.example.com',
       ];
 
       for (const invalidValue of invalidValues) {

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -354,6 +354,7 @@ describe('utils.isLocalUrl', () => {
   });
 });
 
+
 describe('utils.isBrowserNamespace', () => {
   it('is true for browser', () => {
     expect(utils.isBrowserNamespace('browser')).toEqual(true);
@@ -368,5 +369,36 @@ describe('utils.isBrowserNamespace', () => {
     expect(utils.isBrowserNamespace('bar')).toEqual(false);
     expect(utils.isBrowserNamespace('BROWSER')).toEqual(false);
     expect(utils.isBrowserNamespace('chrOme')).toEqual(false);
+  });
+});
+
+
+describe('utils.parseCspPolicy', () => {
+
+  it('should allow empty policies', () => {
+    expect(utils.parseCspPolicy('')).toEqual({});
+    expect(utils.parseCspPolicy(null)).toEqual({});
+    expect(utils.parseCspPolicy(undefined)).toEqual({});
+  });
+
+  it('should parse directives correctly', () => {
+    const rawPolicy = utils.singleLineString`
+      default-src 'none'; script-src 'self'; connect-src https: 'self';
+      img-src 'self'; style-src 'self';
+    `;
+
+    const parsedPolicy = utils.parseCspPolicy(rawPolicy);
+
+    expect(parsedPolicy['script-src']).toEqual('\'self\'');
+    expect(parsedPolicy['default-src']).toEqual('\'none\'');
+    expect(parsedPolicy['connect-src']).toEqual('https: \'self\'');
+    expect(parsedPolicy['img-src']).toEqual('\'self\'');
+    expect(parsedPolicy['style-src']).toEqual('\'self\'' );
+  });
+
+  it('should handle upper case correctly', () => {
+    const parsedPolicy = utils.parseCspPolicy('DEFAULT-SRC \'NoNe\'');
+
+    expect(parsedPolicy['default-src']).toEqual('\'none\'');
   });
 });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -389,16 +389,16 @@ describe('utils.parseCspPolicy', () => {
 
     const parsedPolicy = utils.parseCspPolicy(rawPolicy);
 
-    expect(parsedPolicy['script-src']).toEqual('\'self\'');
-    expect(parsedPolicy['default-src']).toEqual('\'none\'');
-    expect(parsedPolicy['connect-src']).toEqual('https: \'self\'');
-    expect(parsedPolicy['img-src']).toEqual('\'self\'');
-    expect(parsedPolicy['style-src']).toEqual('\'self\'' );
+    expect(parsedPolicy['script-src']).toEqual(['\'self\'']);
+    expect(parsedPolicy['default-src']).toEqual(['\'none\'']);
+    expect(parsedPolicy['connect-src']).toEqual(['https:', '\'self\'']);
+    expect(parsedPolicy['img-src']).toEqual(['\'self\'']);
+    expect(parsedPolicy['style-src']).toEqual(['\'self\'' ]);
   });
 
   it('should handle upper case correctly', () => {
     const parsedPolicy = utils.parseCspPolicy('DEFAULT-SRC \'NoNe\'');
 
-    expect(parsedPolicy['default-src']).toEqual('\'none\'');
+    expect(parsedPolicy['default-src']).toEqual(['\'none\'']);
   });
 });


### PR DESCRIPTION
Fixes #1298 

cc @wagnerand for potential messaging updates.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#Sources mentions 

```
         

<scheme-source>
    A schema such as 'http:' or 'https:'. The colon is required, single quotes shouldn't be used. You can also specify data schemas (not recommended).

        data: Allows data: URIs to be used as a content source. This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
        mediastream: Allows mediastream: URIs to be used as a content source.
        blob: Allows blob: URIs to be used as a content source.
        filesystem: Allows filesystem: URIs to be used as a content source.
```

Do we want to disallow `data:` URIs too?