### PR TITLE
Limit version string length.

### DIFF
--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -14,7 +14,7 @@ const TOOLKIT_REGEXP =
   new RegExp(`^${VERSION_PART}(?:\\.${VERSION_PART}){0,3}${BETA_PART}$`);
 
 export function isValidVersionString(version) {
-  // We should be starting with a string.
+  // We should be starting with a string. Limit length, see bug 1393644
   if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
@@ -22,8 +22,8 @@ export function isValidVersionString(version) {
 }
 
 export function isToolkitVersionString(version) {
-  // We should be starting with a string.
-  if (typeof version !== 'string') {
+  // We should be starting with a string. Limit length, see bug 1393644
+  if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
   return TOOLKIT_REGEXP.test(version);

--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -11,7 +11,7 @@ const TOOLKIT_VERSION_REGEX = /^(\d+\.?){1,3}\.(\d+([A-z]+(-?[\dA-z]+)?))$/;
 
 export function isValidVersionString(version) {
   // We should be starting with a string.
-  if (typeof version !== 'string') {
+  if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
   // If valid toolkit version string, return true early

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -103,6 +103,7 @@ describe('formats', () => {
       '1.0.0.0.0a',
       '1.0.0a-1',
       '1.0.0a1.1',
+      `1.${'9'.repeat(100)}`,
     ];
 
     validToolkitVersionStrings.forEach((validToolkitVersionString) => {

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -41,8 +41,7 @@ describe('formats', () => {
       '1.0.0-rc1.0+001',
       '0.1.12dev-cb31c51',
       '4.1.1dev-abcdef1',
-      // eslint-disable-next-line prefer-template
-      '1.9' + '9'.repeat(99),
+      `1.${'9'.repeat(100)}`,
     ];
 
     validVersionStrings.forEach((validVersionString) => {

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -33,6 +33,8 @@ describe('formats', () => {
       '2.99999',
       '3.65536',
       '1.0.0-beta2',
+      // eslint-disable-next-line prefer-template
+      '1.9' + '9'.repeat(99),
     ];
 
     validVersionStrings.forEach((validVersionString) => {


### PR DESCRIPTION
Fixes bug 1393644.

There is more work going on on this at https://github.com/mozilla/addons-linter/pull/1507 but it'd like to get this merged first.