### PR TITLE
Added merge-locales script

### DIFF
--- a/bin/merge-locales
+++ b/bin/merge-locales
@@ -1,0 +1,17 @@
+const path = require('path');
+
+const glob = require('glob');
+const shell = require('shelljs');
+
+const localeDir = path.join(__dirname, '../locale');
+
+const poFiles = glob.sync(`${localeDir}/**/messages.po`);
+const template = path.join(localeDir, `templates/LC_MESSAGES/messages.pot`);
+
+poFiles.forEach((poFile) => {
+  const dir = path.dirname(poFile);
+  const stem = path.basename(poFile, '.po');
+  const tempFile = path.join(dir, `${stem}.po.tmp`);
+  shell.exec(`msgmerge -q -o ${tempFile} ${poFile} ${template}`);
+  shell.mv(tempFile, poFile);
+});

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "esprima": "3.1.3",
     "first-chunk-stream": "2.0.0",
     "fluent": "0.4.1",
+    "glob": "7.1.2",
     "jed": "1.1.1",
     "pino": "4.10.3",
     "postcss": "6.0.14",


### PR DESCRIPTION
In Reference to #1535
This PR adds the merge-locales script in the bin folder to facilitate g merging of po files with pot files for translators during translation.