### PR TITLE
Fix fixme, fix matching pattern tests.

### DIFF
--- a/tests/schema/test.permissions.js
+++ b/tests/schema/test.permissions.js
@@ -35,11 +35,8 @@ describe('/permissions', () => {
   const matchingPatterns = [
     '*://developer.mozilla.org/*',
     'http://developer.mozilla.org/*',
-    // FIXME: the loop in this test was previously broken.
-    // These lines don't match the schema.
-    // 'https://foo.com',
-    // 'ftp://do.people.still.use.this',
-    // 'app://wat/',
+    'https://foo.com/',
+    'ftp://do.people.still.use.this/',
     'file:///etc/hosts',
   ];
 
@@ -49,6 +46,25 @@ describe('/permissions', () => {
       manifest.permissions = [matchPattern];
       validate(manifest);
       expect(validate.errors).toBeNull();
+    });
+  });
+
+  const invalidMatchingPatterns = [
+    // The path is required to start with a slash.
+    // See https://mzl.la/2gAyLu4 for more details.
+    'https://foo.com',
+    'ftp://do.people.still.use.this',
+
+    // app is not in the list of valid schemas: https://mzl.la/2iWLFam
+    'app://wat.com/',
+  ];
+
+  invalidMatchingPatterns.forEach((invalidMatchPattern) => {
+    it(`should not allow the pattern: ${invalidMatchPattern}`, () => {
+      const manifest = cloneDeep(validManifest);
+      manifest.permissions = [invalidMatchPattern];
+      validate(manifest);
+      expect(validate.errors).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
Fixes #1459 
r? @mstriemer 

What's interesting is that the official schema - https://hg.mozilla.org/mozilla-central/file/tip/toolkit/components/extensions/schemas/manifest.json#l327 - apparently doesn't know anything about `app://` while the docs at https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Match_patterns#scheme do, is that just outdated and should be updated?

**Edit:** `app://` got removed in https://hg.mozilla.org/mozilla-central/rev/cdb240a81e9b#l24.13 so we need to update the wiki page. I'll try to do that once this got merged.