### PR TITLE
fix: prevent Object properties to be detected as existent files by tabs.executeScript rule

### DIFF
--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -38,7 +38,7 @@ export default {
           }
           const normalizedName = normalizePath(fileValue);
           // If file exists then we are good.
-          if (normalizedName in existingFiles) {
+          if (Object.prototype.hasOwnProperty.call(existingFiles, normalizedName)) {
             return;
           }
           // File not exists report an issue.

--- a/tests/rules/javascript/test.content_scripts_file_absent.js
+++ b/tests/rules/javascript/test.content_scripts_file_absent.js
@@ -14,14 +14,23 @@ function createJsScanner(code, validatedFilename, existingFiles = {}) {
 
 describe('content_scripts_file_absent', () => {
   it('should show an error when content script is missing', async () => {
-    const code = `browser.tabs.executeScript({ file: '/content_scripts/absentFile.js' });`;
-    const fileRequiresContentScript = 'file-requires-content-script.js';
-    const jsScanner = createJsScanner(code, fileRequiresContentScript);
+    const nonExistentFiles = [
+      'absentFile.js',
 
-    const { linterMessages } = await jsScanner.scan();
-    expect(linterMessages.length).toEqual(1);
-    expect(linterMessages[0].code).toEqual(CONTENT_SCRIPT_NOT_FOUND.code);
-    expect(linterMessages[0].type).toEqual(VALIDATION_ERROR);
+      // Check that the rule is not detecting Object properties as existent files.
+      'constructor',
+    ];
+
+    nonExistentFiles.forEach(async (filename) => {
+      const code = `browser.tabs.executeScript({ file: '${filename}' });`;
+      const fileRequiresContentScript = 'file-requires-content-script.js';
+      const jsScanner = createJsScanner(code, fileRequiresContentScript);
+
+      const { linterMessages } = await jsScanner.scan();
+      expect(linterMessages.length).toEqual(1);
+      expect(linterMessages[0].code).toEqual(CONTENT_SCRIPT_NOT_FOUND.code);
+      expect(linterMessages[0].type).toEqual(VALIDATION_ERROR);
+    });
   });
 
   it('should not show an error when content script file exists', async () => {


### PR DESCRIPTION
This PR fix a small issue in the rule that checks if the files used in a tabs.executeScript API calls actually exist (even if it is unlikely that an extension would call one of its content script file "constructor", or like other Object properties, the rule is supposed to raise an error if the filename is not an actual property of the existingFiles object).