### PR TITLE
Fix `yarn add` command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To validate your add-on locally, install the linter from
 ```
 # Install globally so you can use the linter from any directory on
 # your machine.
-yarn add --global addons-linter
+yarn global add addons-linter
 # or
 npm install -g addons-linter
 ```


### PR DESCRIPTION
`yarn add --global addons-linter` will:
>yarn add v0.28.4
>error Missing list of packages to add to your project.
>info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

* [*] The change has been successfully run locally.

https://yarnpkg.com/docs/cli/global/