### PR TITLE
Partially revert "Fix version format regexp (#1507)"

### DIFF
--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -1,24 +1,44 @@
 import { URL } from 'whatwg-url';
 
+const VALIDNUMRX = /^[0-9]{1,5}$/;
+
 // Firefox's version format is laxer than Chrome's, it accepts:
 // https://developer.mozilla.org/en-US/docs/Toolkit_version_format
 // We choose a slightly restricted version of that format (but still more
 // permissive than Chrome) to allow Beta addons, per:
 // https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Maintenance
-const VERSION_PART =
-  '(?:0|[1-9]\\d{0,3}|[1-5]\\d{4}|6(?:[0-4]\\d{3}|5(?:[0-4]\\d{2}|5(?:[0-2]\\d|3[0-5]))))';
-const BETA_PART = '(?:a(?:lpha)?|b(?:eta)?|pre|rc)\\d*';
-const VERSION_REGEXP =
-  new RegExp(`^${VERSION_PART}(?:\\.${VERSION_PART}){0,3}(?:${BETA_PART})?$`);
-const TOOLKIT_REGEXP =
-  new RegExp(`^${VERSION_PART}(?:\\.${VERSION_PART}){0,3}${BETA_PART}$`);
+const TOOLKIT_VERSION_REGEX = /^(\d+\.?){1,3}\.(\d+([A-z]+(-?\d+)?))$/;
 
 export function isValidVersionString(version) {
   // We should be starting with a string. Limit length, see bug 1393644
   if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
-  return VERSION_REGEXP.test(version);
+  // If valid toolkit version string, return true early
+  if (TOOLKIT_VERSION_REGEX.test(version)) {
+    return true;
+  }
+  const parts = version.split('.');
+  if (parts.length > 4) {
+    return false;
+  }
+
+  for (let i = 0; i < parts.length; i++) {
+    let part = parts[i];
+    // Leading or multiple zeros not allowed.
+    if (part.startsWith('0') && part.length > 1) {
+      return false;
+    }
+    // Disallow things like 123e5 which parseInt will convert.
+    if (!VALIDNUMRX.test(part)) {
+      return false;
+    }
+    part = parseInt(part, 10);
+    if (Number.isNaN(part) || part < 0 || part > 65535) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function isToolkitVersionString(version) {
@@ -26,7 +46,7 @@ export function isToolkitVersionString(version) {
   if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
-  return TOOLKIT_REGEXP.test(version);
+  return TOOLKIT_VERSION_REGEX.test(version) && isValidVersionString(version);
 }
 
 export function isAbsoluteUrl(value) {

--- a/tests/schema/test.formats.js
+++ b/tests/schema/test.formats.js
@@ -3,7 +3,6 @@ import {
   isAnyUrl,
   isSecureUrl,
   isStrictRelativeUrl,
-  isToolkitVersionString,
   isValidVersionString,
 } from 'schema/formats';
 
@@ -11,7 +10,9 @@ describe('formats', () => {
   describe('isValidVersionString', () => {
     const validVersionStrings = [
       '1.0',
+      '1.01a',
       '1.0.0beta2',
+      '1.000000a1',
       '2.10.2',
       '3.1.2.4567',
       '3.1.2.65535',
@@ -30,12 +31,9 @@ describe('formats', () => {
       '1.2.2.2.4a',
       '01',
       '1.01',
-      '1.01a',
       '1.000000',
-      '1.000000a1',
       '2.99999',
       '3.65536',
-      '3.65536a1',
       '1.0.0-beta2',
       '1.0.0+1',
       '1.0.0-rc1.0+001',
@@ -53,69 +51,6 @@ describe('formats', () => {
     invalidVersionStrings.forEach((invalidVersionString) => {
       it(`should find ${invalidVersionString} to be invalid`, () => {
         expect(isValidVersionString(invalidVersionString)).toEqual(false);
-      });
-    });
-  });
-
-  describe('isToolkitVersionString', () => {
-    const validToolkitVersionStrings = [
-      '1a',
-      '1alpha',
-      '1b',
-      '1beta',
-      '1pre',
-      '1rc',
-      '1.0a1',
-      '1.0.0alpha01',
-      '1.0.0.0b10',
-      '1.0.0beta2',
-      '4.1pre1',
-      '4.1.1pre2',
-      '4.1.1.2pre3',
-    ];
-
-    const invalidToolkitVersionStrings = [
-      2,
-      '123e5',
-      '1.',
-      '.',
-      'a.b.c.d',
-      '1.2.2.2.4',
-      '1.2.2.2.4a',
-      '01',
-      '1.01',
-      '1.01a',
-      '1.000000',
-      '1.000000a1',
-      '2.99999',
-      '3.65536',
-      '3.65536a1',
-      '1.0.0-beta2',
-      '1.0.0+1',
-      '1.0.0-rc1.0+001',
-      '0.1.12dev-cb31c51',
-      '4.1.1dev-abcdef1',
-      '1.0',
-      '2.10.2',
-      '3.1.2.4567',
-      '3.1.2.65535',
-      '1abc',
-      '1.0.0.0.0a',
-      '1.0.0a-1',
-      '1.0.0a1.1',
-      `1.${'9'.repeat(100)}`,
-    ];
-
-    validToolkitVersionStrings.forEach((validToolkitVersionString) => {
-      it(`should find ${validToolkitVersionString} to be valid`, () => {
-        expect(isToolkitVersionString(validToolkitVersionString)).toEqual(true);
-      });
-    });
-
-    invalidToolkitVersionStrings.forEach((invalidToolkitVersionString) => {
-      it(`should find ${invalidToolkitVersionString} to be invalid`, () => {
-        expect(isToolkitVersionString(invalidToolkitVersionString))
-          .toEqual(false);
       });
     });
   });


### PR DESCRIPTION
This reverts commit 7dc81ce726457a5f5ad7fd9bbdbb642619452551

This adds the same fix to invalidate '0.1.12dev-cb31c51' and '4.1.1dev-abcdef1' though.

Might need another follow-up to (partially) fix mentioned issues from #1439 or #1172.