### PR TITLE
Added a check for type of script in warn-on-js

### DIFF
--- a/src/rules/html/warn-on-inline.js
+++ b/src/rules/html/warn-on-inline.js
@@ -6,7 +6,9 @@ export function warnOnInline($, filename) {
   return new Promise((resolve) => {
     const linterMessages = [];
     $('script').each((i, element) => {
-      if ($(element).attr('src') === undefined) {
+      if ($(element).attr('src') === undefined &&
+        ($(element).attr('type') === undefined ||
+        $(element).attr('type') === 'text/javascript')) {
         linterMessages.push(
           Object.assign({}, messages.INLINE_SCRIPT, {
             /* This could occur in any HTML file, so let's make it

--- a/tests/scanners/test.html.js
+++ b/tests/scanners/test.html.js
@@ -35,7 +35,7 @@ describe('HTML', () => {
       });
   });
 
-  it('should require <script> tag to have a src attribute', () => {
+  it('should warn on <script> tag without a src attribute and without type attribute', () => {
     const badHTML = validHTML('<script>alert()</script>');
     const htmlScanner = new HTMLScanner(badHTML, 'index.html');
 
@@ -44,6 +44,29 @@ describe('HTML', () => {
         expect(linterMessages.length).toEqual(1);
         expect(linterMessages[0].code).toEqual(messages.INLINE_SCRIPT.code);
         expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
+      });
+  });
+
+  it('should warn on <script> tag without a src attribute but a type attribute whose value is "text/javascript"', () => {
+    const badHTML = validHTML('<script type="text/javascript">alert()</script>');
+    const htmlScanner = new HTMLScanner(badHTML, 'index.html');
+
+    return htmlScanner.scan()
+      .then(({ linterMessages }) => {
+        expect(linterMessages.length).toEqual(1);
+        expect(linterMessages[0].code).toEqual(messages.INLINE_SCRIPT.code);
+        expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
+      });
+  });
+
+  it('should accept a <script> tag without a src attribute but a type attribute whose value is not "text/javascript"', () => {
+    const goodHTML = validHTML(oneLine`
+        <script type="text/html" id="my-html-template-used-in-knockout">`);
+    const htmlScanner = new HTMLScanner(goodHTML, 'index.html');
+
+    return htmlScanner.scan()
+      .then(({ linterMessages }) => {
+        expect(linterMessages.length).toEqual(0);
       });
   });
 


### PR DESCRIPTION
Fixes #1516 
before raising a warning check for type of javascript and only rise the warning if the script is of type javascript.