### PR TITLE
Add support for SVG fragment identifier

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -187,8 +187,17 @@ export default class ManifestJSONParser extends JSONParser {
       if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
         this.collector.addError(messages.manifestIconMissing(_path));
         this.isValid = false;
-      } else if (!IMAGE_FILE_EXTENSIONS.includes(icons[size].split('.').pop().toLowerCase())) {
-        this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
+      } else {
+        let isImageFileExtension = false;
+        for (const ext of IMAGE_FILE_EXTENSIONS) {
+          isImageFileExtension = _path.endsWith(`.${ext}`);
+          if (isImageFileExtension) {
+            break;
+          }
+        }
+        if (!isImageFileExtension) {
+          this.collector.addWarning(messages.WRONG_ICON_EXTENSION);
+        }
       }
     });
   }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -745,7 +745,9 @@ describe('ManifestJSONParser', () => {
       const json = validManifestJSON({
         icons: {
           32: 'icons/icon-32.txt',
+          48: 'icons/icon.svg#frag',
           64: 'icons/icon-64.html',
+          96: 'icons/icons.svg',
           128: 'icons/icon-128.png',
         },
       });
@@ -753,6 +755,7 @@ describe('ManifestJSONParser', () => {
         'icons/icon-32.txt': '89<PNG>thisistotallysomebinary',
         'icons/icon-64.html': '89<PNG>thisistotallysomebinary',
         'icons/icon-128.png': '89<PNG>thisistotallysomebinary',
+        'icons/icon.svg': '<svg></svg>',
       };
       const manifestJSONParser = new ManifestJSONParser(
         json, addonLinter.collector, { io: { files } });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -747,7 +747,7 @@ describe('ManifestJSONParser', () => {
           32: 'icons/icon-32.txt',
           48: 'icons/icon.svg#frag',
           64: 'icons/icon-64.html',
-          96: 'icons/icons.svg',
+          96: 'icons/icon.svg',
           128: 'icons/icon-128.png',
         },
       });


### PR DESCRIPTION
Fix #1601

Fix wrong warning when SVG fragment identifier is used in icon.

* [ ✓ ] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [ ✓ ] Add `Fixes #ISSUENUM` at the top of your PR.
* [ ✓ ] Add a description of the the changes introduced in this PR.
* [ ✓ ] The change has been successfully run locally.
* [ ✓ ] Add tests to cover the changes added in this PR.
