### PR TITLE
Remove 'alt-right' from badwords.

### DIFF
--- a/src/badwords.json
+++ b/src/badwords.json
@@ -1,7 +1,6 @@
 {
   "en": [
     "ahole",
-    "alt-right",
     "altright",
     "anal",
     "analprobe",


### PR DESCRIPTION
Fixes #1656 