### PR TITLE
fixes #1590 for scripts/css files declared in manifest.json

### DIFF
--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -128,14 +128,38 @@ export function manifestIconMissing(path) {
   };
 }
 
-export const MANIFEST_DECLARED_FILE_NOT_FOUND = 'MANIFEST_DECLARED_FILE_NOT_FOUND';
-export function manifestDeclaredFileMissing(path, type) {
+export const MANIFEST_BACKGROUND_FILE_NOT_FOUND = 'MANIFEST_BACKGROUND_FILE_NOT_FOUND';
+export function manifestBackgroundMissing(path, type) {
   return {
-    code: MANIFEST_DECLARED_FILE_NOT_FOUND,
+    code: MANIFEST_BACKGROUND_FILE_NOT_FOUND,
     legacyCode: null,
-    message: `${type} file declared in the manifest could not be found.`,
+    message: type === 'script' ?
+      'A background script defined in the manifest could not be found.' :
+      'A background page defined in the manifest could not be found.',
     description:
-      sprintf(_(`${type} file declared in manifest could not be found at "%(path)s".`),
+      sprintf(
+        type === 'script' ?
+          _('Background script could not be found at "%(path)s".') :
+          _('Background page could not be found at "%(path)s".'),
+        { path }
+      ),
+    file: MANIFEST_JSON,
+  };
+}
+
+export const MANIFEST_CONTENT_SCRIPT_FILE_NOT_FOUND = 'MANIFEST_CONTENT_SCRIPT_FILE_NOT_FOUND';
+export function manifestContentScriptFileMissing(path, type) {
+  return {
+    code: MANIFEST_CONTENT_SCRIPT_FILE_NOT_FOUND,
+    legacyCode: null,
+    message: type === 'script' ?
+      'A content script defined in the manifest could not be found.' :
+      'A content script css file defined in the manifest could not be found.',
+    description:
+      sprintf(
+        type === 'script' ?
+          _('Content script defined in the manifest could not be found at "%(path)s".') :
+          _('Content script css file defined in the manifest could not be found at "%(path)s".'),
         { path }
       ),
     file: MANIFEST_JSON,

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -128,19 +128,14 @@ export function manifestIconMissing(path) {
   };
 }
 
-export const MANIFEST_BACKGROUND_FILE_NOT_FOUND = 'MANIFEST_BACKGROUND_FILE_NOT_FOUND';
-export function manifestBackgroundMissing(path, type) {
+export const MANIFEST_DECLARED_FILE_NOT_FOUND = 'MANIFEST_DECLARED_FILE_NOT_FOUND';
+export function manifestDeclaredFileMissing(path, type) {
   return {
-    code: MANIFEST_BACKGROUND_FILE_NOT_FOUND,
+    code: MANIFEST_DECLARED_FILE_NOT_FOUND,
     legacyCode: null,
-    message: type === 'script' ?
-      'A background script defined in the manifest could not be found.' :
-      'A background page defined in the manifest could not be found.',
+    message: `${type} file declared in the manifest could not be found.`,
     description:
-      sprintf(
-        type === 'script' ?
-          _('Background script could not be found at "%(path)s".') :
-          _('Background page could not be found at "%(path)s".'),
+      sprintf(_(`${type} file declared in manifest could not be found at "%(path)s".`),
         { path }
       ),
     file: MANIFEST_JSON,

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -159,12 +159,12 @@ export default class ManifestJSONParser extends JSONParser {
       this.parsedJSON.content_scripts.forEach((scriptRule) => {
         if (scriptRule.js && scriptRule.js.length) {
           scriptRule.js.forEach((script) => {
-            this.validateFileExistsInPackage(script, 'script');
+            this.validateFileExistsInPackage(script, 'script', messages.manifestContentScriptFileMissing);
           });
         }
         if (scriptRule.css && scriptRule.css.length) {
           scriptRule.css.forEach((style) => {
-            this.validateFileExistsInPackage(style, 'css');
+            this.validateFileExistsInPackage(style, 'css', messages.manifestContentScriptFileMissing);
           });
         }
       });
@@ -246,10 +246,10 @@ export default class ManifestJSONParser extends JSONParser {
     return Promise.all(promises);
   }
 
-  validateFileExistsInPackage(filePath, type) {
+  validateFileExistsInPackage(filePath, type, messageFunc = messages.manifestBackgroundMissing) {
     const _path = normalizePath(filePath);
     if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
-      this.collector.addError(messages.manifestDeclaredFileMissing(
+      this.collector.addError(messageFunc(
         _path, type));
       this.isValid = false;
     }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -155,6 +155,21 @@ export default class ManifestJSONParser extends JSONParser {
       }
     }
 
+    if (this.parsedJSON.content_scripts && this.parsedJSON.content_scripts.length) {
+      this.parsedJSON.content_scripts.forEach((scriptRule) => {
+        if (scriptRule.js && scriptRule.js.length) {
+          scriptRule.js.forEach((script) => {
+            this.validateFileExistsInPackage(script, 'script');
+          });
+        }
+        if (scriptRule.css && scriptRule.css.length) {
+          scriptRule.css.forEach((style) => {
+            this.validateFileExistsInPackage(style, 'css');
+          });
+        }
+      });
+    }
+
     if (!this.selfHosted && this.parsedJSON.applications &&
         this.parsedJSON.applications.gecko &&
         this.parsedJSON.applications.gecko.update_url) {
@@ -234,7 +249,7 @@ export default class ManifestJSONParser extends JSONParser {
   validateFileExistsInPackage(filePath, type) {
     const _path = normalizePath(filePath);
     if (!Object.prototype.hasOwnProperty.call(this.io.files, _path)) {
-      this.collector.addError(messages.manifestBackgroundMissing(
+      this.collector.addError(messages.manifestDeclaredFileMissing(
         _path, type));
       this.isValid = false;
     }

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -875,9 +875,10 @@ describe('ManifestJSONParser', () => {
         json, linter.collector, { io: { files: {} } });
       expect(manifestJSONParser.isValid).toBeFalsy();
       assertHasMatchingError(linter.collector.errors, {
-        code: messages.MANIFEST_DECLARED_FILE_NOT_FOUND,
-        message: 'script file declared in the manifest could not be found.',
-        description: 'script file declared in manifest could not be found at "foo.js".',
+        code: messages.MANIFEST_BACKGROUND_FILE_NOT_FOUND,
+        message:
+          'A background script defined in the manifest could not be found.',
+        description: 'Background script could not be found at "foo.js".',
       });
     });
 
@@ -900,10 +901,10 @@ describe('ManifestJSONParser', () => {
         json, linter.collector, { io: { files: {} } });
       expect(manifestJSONParser.isValid).toBeFalsy();
       assertHasMatchingError(linter.collector.errors, {
-        code: messages.MANIFEST_DECLARED_FILE_NOT_FOUND,
+        code: messages.MANIFEST_BACKGROUND_FILE_NOT_FOUND,
         message:
-          'page file declared in the manifest could not be found.',
-        description: 'page file declared in manifest could not be found at "foo.html".',
+          'A background page defined in the manifest could not be found.',
+        description: 'Background page could not be found at "foo.html".',
       });
     });
   });
@@ -936,9 +937,9 @@ describe('ManifestJSONParser', () => {
         json, linter.collector, { io: { files: { 'content_scripts/bar.css': '' } } });
       expect(manifestJSONParser.isValid).toBeFalsy();
       assertHasMatchingError(linter.collector.errors, {
-        code: messages.MANIFEST_DECLARED_FILE_NOT_FOUND,
-        message: 'script file declared in the manifest could not be found.',
-        description: 'script file declared in manifest could not be found at "content_scripts/foo.js".',
+        code: messages.MANIFEST_CONTENT_SCRIPT_FILE_NOT_FOUND,
+        message: 'A content script defined in the manifest could not be found.',
+        description: 'Content script defined in the manifest could not be found at "content_scripts/foo.js".',
       });
     });
 
@@ -955,9 +956,9 @@ describe('ManifestJSONParser', () => {
         json, linter.collector, { io: { files: { 'content_scripts/foo.js': '' } } });
       expect(manifestJSONParser.isValid).toBeFalsy();
       assertHasMatchingError(linter.collector.errors, {
-        code: messages.MANIFEST_DECLARED_FILE_NOT_FOUND,
-        message: 'css file declared in the manifest could not be found.',
-        description: 'css file declared in manifest could not be found at "content_scripts/bar.css".',
+        code: messages.MANIFEST_CONTENT_SCRIPT_FILE_NOT_FOUND,
+        message: 'A content script css file defined in the manifest could not be found.',
+        description: 'Content script css file defined in the manifest could not be found at "content_scripts/bar.css".',
       });
     });
   });


### PR DESCRIPTION
adds existence validation for scripts and css files declared in manifest.json under content_scripts