### PR TITLE
Unify isToolkitVersionString and isValidVersionString.

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -11,7 +11,7 @@ import { MANIFEST_JSON, PACKAGE_EXTENSION, CSP_KEYWORD_RE } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
 import JSONParser from 'parsers/json';
-import { isToolkitVersionString } from 'schema/formats';
+import { isValidVersionString } from 'schema/formats';
 import { parseCspPolicy } from 'utils';
 
 function normalizePath(iconPath) {
@@ -142,7 +142,7 @@ export default class ManifestJSONParser extends JSONParser {
       this.collector.addNotice(messages.STRICT_MAX_VERSION);
     }
 
-    if (isToolkitVersionString(this.parsedJSON.version)) {
+    if (isValidVersionString(this.parsedJSON.version)) {
       this.collector.addNotice(messages.PROP_VERSION_TOOLKIT_ONLY);
     }
 

--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -10,8 +10,6 @@ const VERSION_PART =
 const BETA_PART = '(?:a(?:lpha)?|b(?:eta)?|pre|rc)\\d*';
 const VERSION_REGEXP =
   new RegExp(`^${VERSION_PART}(?:\\.${VERSION_PART}){0,3}(?:${BETA_PART})?$`);
-const TOOLKIT_REGEXP =
-  new RegExp(`^${VERSION_PART}(?:\\.${VERSION_PART}){0,3}${BETA_PART}$`);
 
 export function isValidVersionString(version) {
   // We should be starting with a string. Limit length, see bug 1393644
@@ -19,14 +17,6 @@ export function isValidVersionString(version) {
     return false;
   }
   return VERSION_REGEXP.test(version);
-}
-
-export function isToolkitVersionString(version) {
-  // We should be starting with a string. Limit length, see bug 1393644
-  if (typeof version !== 'string' || version.length > 100) {
-    return false;
-  }
-  return TOOLKIT_REGEXP.test(version);
 }
 
 export function isAbsoluteUrl(value) {

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -3,7 +3,6 @@ import {
   isAnyUrl,
   isSecureUrl,
   isStrictRelativeUrl,
-  isToolkitVersionString,
   isValidVersionString,
 } from 'schema/formats';
 
@@ -11,36 +10,49 @@ describe('formats', () => {
   describe('isValidVersionString', () => {
     const validVersionStrings = [
       '1.0',
+      '1.0.0.0b10',
+      '1.0.0alpha01',
       '1.0.0beta2',
+      '1.0a1',
+      '1a',
+      '1alpha',
+      '1b',
+      '1beta',
+      '1pre',
+      '1rc',
       '2.10.2',
       '3.1.2.4567',
       '3.1.2.65535',
-      '4.1pre1',
-      '4.1.1pre2',
       '4.1.1.2pre3',
+      '4.1.1pre2',
+      '4.1pre1',
     ];
 
     const invalidVersionStrings = [
-      2,
-      '123e5',
-      '1.',
       '.',
-      'a.b.c.d',
-      '1.2.2.2.4',
-      '1.2.2.2.4a',
+      '0.1.12dev-cb31c51',
       '01',
-      '1.01',
-      '1.01a',
+      '1.',
+      '1.0.0+1',
+      '1.0.0-beta2',
+      '1.0.0-rc1.0+001',
+      '1.0.0.0.0a',
+      '1.0.0a-1',
+      '1.0.0a1.1',
       '1.000000',
       '1.000000a1',
+      '1.01',
+      '1.01a',
+      '1.2.2.2.4',
+      '1.2.2.2.4a',
+      '123e5',
+      '1abc',
       '2.99999',
       '3.65536',
       '3.65536a1',
-      '1.0.0-beta2',
-      '1.0.0+1',
-      '1.0.0-rc1.0+001',
-      '0.1.12dev-cb31c51',
       '4.1.1dev-abcdef1',
+      'a.b.c.d',
+      2,
       `1.${'9'.repeat(100)}`,
     ];
 
@@ -53,69 +65,6 @@ describe('formats', () => {
     invalidVersionStrings.forEach((invalidVersionString) => {
       it(`should find ${invalidVersionString} to be invalid`, () => {
         expect(isValidVersionString(invalidVersionString)).toEqual(false);
-      });
-    });
-  });
-
-  describe('isToolkitVersionString', () => {
-    const validToolkitVersionStrings = [
-      '1a',
-      '1alpha',
-      '1b',
-      '1beta',
-      '1pre',
-      '1rc',
-      '1.0a1',
-      '1.0.0alpha01',
-      '1.0.0.0b10',
-      '1.0.0beta2',
-      '4.1pre1',
-      '4.1.1pre2',
-      '4.1.1.2pre3',
-    ];
-
-    const invalidToolkitVersionStrings = [
-      2,
-      '123e5',
-      '1.',
-      '.',
-      'a.b.c.d',
-      '1.2.2.2.4',
-      '1.2.2.2.4a',
-      '01',
-      '1.01',
-      '1.01a',
-      '1.000000',
-      '1.000000a1',
-      '2.99999',
-      '3.65536',
-      '3.65536a1',
-      '1.0.0-beta2',
-      '1.0.0+1',
-      '1.0.0-rc1.0+001',
-      '0.1.12dev-cb31c51',
-      '4.1.1dev-abcdef1',
-      '1.0',
-      '2.10.2',
-      '3.1.2.4567',
-      '3.1.2.65535',
-      '1abc',
-      '1.0.0.0.0a',
-      '1.0.0a-1',
-      '1.0.0a1.1',
-      `1.${'9'.repeat(100)}`,
-    ];
-
-    validToolkitVersionStrings.forEach((validToolkitVersionString) => {
-      it(`should find ${validToolkitVersionString} to be valid`, () => {
-        expect(isToolkitVersionString(validToolkitVersionString)).toEqual(true);
-      });
-    });
-
-    invalidToolkitVersionStrings.forEach((invalidToolkitVersionString) => {
-      it(`should find ${invalidToolkitVersionString} to be invalid`, () => {
-        expect(isToolkitVersionString(invalidToolkitVersionString))
-          .toEqual(false);
       });
     });
   });


### PR DESCRIPTION
They were almost identical and as far as I can tell anyway and don't
have to support toolkit specific parts such as '1.*' as they have their
own pattern.

What's more, the part that validates manifest.json:version in
parsers/manifestjson might actually be duplicate since it's already
covered by the schema? The error message is a bit more helpful though,
hmm... opinions?
