### PR TITLE
Gives warning when a API is used without permission

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -338,6 +338,7 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 
+| :white_check_mark: | warning | Web extension | Used API X but didn't take permission Y. | manifest.json | | null | PERMISSIONS_API |
 | :white_check_mark: | error | Web extension | Icons must have valid extension. | manifest.json | | null | WRONG_ICON_EXTENSION |
 | :white_check_mark: | error | Web extension | JSON is not well formed. | manifest.json | | null | JSON_INVALID |
 | :white_check_mark: | error | Web extension | Duplicate key in JSON. | manifest.json | | null | JSON_DUPLICATE_KEY |

--- a/src/const.js
+++ b/src/const.js
@@ -3,6 +3,7 @@ import {
   NO_IMPLIED_EVAL,
   UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT,
   UNSUPPORTED_API,
+  PERMISSIONS_API,
 } from 'messages/javascript';
 
 // eslint-disable-next-line import/extensions
@@ -31,6 +32,7 @@ export const ESLINT_RULE_MAPPING = Object.assign({
   'opendialog-nonlit-uri': ESLINT_WARNING,
   'opendialog-remote-uri': ESLINT_WARNING,
   'webextension-api': ESLINT_WARNING,
+  'webextension-permissions-api': ESLINT_WARNING,
   'webextension-unsupported-api': ESLINT_WARNING,
 }, EXTERNAL_RULE_MAPPING);
 
@@ -38,6 +40,7 @@ export const ESLINT_OVERWRITE_MESSAGE = {
   'no-eval': DANGEROUS_EVAL,
   'no-implied-eval': NO_IMPLIED_EVAL,
   'no-new-func': DANGEROUS_EVAL,
+  'webextension-permissions-api': PERMISSIONS_API,
   'no-unsafe-innerhtml/no-unsafe-innerhtml': UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT,
   'webextension-unsupported-api': UNSUPPORTED_API,
 };

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -126,6 +126,13 @@ export const UNSUPPORTED_API = {
   description: _('This API has not been implemented by Firefox.'),
 };
 
