### PR TITLE
Don't check badwords on binary files such as PNGs.

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -23,7 +23,6 @@ import JavaScriptScanner from 'scanners/javascript';
 import JSONScanner from 'scanners/json';
 import RDFScanner from 'scanners/rdf';
 import { Crx, Directory, Xpi } from 'io';
-import badwords from './badwords.json';
 
 
 export default class Linter {
@@ -375,8 +374,10 @@ export default class Linter {
           this.addonMetadata.totalScannedFileSize += fileSize;
         }
 
-        // Check for badwords across all file-types
-        this._markBadwordUsage(filename, fileData);
+        if (ScannerClass !== BinaryScanner) {
+          // Check for badwords across all file-types
+          this._markBadwordUsage(filename, fileData);
+        }
 
         const scanner = new ScannerClass(fileData, filename, {
           addonMetadata: this.addonMetadata,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -3,9 +3,9 @@ import { assert } from 'assert';
 
 import isMatchWith from 'lodash.ismatchwith';
 import Hash from 'hashish';
+import { oneLine } from 'common-tags';
 
 import { PACKAGE_EXTENSION } from 'const';
-import { oneLine } from 'common-tags';
 
 
 export const fakeMessageData = {
@@ -13,6 +13,12 @@ export const fakeMessageData = {
   description: 'description',
   message: 'message',
 };
+
+export const EMPTY_PNG = Buffer
+  .from(oneLine`iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMA
+                AQAABQABDQottAAAAABJRU5ErkJggg==`,
+        'base64')
+  .toString('base64');
 
 export function getRuleFiles(ruleType) {
   const ruleFiles = fs.readdirSync(`src/rules/${ruleType}`);

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -15,7 +15,8 @@ import { Xpi } from 'io';
 import {
   fakeMessageData,
   unexpectedSuccess,
-  validManifestJSON } from './helpers';
+  validManifestJSON,
+  EMPTY_PNG } from './helpers';
 
 
 const fakeCheckFileExists = () => {
@@ -1306,6 +1307,7 @@ describe('Linter.extractMetadata()', () => {
         'manifest.json': { uncompressedSize: 839 },
         'm1.js': { uncompressedSize: 20 },
         'm2.js': { uncompressedSize: 20 },
+        'foo.png': { uncompressedSize: 364 },
       };
       getFile(filename) {
         return this.getFileAsString(filename);
@@ -1318,6 +1320,7 @@ describe('Linter.extractMetadata()', () => {
           'm1.js': 'const a = "butt fuck"',
           'm2.js': 'const a = "m-fucking"',
           'manifest.json': validManifestJSON({ name: 'Buttonmania' }),
+          'foo.png': EMPTY_PNG,
         };
 
         return Promise.resolve(words[filename]);
@@ -1325,6 +1328,7 @@ describe('Linter.extractMetadata()', () => {
     }
     return addonLinter.scan({ _Xpi: FakeXpi, _console: fakeConsole })
       .then(() => {
+        // Only manifest and js files, binary files like the .png are ignored
         sinon.assert.callCount(markBadwordusageSpy, 3);
         const errors = addonLinter.collector.notices;
         expect(errors.length).toEqual(2);

--- a/tests/test.linter.js
+++ b/tests/test.linter.js
@@ -1344,7 +1344,7 @@ describe('Linter.extractMetadata()', () => {
     class FakeXpi extends FakeIOBase {
       files = {
         'manifest.json': { uncompressedSize: 839 },
-        'angular.js': { uncompressedSize: 7 },
+        'jquery.js': { uncompressedSize: 7 },
         'foo.png': { uncompressedSize: 386 },
       };
       getFile(filename) {
@@ -1372,8 +1372,8 @@ describe('Linter.extractMetadata()', () => {
         const contents = {
           'manifest.json': validManifestJSON({ name: 'Buttonmania' }),
           'foo.png': EMPTY_PNG,
-          'angular.js': fs.readFileSync(
-            'tests/fixtures/jslibs/angular-1.2.28.min.js',
+          'jquery.js': fs.readFileSync(
+            'tests/fixtures/jslibs/jquery-3.2.1.min.js',
           ),
         };
 


### PR DESCRIPTION
Fixes #1504

This adds a test that checks that we don't even try matching on known libraries such as angular.js
