### PR TITLE
Added check to make sure icon has a valid extension

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -337,6 +337,8 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
+
+| :white_check_mark: | error | Web extension | Icons must have valid extension. | manifest.json | | null | WRONG_ICON_EXTENSION |
 | :white_check_mark: | error | Web extension | JSON is not well formed. | manifest.json | | null | JSON_INVALID |
 | :white_check_mark: | error | Web extension | Duplicate key in JSON. | manifest.json | | null | JSON_DUPLICATE_KEY |
 | :white_check_mark: | error | Web extension | manifest_version in manifest.json is not valid. | manifest.json | | null | MANIFEST_VERSION_INVALID |

--- a/src/const.js
+++ b/src/const.js
@@ -135,6 +135,9 @@ export const FLAGGED_FILE_EXTENSIONS = [
 
 export const IMAGE_FILE_EXTENSIONS = [
   'jpg',
+  'jpeg',
+  'webp',
+  'giff',
   'png',
   'svg',
 ];

--- a/src/const.js
+++ b/src/const.js
@@ -133,6 +133,12 @@ export const FLAGGED_FILE_EXTENSIONS = [
   '.swf',
 ];
 
+export const IMAGE_FILE_EXTENSIONS = [
+  'jpg',
+  'png',
+  'svg',
+];
+
 // A list of magic numbers that we won't allow.
 export const FLAGGED_FILE_MAGIC_NUMBERS = [
   [0x4d, 0x5a], // EXE or DLL,

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -151,7 +151,6 @@ export const NO_DEFAULT_LOCALE = {
 
 export const WRONG_ICON_EXTENSION = {
   code: 'WRONG_ICON_EXTENSION',
-  legacyCode: null,
   message: _('Unsupported image extension'),
   description: _('Icons should be one of JPG, JPEG, WebP, GIFF, PNG or SVG.'),
   file: MANIFEST_JSON,

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -153,6 +153,6 @@ export const WRONG_ICON_EXTENSION = {
   code: 'WRONG_ICON_EXTENSION',
   legacyCode: null,
   message: _('Consider Adding another icon'),
-  description: sprintf('Icons Should be of type jpg, jpeg, webp, giff, png or svg.'),
+  description: _('Icons should be one of JPG, JPEG, WebP, GIFF, PNG or SVG.'),
   file: MANIFEST_JSON,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -152,7 +152,7 @@ export const NO_DEFAULT_LOCALE = {
 export const WRONG_ICON_EXTENSION = {
   code: 'WRONG_ICON_EXTENSION',
   legacyCode: null,
-  message: _('Consider Adding another icon'),
+  message: _('Unsupported image extension'),
   description: _('Icons should be one of JPG, JPEG, WebP, GIFF, PNG or SVG.'),
   file: MANIFEST_JSON,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -148,3 +148,11 @@ export const NO_DEFAULT_LOCALE = {
     See: https://mzl.la/2hjcaEE`),
   file: MANIFEST_JSON,
 };
+
+export const WRONG_ICON_EXTENSION = {
+  code: 'WRONG_ICON_EXTENSION',
+  legacyCode: null,
+  message: _('Consider Adding another icon'),
+  description: sprintf('Icons Should be of type jpg, png or svg'),
+  file: MANIFEST_JSON,
+};

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -153,6 +153,6 @@ export const WRONG_ICON_EXTENSION = {
   code: 'WRONG_ICON_EXTENSION',
   legacyCode: null,
   message: _('Consider Adding another icon'),
-  description: sprintf('Icons Should be of type jpg, png or svg'),
+  description: sprintf('Icons Should be of type jpg, jpeg, webp, giff, png or svg.'),
   file: MANIFEST_JSON,
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -7,7 +7,7 @@ import { oneLine } from 'common-tags';
 
 import validate from 'schema/validator';
 import { getConfig } from 'cli';
-import { MANIFEST_JSON, PACKAGE_EXTENSION, CSP_KEYWORD_RE } from 'const';
+import { MANIFEST_JSON, PACKAGE_EXTENSION, CSP_KEYWORD_RE, IMAGE_FILE_EXTENSIONS } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
 import JSONParser from 'parsers/json';
@@ -176,6 +176,8 @@ export default class ManifestJSONParser extends JSONParser {
       if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
         this.collector.addError(messages.manifestIconMissing(_path));
         this.isValid = false;
+      } else if (IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop())) {
+        this.collector.addError(messages.WRONG_ICON_EXTENSION);
       }
     });
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -176,7 +176,7 @@ export default class ManifestJSONParser extends JSONParser {
       if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
         this.collector.addError(messages.manifestIconMissing(_path));
         this.isValid = false;
-      } else if (IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop())) {
+      } else if (IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
         this.collector.addError(messages.WRONG_ICON_EXTENSION);
       }
     });

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -176,8 +176,8 @@ export default class ManifestJSONParser extends JSONParser {
       if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
         this.collector.addError(messages.manifestIconMissing(_path));
         this.isValid = false;
-      } else if (IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
-        this.collector.addError(messages.WRONG_ICON_EXTENSION);
+      } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
+        this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
       }
     });
   }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -760,6 +760,5 @@ describe('ManifestJSONParser', () => {
       expect(warnings[0].code).toEqual(messages.WRONG_ICON_EXTENSION.code);
       expect(warnings[1].code).toEqual(messages.WRONG_ICON_EXTENSION.code);
     });
-
   });
 });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -740,7 +740,7 @@ describe('ManifestJSONParser', () => {
       });
     });
 
-    it('adds an error if the icon does not have a valid extension', () => {
+    it('adds a warning if the icon does not have a valid extension', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
         icons: {

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -739,5 +739,27 @@ describe('ManifestJSONParser', () => {
         description: 'Icon could not be found at "icons/icon-64.png".',
       });
     });
+
+    it('adds an error if the icon does not have a valid extension', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        icons: {
+          32: 'icons/icon-32.txt',
+          64: 'icons/icon-64.html',
+        },
+      });
+      const files = {
+        'icons/icon-32.txt': '89<PNG>thisistotallysomebinary',
+        'icons/icon-64.html': '89<PNG>thisistotallysomebinary',
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, { io: { files } });
+      expect(manifestJSONParser.isValid).toBeTruthy();
+      const warnings = addonLinter.collector.warnings;
+      expect(warnings.length).toEqual(2);
+      expect(warnings[0].code).toEqual(messages.WRONG_ICON_EXTENSION.code);
+      expect(warnings[1].code).toEqual(messages.WRONG_ICON_EXTENSION.code);
+    });
+
   });
 });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -746,11 +746,13 @@ describe('ManifestJSONParser', () => {
         icons: {
           32: 'icons/icon-32.txt',
           64: 'icons/icon-64.html',
+          128: 'icons/icon-128.png',
         },
       });
       const files = {
         'icons/icon-32.txt': '89<PNG>thisistotallysomebinary',
         'icons/icon-64.html': '89<PNG>thisistotallysomebinary',
+        'icons/icon-128.png': '89<PNG>thisistotallysomebinary',
       };
       const manifestJSONParser = new ManifestJSONParser(
         json, addonLinter.collector, { io: { files } });


### PR DESCRIPTION
Fixes #1328

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.

Added a check to make sure that the icon has a valid extension. Gives a warning in case the extension of the image doesn't match a valid image format.
The valid extensions included for now are :   jpg, jpeg, webp, giff, png, svg