### PR TITLE
Switch dependency to probe-image-size

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "probe-image-size": "3.2.0",
     "relaxed-json": "1.0.1",
     "semver": "5.4.1",
-    "sharp": "0.18.1",
     "source-map-support": "0.4.18",
     "strip-bom-stream": "3.0.0",
     "whatwg-url": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "jed": "1.1.1",
     "pino": "^4.6.0",
     "postcss": "6.0.14",
+    "probe-image-size": "3.2.0",
     "relaxed-json": "1.0.1",
     "semver": "5.4.1",
     "sharp": "0.18.1",

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -4,7 +4,8 @@ import path from 'path';
 import RJSON from 'relaxed-json';
 import { URL } from 'whatwg-url';
 import { oneLine } from 'common-tags';
-import sharp from 'sharp';
+//import sharp from 'sharp';
+import probeImageSize from 'probe-image-size';
 
 import { validateAddon, validateLangPack } from 'schema/validator';
 import { getConfig } from 'cli';
@@ -26,6 +27,8 @@ function normalizePath(iconPath) {
 }
 
 function getImageMetadata(io, iconPath) {
+  return probeImageSize(iconPath);
+  /*
   return io.getFileAsStream(iconPath)
     .then((fileStream) => {
       return new Promise((resolve, reject) => {
@@ -38,6 +41,7 @@ function getImageMetadata(io, iconPath) {
         }));
       });
     });
+  */
 }
 
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -27,7 +27,10 @@ function normalizePath(iconPath) {
 }
 
 function getImageMetadata(io, iconPath) {
-  return probeImageSize(iconPath);
+  return io.getFileAsStream(iconPath)
+    .then((fileStream) => {
+      return probeImageSize(fileStream);
+    });
   /*
   return io.getFileAsStream(iconPath)
     .then((fileStream) => {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -229,7 +229,8 @@ export default class ManifestJSONParser extends JSONParser {
               if (info.width !== info.height) {
                 this.collector.addError(messages.iconIsNotSquare(_path));
                 this.isValid = false;
-              } else if (parseInt(info.width, 10) !== parseInt(size, 10)) {
+              } else if (info.mime !== 'image/svg+xml' &&
+                         parseInt(info.width, 10) !== parseInt(size, 10)) {
                 this.collector.addWarning(messages.iconSizeInvalid({
                   path: _path,
                   expected: parseInt(size, 10),

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -4,7 +4,6 @@ import path from 'path';
 import RJSON from 'relaxed-json';
 import { URL } from 'whatwg-url';
 import { oneLine } from 'common-tags';
-//import sharp from 'sharp';
 import probeImageSize from 'probe-image-size';
 
 import { validateAddon, validateLangPack } from 'schema/validator';
@@ -27,24 +26,7 @@ function normalizePath(iconPath) {
 }
 
 function getImageMetadata(io, iconPath) {
-  return io.getFileAsStream(iconPath)
-    .then((fileStream) => {
-      return probeImageSize(fileStream);
-    });
-  /*
-  return io.getFileAsStream(iconPath)
-    .then((fileStream) => {
-      return new Promise((resolve, reject) => {
-        fileStream.pipe(sharp().metadata((err, info) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(info);
-          }
-        }));
-      });
-    });
-  */
+  return io.getFileAsStream(iconPath).then(probeImageSize);
 }
 
 

--- a/tests/fixtures/icon.svg
+++ b/tests/fixtures/icon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="64" width="64"
+     viewBox="0 0 64 64">
+  <style>
+    g {
+      fill: transparent;
+    }
+    g:not(:target):not(#red),
+    g:target ~ #red {
+      display: none;
+    }
+    #blue {
+      stroke: blue;
+    }
+    #red {
+      stroke: red;
+    }
+  </style>
+  <symbol id="icon">
+    <circle cx="32" cy="32" r="24" stroke-width="16"/>
+  </symbol>
+  <g id="blue">
+    <use href="#icon"/>
+  </g>
+  <g id="red">
+    <use href="#icon"/>
+  </g>
+</svg>

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -852,6 +852,26 @@ describe('ManifestJSONParser', () => {
         });
     });
 
+    it('does not add a warning if the icon is SVG but the image size is not the same as mentioned', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        icons: {
+          32: 'tests/fixtures/icon.svg',
+        },
+      });
+      const files = {
+        'tests/fixtures/icon.svg': fs.createReadStream('tests/fixtures/icon.svg'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json, addonLinter.collector, { io: getStreamableIO(files) });
+      return manifestJSONParser.validateIcons()
+        .then(() => {
+          expect(manifestJSONParser.isValid).toBeTruthy();
+          const { warnings } = addonLinter.collector;
+          expect(warnings.length).toEqual(0);
+        });
+    });
+
     it('adds an error if the dimensions of the image are not the same', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({


### PR DESCRIPTION
Fixes #1668, #1669

'sharp' requires Python executable when installing, but Python is not installed by default on Windows, so we should replace 'sharp' to something else.

Fixed SVG icon size mismatch warning too.

Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

Please delete anything that isn't relevant to your patch.

* [✓] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [✓] Add `Fixes #ISSUENUM` at the top of your PR.
* [✓] Add a description of the the changes introduced in this PR.
* [✓] The change has been successfully run locally.
* [✓] Add tests to cover the changes added in this PR.

Once you have met the above requirements please replace this section with
a `Fixes #ISSUENUM` linking to the issue fixed by this PR along with an
explanation of the changes. Thanks for your contribution!
