### PR TITLE
Replace singleLineString with common-tags equivalent

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ajv": "5.2.2",
     "chalk": "2.1.0",
     "cheerio": "1.0.0-rc.2",
+    "common-tags": "1.4.0",
     "columnify": "1.5.4",
     "crx-parser": "0.1.2",
     "dispensary": "0.10.13",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import argv from 'yargs';
 
 import log from 'logger';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 import { version } from '../package';
 
@@ -19,7 +19,7 @@ export function terminalWidth(_process = process) {
 
 export function getConfig({ useCLI = true } = {}) {
   if (useCLI === false) {
-    log.error(singleLineString`Config requested from CLI, but not in CLI mode.
+    log.error(oneLine`Config requested from CLI, but not in CLI mode.
       Please supply a config instead of relying on the getConfig() call.`);
     throw new Error('Cannot request config from CLI in library mode');
   }

--- a/src/io/base.js
+++ b/src/io/base.js
@@ -1,6 +1,6 @@
 import { FLAGGED_FILE_MAGIC_NUMBERS_LENGTH, MAX_FILE_SIZE_MB } from 'const';
 
-import { singleLineString } from '../utils';
+import { oneLine } from 'common-tags';
 
 
 /*
@@ -39,7 +39,7 @@ export class IOBase {
         return this.getChunkAsBuffer(path, FLAGGED_FILE_MAGIC_NUMBERS_LENGTH);
 
       default:
-        throw new Error(singleLineString`Unexpected fileStreamType
+        throw new Error(oneLine`Unexpected fileStreamType
           value "${fileStreamType}" should be one of "string",
           "stream" or "chunk"`);
     }

--- a/src/io/directory.js
+++ b/src/io/directory.js
@@ -3,12 +3,11 @@ import { createReadStream } from 'fs';
 
 import firstChunkStream from 'first-chunk-stream';
 import stripBomStream from 'strip-bom-stream';
+import { oneLine } from 'common-tags';
 
 import { IOBase } from 'io/base';
 import { walkPromise } from 'io/utils';
 import log from 'logger';
-
-import { singleLineString } from '../utils';
 
 
 export class Directory extends IOBase {
@@ -16,7 +15,7 @@ export class Directory extends IOBase {
     // If we have already processed this directory and have data
     // on this instance return that.
     if (Object.keys(this.files).length) {
-      log.info(singleLineString`Files already exist for directory
+      log.info(oneLine`Files already exist for directory
                "${this.path}" returning cached data`);
       return Promise.resolve(this.files);
     }

--- a/src/io/xpi.js
+++ b/src/io/xpi.js
@@ -4,7 +4,7 @@ import firstChunkStream from 'first-chunk-stream';
 
 import { IOBase } from 'io/base';
 import log from 'logger';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 /*
@@ -43,7 +43,7 @@ export class Xpi extends IOBase {
     }
     if (this.entries.includes(entry.fileName)) {
       log.info('Found duplicate file entry: "%s" in package', entry.fileName);
-      reject(new Error(singleLineString`DuplicateZipEntry: Entry
+      reject(new Error(oneLine`DuplicateZipEntry: Entry
         "${entry.fileName}" has already been seen`));
     }
     this.entries.push(entry.fileName);

--- a/src/linter.js
+++ b/src/linter.js
@@ -9,7 +9,7 @@ import { terminalWidth } from 'cli';
 import * as constants from 'const';
 import { BANNED_LIBRARIES, UNADVISED_LIBRARIES } from 'libraries';
 import * as messages from 'messages';
-import { checkMinNodeVersion, gettext as _, singleLineString } from 'utils';
+import { checkMinNodeVersion, gettext as _ } from 'utils';
 import log from 'logger';
 import Collector from 'collector';
 import InstallRdfParser from 'parsers/installrdf';
@@ -23,6 +23,7 @@ import JSONScanner from 'scanners/json';
 import RDFScanner from 'scanners/rdf';
 import { Crx, Directory, Xpi } from 'io';
 import badwords from 'badwords.json';
+import { oneLine } from 'common-tags';
 
 
 export default class Linter {
@@ -65,7 +66,7 @@ export default class Linter {
       case constants.VALIDATION_NOTICE:
         return this.chalk.blue;
       default:
-        throw new Error(singleLineString`colorize passed invalid type.
+        throw new Error(oneLine`colorize passed invalid type.
           Should be one of ${constants.MESSAGE_TYPES.join(', ')}`);
     }
   }
@@ -269,7 +270,7 @@ export default class Linter {
               return manifestParser.getMetadata();
             });
         }
-        _log.warn(singleLineString`No ${constants.INSTALL_RDF} or ${constants.MANIFEST_JSON}
+        _log.warn(oneLine`No ${constants.INSTALL_RDF} or ${constants.MANIFEST_JSON}
                    was found in the package metadata`);
         this.collector.addNotice(messages.TYPE_NO_MANIFEST_JSON);
         this.collector.addNotice(messages.TYPE_NO_INSTALL_RDF);

--- a/src/message.js
+++ b/src/message.js
@@ -1,5 +1,5 @@
 import { MESSAGE_TYPES } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 // These are the props we expect to pull out of
@@ -38,7 +38,7 @@ export default class Message {
       }
     });
     if (missingProps.length) {
-      throw new Error(singleLineString`Message data object is missing the
+      throw new Error(oneLine`Message data object is missing the
         following props: ${missingProps.join(', ')}`);
     }
   }
@@ -49,7 +49,7 @@ export default class Message {
 
   set type(type) {
     if (!MESSAGE_TYPES.includes(type)) {
-      throw new Error(singleLineString`Message type "${type}"
+      throw new Error(oneLine`Message type "${type}"
         is not one of ${MESSAGE_TYPES.join(', ')}`);
     }
     this._type = type;

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -1,4 +1,5 @@
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _} from 'utils';
+import { oneLine } from 'common-tags';
 
 
 export const CSS_SYNTAX_ERROR = {
@@ -6,7 +7,7 @@ export const CSS_SYNTAX_ERROR = {
   // This will be overriden by the reason passed from the error.
   legacyCode: null,
   message: _('A CSS syntax error was encountered'),
-  description: _(singleLineString`An error was found in the CSS file being
+  description: _(oneLine`An error was found in the CSS file being
     processed as a result further processing of that file is not possible`),
 };
 
@@ -14,5 +15,5 @@ export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   legacyCode: null,
   message: _('Invalid nesting of selectors found'),
-  description: _(singleLineString`Selectors should not be nested`),
+  description: _(oneLine`Selectors should not be nested`),
 };

--- a/src/messages/html.js
+++ b/src/messages/html.js
@@ -1,10 +1,12 @@
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _ } from 'utils';
+import { oneLine } from 'common-tags';
+
 
 export const INLINE_SCRIPT = {
   code: 'INLINE_SCRIPT',
   legacyCode: null,
   message: _('Inline scripts blocked by default'),
-  description: _(singleLineString`Default CSP rules prevent inline JavaScript
+  description: _(oneLine`Default CSP rules prevent inline JavaScript
     from running (https://mzl.la/2pn32nd).`),
 };
 
@@ -13,6 +15,6 @@ export const REMOTE_SCRIPT = {
   code: 'REMOTE_SCRIPT',
   legacyCode: null,
   message: _('Remote scripts are not allowed as per the Add-on Policies.'),
-  description: _(singleLineString`Please include all scripts in the add-on.
+  description: _(oneLine`Please include all scripts in the add-on.
     For more information, refer to https://mzl.la/2uEOkYp.`),
 };

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,4 +1,5 @@
-import { apiToMessage, gettext as _, singleLineString } from 'utils';
+import { apiToMessage, gettext as _ } from 'utils';
+import { oneLine } from 'common-tags';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
@@ -8,14 +9,14 @@ export const JS_SYNTAX_ERROR = {
     'syntax_error',
   ],
   message: _('JavaScript syntax error'),
-  description: _(singleLineString`There is a JavaScript syntax error in your
+  description: _(oneLine`There is a JavaScript syntax error in your
     code; validation cannot continue on this file.`),
 };
 
 export const EVENT_LISTENER_FOURTH = {
   code: 'EVENT_LISTENER_FOURTH',
   message: _('addEventListener` called with truthy fourth argument.'),
-  description: _(singleLineString`When called with a truthy forth argument,
+  description: _(oneLine`When called with a truthy forth argument,
     listeners can be triggered potentially unsafely by untrusted code. This
     requires careful review.`),
   legacyCode: ['js', 'instanceactions', 'addEventListener_fourth'],
@@ -48,7 +49,7 @@ export function _nonLiteralUri(method) {
       `${method}_nonliteral`,
     ],
     message: _(`'${method}' called with a non-literal uri`),
-    description: _(singleLineString`Calling '${method}' with variable
+    description: _(oneLine`Calling '${method}' with variable
       parameters can result in potential security vulnerabilities if the
       variable contains a remote URI. Consider using 'window.open' with
       the 'chrome=no' flag.`),
@@ -64,7 +65,7 @@ export function _methodPassedRemoteUri(method) {
       `${method}_remote_uri`,
     ],
     message: _(`'${method}' called with non-local URI`),
-    description: _(singleLineString`Calling '${method}' with a non-local
+    description: _(oneLine`Calling '${method}' with a non-local
       URI will result in the dialog being opened with chrome privileges.`),
   };
 }
@@ -75,7 +76,7 @@ export const OPENDIALOG_NONLIT_URI = _nonLiteralUri('openDialog');
 export const DANGEROUS_EVAL = {
   code: 'DANGEROUS_EVAL',
   message: null,
-  description: _(singleLineString`Evaluation of strings as code can lead to
+  description: _(oneLine`Evaluation of strings as code can lead to
     security vulnerabilities and performance issues, even in the
     most innocuous of circumstances. Please avoid using \`eval\` and the
     \`Function\` constructor when at all possible.'`),
@@ -85,7 +86,7 @@ export const DANGEROUS_EVAL = {
 export const NO_IMPLIED_EVAL = {
   code: 'NO_IMPLIED_EVAL',
   message: null,
-  description: _(singleLineString`setTimeout, setInterval and execScript
+  description: _(oneLine`setTimeout, setInterval and execScript
     functions should be called only with function expressions as their
     first argument`),
   legacyCode: null,
@@ -94,7 +95,7 @@ export const NO_IMPLIED_EVAL = {
 export const UNEXPECTED_GLOGAL_ARG = {
   code: 'UNEXPECTED_GLOGAL_ARG',
   message: _('Unexpected global passed as an argument'),
-  description: _(singleLineString`Passing a global as an argument
+  description: _(oneLine`Passing a global as an argument
     is not recommended. Please make this a var instead.`),
   legacyCode: null,
 };
@@ -102,7 +103,7 @@ export const UNEXPECTED_GLOGAL_ARG = {
 export const NO_DOCUMENT_WRITE = {
   code: 'NO_DOCUMENT_WRITE',
   message: _('Use of document.write strongly discouraged.'),
-  description: _(singleLineString`document.write will fail in many
+  description: _(oneLine`document.write will fail in many
     circumstances when used in extensions, and has potentially severe security
     repercussions when used improperly. Therefore, it should not be used.`),
   legacyCode: [
@@ -114,7 +115,7 @@ export const NO_DOCUMENT_WRITE = {
 export const BANNED_LIBRARY = {
   code: 'BANNED_LIBRARY',
   message: _('Banned 3rd-party JS library'),
-  description: _(singleLineString`Your add-on uses a JavaScript library we
+  description: _(oneLine`Your add-on uses a JavaScript library we
     consider unsafe. Read more: https://bit.ly/1TRIyZY`),
   legacyCode: null,
 };
@@ -122,7 +123,7 @@ export const BANNED_LIBRARY = {
 export const UNADVISED_LIBRARY = {
   code: 'UNADVISED_LIBRARY',
   message: _('Unadvised 3rd-party JS library'),
-  description: _(singleLineString`Your add-on uses a JavaScript library we do
+  description: _(oneLine`Your add-on uses a JavaScript library we do
     not recommend. Read more: https://bit.ly/1TRIyZY`),
   legacyCode: null,
 };
@@ -130,7 +131,7 @@ export const UNADVISED_LIBRARY = {
 export const KNOWN_LIBRARY = {
   code: 'KNOWN_LIBRARY',
   message: _('Known JS library detected'),
-  description: _(singleLineString`JavaScript libraries are discouraged for
+  description: _(oneLine`JavaScript libraries are discouraged for
     simple add-ons, but are generally accepted.`),
   legacyCode: [
     'testcases_content', 'test_packed_packages', 'blacklisted_js_library',
@@ -142,7 +143,7 @@ export const UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT = {
   // Uses original message from eslint
   message: null,
   legacyCode: null,
-  description: _(singleLineString`Due to both security and performance
+  description: _(oneLine`Due to both security and performance
     concerns, this may not be set using dynamic values which have
     not been adequately sanitized. This can lead to security issues or fairly
     serious performance degradation.`),
@@ -165,7 +166,7 @@ function deprecatedAPI(api) {
       api,
     ],
     message: _(`"${api}" is deprecated or unimplemented`),
-    description: _(singleLineString`This API has been deprecated by Chrome
+    description: _(oneLine`This API has been deprecated by Chrome
       and has not been implemented by Firefox.`),
   };
 }
@@ -191,7 +192,7 @@ function temporaryAPI(api) {
       api,
     ],
     message: _(`"${api}" can cause issues when loaded temporarily`),
-    description: _(singleLineString`This API can cause issues when loaded
+    description: _(oneLine`This API can cause issues when loaded
       temporarily using about:debugging in Firefox unless you specify
       applications > gecko > id in the manifest. Please see:
       https://mzl.la/2hizK4a for more.`),

--- a/src/messages/json.js
+++ b/src/messages/json.js
@@ -1,4 +1,5 @@
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _ } from 'utils';
+import { oneLine } from 'common-tags';
 
 export const JSON_INVALID = {
   code: 'JSON_INVALID',
@@ -11,7 +12,7 @@ export const JSON_BLOCK_COMMENTS = {
   code: 'JSON_BLOCK_COMMENTS',
   legacyCode: null,
   message: _('Your JSON contains block comments.'),
-  description: _(singleLineString`Only line comments (comments beginning with
+  description: _(oneLine`Only line comments (comments beginning with
     "//") are allowed in JSON files. Please remove block comments (comments
     beginning with "/*")`),
 };
@@ -20,5 +21,5 @@ export const JSON_DUPLICATE_KEY = {
   code: 'JSON_DUPLICATE_KEY',
   legacyCode: null,
   message: _('Duplicate keys are not allowed in JSON files.'),
-  description: _(singleLineString`Duplicate key found in JSON file.`),
+  description: _(oneLine`Duplicate key found in JSON file.`),
 };

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -1,5 +1,6 @@
 import { MAX_FILE_SIZE_TO_PARSE_MB } from 'const';
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _ } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 export const DUPLICATE_XPI_ENTRY = {
@@ -10,7 +11,7 @@ export const DUPLICATE_XPI_ENTRY = {
     'duplicate_entries',
   ],
   message: _('Package contains duplicate entries'),
-  description: _(singleLineString`The package contains multiple entries
+  description: _(oneLine`The package contains multiple entries
     with the same name. This practice has been banned. Try unzipping
     and re-zipping your add-on package and try again.`),
 };
@@ -30,7 +31,7 @@ export const TYPE_NO_INSTALL_RDF = {
     'missing_install_rdf',
   ],
   message: _('install.rdf was not found'),
-  description: _(singleLineString`The type should be determined by
+  description: _(oneLine`The type should be determined by
     install.rdf if present. As there's no install.rdf, type detection
     will be attempted to be inferred by package layout.`),
 };
@@ -43,7 +44,7 @@ export const TYPE_NO_MANIFEST_JSON = {
     'missing_manifest_json',
   ],
   message: _('manifest.json was not found'),
-  description: _(singleLineString`The type should be determined by
+  description: _(oneLine`The type should be determined by
     manifest.json if present. As there's no manifest.json, type detection
     will be attempted to be inferred by package layout.`),
 };
@@ -56,7 +57,7 @@ export const MULTIPLE_MANIFESTS = {
     'install_rdf_and_manifest_json',
   ],
   message: _('Both install_rdf and manifest.json found'),
-  description: _(singleLineString`The type should be determined by
+  description: _(oneLine`The type should be determined by
     manifest.json if present. Both install_rdf and manifest_json
     are defined.`),
 };
@@ -69,7 +70,7 @@ export const TYPE_NOT_DETERMINED = {
     'undeterminable_type',
   ],
   message: _('Unable to determine add-on type'),
-  description: _(singleLineString`The type detection algorithm could not
+  description: _(oneLine`The type detection algorithm could not
     determine the type of the add-on.`),
 };
 
@@ -77,7 +78,7 @@ export const FILE_TOO_LARGE = {
   code: 'FILE_TOO_LARGE',
   legacyCode: null,
   message: _('File is too large to parse.'),
-  description: _(singleLineString`This file is not binary and is too large to
+  description: _(oneLine`This file is not binary and is too large to
     parse. Files larger than ${MAX_FILE_SIZE_TO_PARSE_MB}MB will not be
     parsed. If your JavaScript file has a large list, consider removing the
     list and loading it as a separate JSON file instead.`),
@@ -91,7 +92,7 @@ export const HIDDEN_FILE = {
     'hidden_files',
   ],
   message: _('Hidden file flagged'),
-  description: _(singleLineString`Hidden files complicate the
+  description: _(oneLine`Hidden files complicate the
     review process and can contain sensitive information about the system that
     generated the add-on. Please modify the packaging process so that these
     files aren't included.`),
@@ -105,7 +106,7 @@ export const FLAGGED_FILE = {
     'flagged_files',
   ],
   message: _('Flagged filename found'),
-  description: _(singleLineString`Files were found that are either unnecessary
+  description: _(oneLine`Files were found that are either unnecessary
     or have been included unintentionally. They should be removed.`),
 };
 
@@ -117,7 +118,7 @@ export const FLAGGED_FILE_EXTENSION = {
     'disallowed_extension',
   ],
   message: _('Flagged file extensions found'),
-  description: _(singleLineString`Files were found that are either unnecessary
+  description: _(oneLine`Files were found that are either unnecessary
     or have been included unintentionally. They should be removed.`),
 };
 
@@ -129,7 +130,7 @@ export const FLAGGED_FILE_TYPE = {
     'disallowed_file_type',
   ],
   message: _('Flagged file type found'),
-  description: _(singleLineString`Files whose names end with flagged extensions
+  description: _(oneLine`Files whose names end with flagged extensions
     have been found in the add-on. The extension of these files are flagged
     because they usually identify binary components. Please see
     https://bit.ly/review-policy for more information on the binary content
@@ -140,7 +141,7 @@ export const ALREADY_SIGNED = {
   code: 'ALREADY_SIGNED',
   legacyCode: null,
   message: _('Package already signed'),
-  description: _(singleLineString`Add-ons which are already signed will be
+  description: _(oneLine`Add-ons which are already signed will be
     re-signed when published on AMO. This will replace any existing signatures
     on the add-on.`),
 };
@@ -149,7 +150,7 @@ export const MOZILLA_COND_OF_USE = {
   code: 'MOZILLA_COND_OF_USE',
   legacyCode: null,
   message: _('Violation of Mozilla conditions of use.'),
-  description: _(singleLineString`Words found that violate the Mozilla
+  description: _(oneLine`Words found that violate the Mozilla
     conditions of use.
     See https://www.mozilla.org/en-US/about/legal/acceptable-use/ for more
     details.`),

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,5 +1,6 @@
-import { gettext as _, singleLineString, sprintf } from 'utils';
+import { gettext as _, sprintf } from 'utils';
 import { MANIFEST_JSON } from 'const';
+import { oneLine } from 'common-tags';
 
 
 export const MANIFEST_FIELD_REQUIRED = {
@@ -22,7 +23,7 @@ export const MANIFEST_BAD_PERMISSION = {
   code: 'MANIFEST_BAD_PERMISSION',
   legacyCode: null,
   message: _('The permission type is unsupported.'),
-  description: _(singleLineString`See https://mzl.la/1R1n1t0
+  description: _(oneLine`See https://mzl.la/1R1n1t0
     (MDN Docs) for more information.`),
   file: MANIFEST_JSON,
 };
@@ -48,7 +49,7 @@ export const MANIFEST_CSP = {
   // it depends on it to detect add-ons with a custom content security policy.
   code: 'MANIFEST_CSP',
   legacyCode: null,
-  message: _(singleLineString`
+  message: _(oneLine`
     "content_security_policy" allows remote code execution in manifest.json`),
   description: _('A custom content_security_policy needs additional review.'),
   file: MANIFEST_JSON,
@@ -82,7 +83,7 @@ export const MANIFEST_UPDATE_URL = {
   code: 'MANIFEST_UPDATE_URL',
   legacyCode: null,
   message: _('"update_url" is not allowed.'),
-  description: _(singleLineString`"applications.gecko.update_url" is not allowed
+  description: _(oneLine`"applications.gecko.update_url" is not allowed
     for Mozilla-hosted add-ons.`),
   file: MANIFEST_JSON,
 };
@@ -91,7 +92,7 @@ export const MANIFEST_UNUSED_UPDATE = {
   code: 'MANIFEST_UNUSED_UPDATE',
   legacyCode: null,
   message: _('The "update_url" property is not used by Firefox.'),
-  description: _(singleLineString`The "update_url" is not used by Firefox in
+  description: _(oneLine`The "update_url" is not used by Firefox in
     the root of a manifest; your add-on will be updated via the Add-ons
     site and not your "update_url". See: https://mzl.la/25zqk4O`),
   file: MANIFEST_JSON,
@@ -101,7 +102,7 @@ export const STRICT_MAX_VERSION = {
   code: 'STRICT_MAX_VERSION',
   legacyCode: null,
   message: _('"strict_max_version" not required.'),
-  description: _(singleLineString`"strict_max_version" shouldn't be used unless
+  description: _(oneLine`"strict_max_version" shouldn't be used unless
     the add-on is expected not to work with future versions of Firefox.`),
   file: MANIFEST_JSON,
 };
@@ -137,7 +138,7 @@ export const NO_MESSAGES_FILE = {
   code: 'NO_MESSAGES_FILE',
   legacyCode: null,
   message: _('The "default_locale" is missing localizations.'),
-  description: _(singleLineString`The "default_locale" value is specified in
+  description: _(oneLine`The "default_locale" value is specified in
     the manifest, but no matching "messages.json" in the "_locales" directory
     exists. See: https://mzl.la/2hjcaEE`),
   file: MANIFEST_JSON,
@@ -147,7 +148,7 @@ export const NO_DEFAULT_LOCALE = {
   code: 'NO_DEFAULT_LOCALE',
   legacyCode: null,
   message: _('The "default_locale" is missing but "_locales" exist.'),
-  description: _(singleLineString`The "default_locale" value is not specifed in
+  description: _(oneLine`The "default_locale" value is not specifed in
     the manifest, but a "_locales" directory exists.
     See: https://mzl.la/2hjcaEE`),
   file: MANIFEST_JSON,

--- a/src/messages/rdf.js
+++ b/src/messages/rdf.js
@@ -1,5 +1,6 @@
-import { gettext as _, singleLineString } from 'utils';
+import { gettext as _ } from 'utils';
 import { INSTALL_RDF } from 'const';
+import { oneLine } from 'common-tags';
 
 
 export const _tagNotAllowed = (tagName) => {
@@ -9,7 +10,7 @@ export const _tagNotAllowed = (tagName) => {
     // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
     legacyCode: null,
     message: _(`<${tagName}> tag is not allowed`),
-    description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
+    description: _(oneLine`Your RDF file contains the <${tagName}> tag,
       which is not allowed in an Add-on.`),
   };
 };
@@ -21,7 +22,7 @@ export const _tagNotAllowedIfTag = (tagName, otherTag) => {
     // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
     legacyCode: null,
     message: _(`<${tagName}> cannot be used with <${otherTag}>`),
-    description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
+    description: _(oneLine`Your RDF file contains the <${tagName}> tag,
       which cannot be used with a <${otherTag}> tag.`),
   };
 };
@@ -33,7 +34,7 @@ export const _tagObsolete = (tagName) => {
     // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
     legacyCode: null,
     message: _(`<${tagName}> tag is obsolete`),
-    description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
+    description: _(oneLine`Your RDF file contains the <${tagName}> tag,
       which is obsolete.`),
   };
 };
@@ -42,7 +43,7 @@ export const RDF_GUID_TOO_LONG = {
   code: 'RDF_GUID_TOO_LONG',
   legacyCode: null,
   message: _('GUID is too long (over 255 chars)'),
-  description: _(singleLineString`A GUID must be 255 characters or less.
+  description: _(oneLine`A GUID must be 255 characters or less.
     Please use a shorter GUID.`),
   file: INSTALL_RDF,
 };
@@ -64,7 +65,7 @@ export const RDF_TYPE_INVALID = {
     'invalid_em_type',
   ],
   message: _('Invalid <em:type> value'),
-  description: _(singleLineString`The only valid values for <em:type>
+  description: _(oneLine`The only valid values for <em:type>
     are 2, 4, 8, and 32. Any other values are either invalid or
     deprecated.`),
   file: INSTALL_RDF,
@@ -78,7 +79,7 @@ export const RDF_TYPE_MISSING = {
     'no_em:type',
   ],
   message: _('No <em:type> element found in install.rdf'),
-  description: _(singleLineString`It isn't always required, but it is
+  description: _(oneLine`It isn't always required, but it is
     the most reliable method for determining add-on type.`),
   file: INSTALL_RDF,
 };

--- a/src/parsers/installrdf.js
+++ b/src/parsers/installrdf.js
@@ -1,7 +1,7 @@
 import { ADDON_TYPE_MAP, RDF_DEFAULT_NAMESPACE } from 'const';
 import * as messages from 'messages';
 import log from 'logger';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 export default class InstallRdfParser {
@@ -65,7 +65,7 @@ export default class InstallRdfParser {
     const descriptionNodes = Array.prototype.slice.call(rdfNode.childNodes)
       .filter((node) => node.nodeName === 'Description');
     if (descriptionNodes.length > 1) {
-      throw new Error(singleLineString`RDF node should only have a
+      throw new Error(oneLine`RDF node should only have a
         single descendant <Description>`);
     }
     return descriptionNodes[0];

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -11,7 +11,8 @@ import log from 'logger';
 import * as messages from 'messages';
 import JSONParser from 'parsers/json';
 import { isToolkitVersionString } from 'schema/formats';
-import { singleLineString, parseCspPolicy } from 'utils';
+import { parseCspPolicy } from 'utils';
+import { oneLine } from 'common-tags';
 
 function normalizePath(iconPath) {
   // Convert the icon path to a URL so we can strip any fragments and resolve
@@ -83,7 +84,7 @@ export default class ManifestJSONParser extends JSONParser {
     const match = error.dataPath.match(/^\/(permissions)\/([\d+])/);
     if (match && baseObject.code !== messages.MANIFEST_BAD_PERMISSION.code) {
       baseObject = messages[`MANIFEST_${match[1].toUpperCase()}`];
-      overrides.message = singleLineString`/${match[1]}: Unknown ${match[1]}
+      overrides.message = oneLine`/${match[1]}: Unknown ${match[1]}
           "${error.data}" at ${match[2]}.`;
     }
 

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -9,7 +9,8 @@ import {
 } from 'const';
 import * as messages from 'messages';
 import { rules } from 'rules/javascript';
-import { ensureFilenameExists, singleLineString } from 'utils';
+import { ensureFilenameExists } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 export default class JavaScriptScanner {
@@ -95,7 +96,7 @@ export default class JavaScriptScanner {
 
           if (typeof message.message === 'undefined') {
             throw new Error(
-              singleLineString`JS rules must pass a valid message as
+              oneLine`JS rules must pass a valid message as
               the second argument to context.report()`);
           }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,37 +2,9 @@ import url from 'url';
 
 import jed from 'jed';
 import semver from 'semver';
+import { oneLine } from 'common-tags';
 
 import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
-
-/*
- * Template tag for removing whitespace and new lines
- * in order to be able to use multiline template strings
- * as a single string.
- *
- * Usage: singleLineString`foo bar baz
- *                    whatever`;
- *
- * Will output: 'foo bar baz whatever'
- *
- */
-export function singleLineString(strings, ...vars) {
-  // Interweave the strings with the
-  // substitution vars first.
-  let output = '';
-  for (let i = 0; i < vars.length; i++) {
-    output += strings[i] + vars[i];
-  }
-  output += strings[vars.length];
-
-  // Split on newlines.
-  const lines = output.split(/(?:\r\n|\n|\r)/);
-
-  // Rip out the leading whitespace.
-  return lines.map((line) => {
-    return line.replace(/^\s+/gm, '');
-  }).join(' ').trim();
-}
 
 /*
  * Takes an AST node and returns the root property.
@@ -155,7 +127,7 @@ export function checkMinNodeVersion(minVersion, _process = process) {
     // eslint-disable-next-line no-param-reassign
     minVersion = minVersion || '0.12.0';
     if (!semver.gte(_process.version, minVersion)) {
-      throw new Error(singleLineString`Node version must be ${minVersion} or
+      throw new Error(oneLine`Node version must be ${minVersion} or
                       greater. You are using ${_process.version}.`);
     } else {
       resolve();

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,7 +5,7 @@ import isMatchWith from 'lodash.ismatchwith';
 import Hash from 'hashish';
 
 import { PACKAGE_EXTENSION } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 
 export const fakeMessageData = {
@@ -51,7 +51,7 @@ export function metadataPassCheck(contents, filename, { addonMetadata = null } =
 }
 
 export function validHTML(contents = '') {
-  return singleLineString`<!DOCTYPE html>
+  return oneLine`<!DOCTYPE html>
   <html>
     <head>
       <meta charset="utf-8">
@@ -70,7 +70,7 @@ export function validMetadata(metadata = {}) {
 }
 
 export function validRDF(contents) {
-  return singleLineString`<?xml version='1.0' encoding='utf-8'?>
+  return oneLine`<?xml version='1.0' encoding='utf-8'?>
   <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
        xmlns:em="http://www.mozilla.org/2004/em-rdf#">
     <Description about="urn:mozilla:install-manifest">

--- a/tests/parsers/test.installrdf.js
+++ b/tests/parsers/test.installrdf.js
@@ -3,7 +3,7 @@ import RDFScanner from 'scanners/rdf';
 import InstallRdfParser from 'parsers/installrdf';
 import Linter from 'linter';
 import * as messages from 'messages';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 import { unexpectedSuccess, validRDF } from '../helpers';
 
@@ -282,7 +282,7 @@ describe('InstallRdfParser._getIsBootstrapped()', () => {
 
 describe('InstallRdfParser._getDescriptionNode()', () => {
   it('should reject on missing RDF node', () => {
-    const badRdf = singleLineString`<xml><RDF><Description>hai</Description>
+    const badRdf = oneLine`<xml><RDF><Description>hai</Description>
       <Description>there</Description></RDF></xml>`;
     const rdfScanner = new RDFScanner(badRdf, constants.INSTALL_RDF);
     return rdfScanner.getContents()

--- a/tests/parsers/test.json.js
+++ b/tests/parsers/test.json.js
@@ -1,7 +1,7 @@
 import Linter from 'linter';
 import JSONParser from 'parsers/json';
 import * as messages from 'messages';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 import { validManifestJSON } from '../helpers';
 
@@ -24,7 +24,7 @@ describe('JSONParser', () => {
 describe('JSONParser duplicate keys', () => {
   it('should error if duplicate keys are found in a JSON file', () => {
     const addonLinter = new Linter({ _: ['bar'] });
-    // We aren't using singleLineString here so we can test the line number
+    // We aren't using oneLine here so we can test the line number
     // reporting.
     /* eslint-disable indent */
     const json = ['{',
@@ -55,7 +55,7 @@ describe('JSONParser duplicate keys', () => {
 
   it('should report all dupes if multiple duplicate keys are found', () => {
     const addonLinter = new Linter({ _: ['bar'] });
-    const json = singleLineString`{
+    const json = oneLine`{
       "description": "Very good music.",
       "manifest_version": 2,
       "name": "Prince",
@@ -87,7 +87,7 @@ describe('JSONParser duplicate keys', () => {
 
   it('should not expose other RJSON errors', () => {
     const addonLinter = new Linter({ _: ['bar'] });
-    // We aren't using singleLineString here so we can test the line number
+    // We aren't using oneLine here so we can test the line number
     // reporting.
     /* eslint-disable indent */
     const json = ['{',
@@ -135,7 +135,7 @@ describe('JSONParser duplicate keys', () => {
 
   it('should not be invalid if unknown RJSON errors', () => {
     const addonLinter = new Linter({ _: ['bar'] });
-    // We aren't using singleLineString here so we can test the line number
+    // We aren't using oneLine here so we can test the line number
     // reporting.
     const json = '{}';
 

--- a/tests/rules/css/test.invalidNesting.js
+++ b/tests/rules/css/test.invalidNesting.js
@@ -1,12 +1,12 @@
 import * as messages from 'messages';
 import { VALIDATION_WARNING } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 import CSSScanner from 'scanners/css';
 
 
 describe('CSS Rule InvalidNesting', () => {
   it('should detect invalid nesting', () => {
-    const code = singleLineString`/* I'm a comment */
+    const code = oneLine`/* I'm a comment */
       #something {
         .bar {
           height: 100px;
@@ -25,7 +25,7 @@ describe('CSS Rule InvalidNesting', () => {
   });
 
   it('should not detect invalid nesting', () => {
-    const code = singleLineString`/* I'm a comment */
+    const code = oneLine`/* I'm a comment */
       @media only screen and (max-width: 959px) {
           .something-else {
               height: 100px;
@@ -40,7 +40,7 @@ describe('CSS Rule InvalidNesting', () => {
   });
 
   it('should detect invalid nesting in @media block', () => {
-    const code = singleLineString`/* I'm a comment */
+    const code = oneLine`/* I'm a comment */
       @media only screen and (max-width: 959px) {
         .foo {
           .something-else {

--- a/tests/rules/javascript/test.deprecated_entities.js
+++ b/tests/rules/javascript/test.deprecated_entities.js
@@ -1,5 +1,5 @@
 import { VALIDATION_WARNING } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 import { DEPRECATED_ENTITIES } from 'rules/javascript/deprecated-entities';
 import JavaScriptScanner from 'scanners/javascript';
 
@@ -22,7 +22,7 @@ describe('deprecated_entities', () => {
     });
 
     it(`should know when a variable references ${obj}`, () => {
-      const code = singleLineString`var foo = ${obj};
+      const code = oneLine`var foo = ${obj};
         foo.${prop}();`;
       const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 

--- a/tests/rules/javascript/test.event_listener_fourth.js
+++ b/tests/rules/javascript/test.event_listener_fourth.js
@@ -1,6 +1,6 @@
 import JavaScriptScanner from 'scanners/javascript';
 import { VALIDATION_WARNING } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 import * as messages from 'messages';
 
 describe('event_listener_fourth', () => {
@@ -53,7 +53,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should not allow a true identifier', () => {
-    const code = singleLineString`var t = 'true';
+    const code = oneLine`var t = 'true';
       window.addEventListener("click", function(){}, false, t);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -68,7 +68,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should allow a false identifier', () => {
-    const code = singleLineString`var t = false;
+    const code = oneLine`var t = false;
       window.addEventListener("click", function(){}, false, t);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -79,7 +79,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should not allow a window identifier', () => {
-    const code = singleLineString`var foo = window;
+    const code = oneLine`var foo = window;
       foo.addEventListener("click", function(){}, false, false);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -90,7 +90,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should not allow a hidden addEventListener identifier', () => {
-    const code = singleLineString`var foo = window.addEventListener;
+    const code = oneLine`var foo = window.addEventListener;
       foo("click", function(){}, false, false);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -101,7 +101,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should not allow a true identifier with untrusted argument', () => {
-    const code = singleLineString`var foo = window;
+    const code = oneLine`var foo = window;
       foo.addEventListener("click", function(){}, false, true);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -116,7 +116,7 @@ describe('event_listener_fourth', () => {
   });
 
   it('should not allow a true identifier hidden with arg', () => {
-    const code = singleLineString`var foo = window.addEventListener;
+    const code = oneLine`var foo = window.addEventListener;
       foo("click", function(){}, false, true);`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 

--- a/tests/rules/javascript/test.no_implied_eval.js
+++ b/tests/rules/javascript/test.no_implied_eval.js
@@ -1,5 +1,5 @@
 import { VALIDATION_WARNING } from 'const';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 import JavaScriptScanner from 'scanners/javascript';
 import { NO_IMPLIED_EVAL } from 'messages';
 
@@ -7,7 +7,7 @@ import { NO_IMPLIED_EVAL } from 'messages';
 // These rules were mostly copied and adapted from eslint.
 // Please make sure to keep them up-to-date and report upstream errors.
 describe('no_implied_eval', () => {
-  const expectedErrorMessage = singleLineString`
+  const expectedErrorMessage = oneLine`
     Implied eval. Consider passing a function instead of a string.`;
 
   const validCodes = [

--- a/tests/rules/test.rdf.js
+++ b/tests/rules/test.rdf.js
@@ -2,7 +2,7 @@ import { VALIDATION_ERROR, VALIDATION_NOTICE, VALIDATION_WARNING } from 'const';
 import * as rules from 'rules/rdf';
 import RDFScanner from 'scanners/rdf';
 import * as messages from 'messages';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 
 import { validRDF } from '../helpers';
 
@@ -25,7 +25,7 @@ describe('RDF: mustNotExist', () => {
   });
 
   it('should not blow up when multiple bad tags are found', () => {
-    const contents = validRDF(singleLineString`<em:hidden>true</em:hidden>
+    const contents = validRDF(oneLine`<em:hidden>true</em:hidden>
       <em:hidden>false</em:hidden>`);
     const rdfScanner = new RDFScanner(contents, filename);
 
@@ -42,7 +42,7 @@ describe('RDF: mustNotExist', () => {
 
   it('should not allow certain tags when listed', () => {
     // Should fail because Add-on is listed and has an updateURL.
-    const contents = validRDF(singleLineString`<em:listed>true</em:listed>
+    const contents = validRDF(oneLine`<em:listed>true</em:listed>
       <em:updateURL>http://mozilla.com/updateMyAddon.php</em:updateURL>`);
     const rdfScanner = new RDFScanner(contents, filename);
 
@@ -57,7 +57,7 @@ describe('RDF: mustNotExist', () => {
   });
 
   it('should allow certain tags when not listed', () => {
-    const contents = validRDF(singleLineString`
+    const contents = validRDF(oneLine`
       <em:updateURL>http://mozilla.com/updateMyAddon.php</em:updateURL>`);
     const rdfScanner = new RDFScanner(contents, filename);
 
@@ -68,7 +68,7 @@ describe('RDF: mustNotExist', () => {
   });
 
   it('should test for obsolete tags', () => {
-    const contents = validRDF(singleLineString`<em:file>'foo.js'</em:file>
+    const contents = validRDF(oneLine`<em:file>'foo.js'</em:file>
       <em:requires>'something'</em:requires><em:skin>true</em:skin>`);
     const rdfScanner = new RDFScanner(contents, filename);
 
@@ -89,7 +89,7 @@ describe('RDF: mustNotExist', () => {
   });
 
   it('_checkForTags should find tags and set the correct type', () => {
-    const contents = validRDF(singleLineString`<em:nameTag>Matthew Riley
+    const contents = validRDF(oneLine`<em:nameTag>Matthew Riley
       MacPherson</em:nameTag><em:file>'foo.js'</em:file>`);
     const rdfScanner = new RDFScanner(contents, 'install.rdf');
 

--- a/tests/scanners/test.css.js
+++ b/tests/scanners/test.css.js
@@ -1,8 +1,9 @@
 import * as messages from 'messages';
 import { VALIDATION_WARNING } from 'const';
+import { oneLine } from 'common-tags';
 import CSSScanner from 'scanners/css';
 import * as rules from 'rules/css';
-import { ignorePrivateFunctions, singleLineString } from 'utils';
+import { ignorePrivateFunctions } from 'utils';
 
 import { getRuleFiles, metadataPassCheck, validMetadata } from '../helpers';
 
@@ -29,7 +30,7 @@ describe('CSSScanner', () => {
   });
 
   it('should pass metadata to rules', () => {
-    const code = singleLineString`/* whatever code */
+    const code = oneLine`/* whatever code */
       #myName { position: relative; }
       .myClass { background: #000; }`;
     const fakeRules = { metadataPassCheck: () => {} };
@@ -76,7 +77,7 @@ describe('CSSScanner', () => {
 
   it('should export and run all rules in rules/css', () => {
     const ruleFiles = getRuleFiles('css');
-    const code = singleLineString`/* whatever code */
+    const code = oneLine`/* whatever code */
       #myName { position: relative; }
       .myClass { background: #000; }`;
     const cssScanner = new CSSScanner(code, 'fakeFile.css');

--- a/tests/scanners/test.html.js
+++ b/tests/scanners/test.html.js
@@ -1,10 +1,11 @@
 import cheerio from 'cheerio';
 
 import { VALIDATION_WARNING } from 'const';
+import { oneLine } from 'common-tags';
 import HTMLScanner from 'scanners/html';
 import * as rules from 'rules/html';
 import * as messages from 'messages';
-import { ignorePrivateFunctions, singleLineString } from 'utils';
+import { ignorePrivateFunctions } from 'utils';
 
 import { getRuleFiles, validHTML } from '../helpers';
 
@@ -47,7 +48,7 @@ describe('HTML', () => {
   });
 
   it('should accept a <script> tag with a src attribute', () => {
-    const goodHTML = validHTML(singleLineString`
+    const goodHTML = validHTML(oneLine`
         <script src="">alert()</script>`);
     const htmlScanner = new HTMLScanner(goodHTML, 'index.html');
 
@@ -58,7 +59,7 @@ describe('HTML', () => {
   });
 
   it('should warn on remote <script> tag src attribute', () => {
-    const badHTML = validHTML(singleLineString`
+    const badHTML = validHTML(oneLine`
       <script src="http://foo.bar/my.js"></script>
       <script src="https://foo.bar/my.js"></script>
       <script src="file://foo.bar/my.js"></script>
@@ -80,7 +81,7 @@ describe('HTML', () => {
   });
 
   it('should allow <script> src attribute to be local', () => {
-    const badHTML = validHTML(singleLineString`
+    const badHTML = validHTML(oneLine`
       <script src="./bar/my.js"></script>
       <script src="/foo/my.js"></script>
       <script src="foo/my.js"></script>

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -12,7 +12,8 @@ import {
 import JavaScriptScanner from 'scanners/javascript';
 import * as messages from 'messages';
 import { rules } from 'rules/javascript';
-import { apiToMessage, singleLineString } from 'utils';
+import { apiToMessage } from 'utils';
+import { oneLine } from 'common-tags';
 
 import {
   fakeMessageData,
@@ -114,7 +115,7 @@ describe('JavaScript Scanner', () => {
   });
 
   it('ignores /*eslint-disable*/ comments', () => {
-    const code = singleLineString`/*eslint-disable*/
+    const code = oneLine`/*eslint-disable*/
                                 var myDatabase = indexeddb || mozIndexedDB;`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -126,7 +127,7 @@ describe('JavaScript Scanner', () => {
   });
 
   it('ignores // eslint-disable-line comments', () => {
-    const code = singleLineString`var myDatabase = indexeddb || mozIndexedDB;
+    const code = oneLine`var myDatabase = indexeddb || mozIndexedDB;
                                 // eslint-disable-line`;
     const jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
@@ -162,7 +163,7 @@ describe('JavaScript Scanner', () => {
   // This is just a precaution against disabling environments in ESLint, which
   // isn't allowed as of writing, but will warn us if it ever happens :-)
   it('ignores /*eslint-env*/ comments', () => {
-    const code = singleLineString`/*eslint-env es6:false*/
+    const code = oneLine`/*eslint-env es6:false*/
       var makeBigger = (number) => {
         return number + 1;
       }`;

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -8,7 +8,7 @@ import BinaryScanner from 'scanners/binary';
 import CSSScanner from 'scanners/css';
 import FilenameScanner from 'scanners/filename';
 import JSONScanner from 'scanners/json';
-import { singleLineString } from 'utils';
+import { oneLine } from 'common-tags';
 import { Xpi } from 'io';
 
 import {
@@ -565,7 +565,7 @@ describe('Linter.textOutput()', () => {
     expect(text).not.toContain('whatever error description');
   });
 
-  it(singleLineString`should remove columns, description, and lines when terminal is < 60 columns wide`, () => {
+  it(oneLine`should remove columns, description, and lines when terminal is < 60 columns wide`, () => {
     const addonLinter = new Linter({ _: ['bar'] });
     addonLinter.collector.addError({
       code: 'WHATEVER_ERROR',

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -1,38 +1,8 @@
 import * as utils from 'utils';
 
 import { unexpectedSuccess } from './helpers';
+import { oneLine } from 'common-tags';
 
-
-describe('utils.singleLineString()', () => {
-  it('reduce a multiline template string into one string', () => {
-    const output = utils.singleLineString`foo
-              bar
-        baz`;
-    expect(output).toEqual('foo bar baz');
-  });
-
-  it('should still do subs', () => {
-    const foo = 1;
-    const bar = 2;
-    const baz = 3;
-    const output = utils.singleLineString`one ${foo}
-              two ${bar}
-        three ${baz}`;
-    expect(output).toEqual('one 1 two 2 three 3');
-  });
-
-  it('should still work with tabs', () => {
-    /* eslint-disable no-tabs */
-    const me = 'me';
-    const raggedy = 'raggedy';
-    const you = 'you';
-    const output = utils.singleLineString`So here is us, on the
-          ${raggedy} edge. Don't push ${me},
-              			and I won't push ${you}.`;
-    expect(output).toEqual('So here is us, on the raggedy edge. ' +
-    "Don't push me, and I won't push you.");
-  });
-});
 
 describe('utils.getRootExpression()', () => {
   const node = {
@@ -371,7 +341,7 @@ describe('utils.parseCspPolicy', () => {
   });
 
   it('should parse directives correctly', () => {
-    const rawPolicy = utils.singleLineString`
+    const rawPolicy = oneLine`
       default-src 'none'; script-src 'self'; connect-src https: 'self';
       img-src 'self'; style-src 'self';
     `;


### PR DESCRIPTION
Fixes #1199 
Replaced `singleLineString` with its common-tag equivalent `oneLine `
@EnTeQuAk  Please let me know if I need to add some tests to cover the changes.