### PR TITLE
Fixes #1616: Fix zip decoding when hitting an encoding boundary between two chunks;

### DIFF
--- a/src/io/xpi.js
+++ b/src/io/xpi.js
@@ -123,13 +123,14 @@ export class Xpi extends IOBase {
     return this.getFileAsStream(path)
       .then((fileStream) => {
         return new Promise((resolve, reject) => {
-          let fileString = '';
+          let buf = new Buffer('');
           fileStream.on('data', (chunk) => {
-            fileString += chunk;
+            buf = Buffer.concat([buf, chunk]);
           });
 
           // Once the file is assembled, resolve the promise.
           fileStream.on('end', () => {
+            const fileString = buf.toString('utf8');
             resolve(fileString);
           });
 


### PR DESCRIPTION
* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [ ] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.

The issue is that we hit a boundary between the two bytes encoding an utf8 char: say we have a char that has encoding \a\b, a first zip chunk is read and ends with \a, the second one starts with \b, but the current implementation thinks these are two different chars.

Instead, we should store the data in a raw byte buffer and do the conversion to utf8 at the end.

The test is basically the whole grammalecte zip file, which needs this precise file layout (to match the internal zip chunk size), so not sure how useful it is to include it here.

@diox, can you have a look, please? Thanks!