+export const PERMISSIONS_API = {
+  code: 'PERMISSIONS_API',
+  message: null,
+  messageFormat: _(' API has been used but '),
+  description: _('Used API without permission'),
+};
+
 function deprecatedAPI(api) {
   return {
     code: apiToMessage(api),

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -14,6 +14,8 @@ import JSONParser from 'parsers/json';
 import { isToolkitVersionString } from 'schema/formats';
 import { parseCspPolicy } from 'utils';
 
+let parsedJSON;
+
 function normalizePath(iconPath) {
   // Convert the icon path to a URL so we can strip any fragments and resolve
   // . and .. automatically. We need an absolute URL to use as a base so we're
@@ -129,6 +131,10 @@ export default class ManifestJSONParser extends JSONParser {
       this.validateIcons();
     }
 
+    if (this.parsedJSON.permissions){
+      this.getPermissionJSON();
+    }
+
     if (this.parsedJSON.background) {
       if (this.parsedJSON.background.scripts) {
         this.parsedJSON.background.scripts.forEach((script) => {
@@ -182,15 +188,21 @@ export default class ManifestJSONParser extends JSONParser {
 
   validateIcons() {
     const { icons } = this.parsedJSON;
-    Object.keys(icons).forEach((size) => {
-      const _path = normalizePath(icons[size]);
-      if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
-        this.collector.addError(messages.manifestIconMissing(_path));
-        this.isValid = false;
-      } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
-        this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
-      }
-    });
+    if (Object.keys(icons)) {
+      Object.keys(icons).forEach((size) => {
+        const _path = normalizePath(icons[size]);
+        if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
+          this.collector.addError(messages.manifestIconMissing(_path));
+          this.isValid = false;
+        } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
+          this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
+        }
+      });
+    }
+  }
+
+  getPermissionJSON() {
+    parsedJSON = this.parsedJSON.permissions;
   }
 
   validateFileExistsInPackage(filePath, type) {
@@ -273,4 +285,8 @@ export default class ManifestJSONParser extends JSONParser {
       version: this.parsedJSON.version,
     };
   }
+}
+
+export function getParsedJSON() {
+  return parsedJSON;
 }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -131,7 +131,7 @@ export default class ManifestJSONParser extends JSONParser {
       this.validateIcons();
     }
 
-    if (this.parsedJSON.permissions){
+    if (this.parsedJSON.permissions) {
       this.getPermissionJSON();
     }
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -14,7 +14,7 @@ import JSONParser from 'parsers/json';
 import { isToolkitVersionString } from 'schema/formats';
 import { parseCspPolicy } from 'utils';
 
-let parsedJSON;
+let parsedJSONPermissions;
 
 function normalizePath(iconPath) {
   // Convert the icon path to a URL so we can strip any fragments and resolve
@@ -132,7 +132,7 @@ export default class ManifestJSONParser extends JSONParser {
     }
 
     if (this.parsedJSON.permissions) {
-      this.getPermissionJSON();
+      parsedJSONPermissions = this.parsedJSON.permissions;
     }
 
     if (this.parsedJSON.background) {
@@ -188,21 +188,15 @@ export default class ManifestJSONParser extends JSONParser {
 
   validateIcons() {
     const { icons } = this.parsedJSON;
-    if (Object.keys(icons)) {
-      Object.keys(icons).forEach((size) => {
-        const _path = normalizePath(icons[size]);
-        if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
-          this.collector.addError(messages.manifestIconMissing(_path));
-          this.isValid = false;
-        } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
-          this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
-        }
-      });
-    }
-  }
-
-  getPermissionJSON() {
-    parsedJSON = this.parsedJSON.permissions;
+    Object.keys(icons).forEach((size) => {
+      const _path = normalizePath(icons[size]);
+      if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
+        this.collector.addError(messages.manifestIconMissing(_path));
+        this.isValid = false;
+      } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
+        this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
+      }
+    });
   }
 
   validateFileExistsInPackage(filePath, type) {
@@ -288,5 +282,5 @@ export default class ManifestJSONParser extends JSONParser {
 }
 
 export function getParsedJSON() {
-  return parsedJSON;
+  return parsedJSONPermissions;
 }

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -14,5 +14,7 @@ module.exports = {
     'webextension-api': require('./webextension-api').default,
     'webextension-unsupported-api':
       require('./webextension-unsupported-api').default,
+    'webextension-permissions-api':
+      require('./webextension-permissions-api').default,
   },
 };

--- a/src/rules/javascript/webextension-permissions-api.js
+++ b/src/rules/javascript/webextension-permissions-api.js
@@ -15,9 +15,9 @@ export default {
           const contents = getParsedJSON();
           const permissionsNotTaken = doesExistInPermissions(permissionsNeeded, contents);
           if (permissionsNotTaken) {
-            for (let i = 0; i < permissionsNotTaken.length ; i++) {
-              context.report(node, namespace + PERMISSIONS_API.messageFormat +
-              permissionsNotTaken[i] + ' permission has not been taken');
+            for (let i = 0; i < permissionsNotTaken.length; i++) {
+              context.report(node, `${namespace} ${PERMISSIONS_API.messageFormat}` +
+              `${permissionsNotTaken[i]} permission has not been taken`);
             }
           }
         }

--- a/src/rules/javascript/webextension-permissions-api.js
+++ b/src/rules/javascript/webextension-permissions-api.js
@@ -1,0 +1,27 @@
+import { permissionNeeded } from 'schema/browser-apis';
+import { PERMISSIONS_API } from 'messages/javascript';
+import { getParsedJSON } from 'parsers/manifestjson';
+import { doesExistInPermissions } from 'utils';
+
+export default {
+  create(context) {
+    return {
+    // eslint-disable-next-line consistent-return
+      MemberExpression(node) {
+        if (node.object.object) {
+          const namespace = node.object.property.name;
+          const property = node.property.name;
+          const permissionsNeeded = permissionNeeded(namespace, property);
+          const contents = getParsedJSON();
+          const permissionsNotTaken = doesExistInPermissions(permissionsNeeded, contents);
+          if (permissionsNotTaken) {
+            for (let i = 0; i < permissionsNotTaken.length ; i++) {
+              context.report(node, namespace + PERMISSIONS_API.messageFormat +
+              permissionsNotTaken[i] + ' permission has not been taken');
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/schema/browser-apis.js
+++ b/src/schema/browser-apis.js
@@ -46,3 +46,29 @@ export function hasBrowserApi(namespace, property) {
   return hasObjectProperty(schema, property)
     || hasArrayProperty(schema, property);
 }
+
+function insertPermissions(permissionsNeeded, schema) {
+  if (schema) {
+    for (let i = 0; i < schema.length; i++) {
+      permissionsNeeded.push(schema[i]);
+    }
+  }
+}
+
+export function permissionNeeded(namespace, property) {
+  const permissionsNeeded = [];
+  if (schemas[namespace]) {
+    let schema = schemas[namespace].permissions;
+    const schemaProperty = schemas[namespace].functions;
+    insertPermissions(permissionsNeeded, schema);
+    if (schemaProperty) {
+      for (let i = 0; i < schemaProperty.length; i++) {
+        if (schemaProperty[i].name === property) {
+          schema = schemaProperty[i].permissions;
+          insertPermissions(permissionsNeeded, schema);
+        }
+      }
+    }
+  }
+  return permissionsNeeded;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,26 +138,20 @@ export function checkMinNodeVersion(minVersion, _process = process) {
   });
 }
 
+function include(arr, obj) {
+  return (arr.indexOf(obj) !== -1);
+}
+
 export function doesExistInPermissions(permissionsNeeded, contents) {
-  let flagDidFindPermission = false;
   const permissionsArray = [];
   const contentsTemp = contents;
   // if (!contents) {
   //   contentsTemp = [];
   // }
-  if (permissionsNeeded) {
+  if (permissionsNeeded && contentsTemp) {
     for (let i = 0; i < permissionsNeeded.length; i++) {
-      flagDidFindPermission = false;
-      if (contentsTemp) {
-        for (let j = 0; j < contentsTemp.length; j++) {
-          if (contentsTemp[j] === permissionsNeeded[i]) {
-            flagDidFindPermission = true;
-            break;
-          }
-        }
-        if (!flagDidFindPermission) {
-          permissionsArray.push(permissionsNeeded[i]);
-        }
+      if (!include(contentsTemp, permissionsNeeded[i])) {
+        permissionsArray.push(permissionsNeeded[i]);
       }
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,6 +138,31 @@ export function checkMinNodeVersion(minVersion, _process = process) {
   });
 }
 
+export function doesExistInPermissions(permissionsNeeded, contents) {
+  let flagDidFindPermission = false;
+  const permissionsArray = [];
+  const contentsTemp = contents;
+  // if (!contents) {
+  //   contentsTemp = [];
+  // }
+  if (permissionsNeeded) {
+    for (let i = 0; i < permissionsNeeded.length; i++) {
+      flagDidFindPermission = false;
+      if (contentsTemp) {
+        for (let j = 0; j < contentsTemp.length; j++) {
+          if (contentsTemp[j] === permissionsNeeded[i]) {
+            flagDidFindPermission = true;
+            break;
+          }
+        }
+        if (!flagDidFindPermission) {
+          permissionsArray.push(permissionsNeeded[i]);
+        }
+      }
+    }
+  }
+  return permissionsArray;
+}
 
 export function getPackageTypeAsString(numericPackageType) {
   const packageKeys = Object.keys(PACKAGE_TYPES);


### PR DESCRIPTION
Fixes issue #978

* [x] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.

Added a new rule (webextension-permission-api) which checks if a certain API is being used without a permission
