### PR TITLE
refactor normalizePath handling

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ export function normalizePath(filePath) {
   // . and .. automatically. We need an absolute URL to use as a base so we're
   // using https://example.com/.
   const { pathname } = new URL(filePath, 'https://example.com/');
-  return decodeURIComponent(pathname).slice(1).replace(/[/]/g, path.sep);
+  return decodeURIComponent(pathname).slice(1).replace(/\//g, path.sep);
 }
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ export function normalizePath(filePath) {
   // using https://example.com/.
   const { pathname } = new URL(filePath, 'https://example.com/');
   // Split pathname into directories and join them with OS specific separator.
-  // Also we need to strip leading slash '/' from pathname.
+  // We also need to strip leading slash '/' from pathname.
   // Decode component which is encoded when converting to a URL, for example
   // space (%20).
   return pathname.split('/').reduce((prior, component) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,8 +21,9 @@ export function normalizePath(filePath) {
   // Decode components which is encoded when converting to a URL, for example
   // space (%20).
   const dir = pathname.split("/");
-  return dir.reduce((p, c) =>
-    p && path.join(p, decodeURIComponent(c)) || decodeURIComponent(c)
+  return dir.reduce((prior, component) =>
+    prior && path.join(prior, decodeURIComponent(component)) ||
+    decodeURIComponent(component)
   );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,9 +24,8 @@ export function normalizePath(filePath) {
   return components.reduce((prior, component) => {
     if (prior) {
       return path.join(prior, decodeURIComponent(component));
-    } else {
-      return decodeURIComponent(component);
     }
+    return decodeURIComponent(component);
   });
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,16 +16,7 @@ export function normalizePath(filePath) {
   // . and .. automatically. We need an absolute URL to use as a base so we're
   // using https://example.com/.
   const { pathname } = new URL(filePath, 'https://example.com/');
-  // Split pathname into directories and join them with OS specific separator.
-  // We also need to strip leading slash '/' from pathname.
-  // Decode component which is encoded when converting to a URL, for example
-  // space (%20).
-  return pathname.split('/').reduce((prior, component) => {
-    if (prior) {
-      return path.join(prior, decodeURIComponent(component));
-    }
-    return decodeURIComponent(component);
-  });
+  return decodeURIComponent(pathname).slice(1).replace(/[/]/g, path.sep);
 }
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,14 +17,17 @@ export function normalizePath(filePath) {
   // using https://example.com/.
   const { pathname } = new URL(filePath, 'https://example.com/');
   // Split pathname into directories and join them with OS specific separator.
-  // Also strip leading slash '/'.
-  // Decode components which is encoded when converting to a URL, for example
+  // Also we need to strip leading slash '/' from pathname.
+  // Decode component which is encoded when converting to a URL, for example
   // space (%20).
-  const dir = pathname.split("/");
-  return dir.reduce((prior, component) =>
-    prior && path.join(prior, decodeURIComponent(component)) ||
-    decodeURIComponent(component)
-  );
+  const components = pathname.split('/');
+  return components.reduce((prior, component) => {
+    if (prior) {
+      return path.join(prior, decodeURIComponent(component));
+    } else {
+      return decodeURIComponent(component);
+    }
+  });
 }
 
 /*
@@ -206,7 +209,7 @@ export function ensureFilenameExists(filename) {
 
 export function isLocalUrl(urlInput) {
   const parsedUrl = url.parse(urlInput);
-  const { protocol, path } = parsedUrl;
+  const { protocol, path: parsedPath } = parsedUrl;
 
   // Check protocol is chrome: or resource: if set.
   // Details on the chrome protocol are here: https://goo.gl/W52T0Q
@@ -215,7 +218,7 @@ export function isLocalUrl(urlInput) {
     return false;
   }
   // Disallow protocol-free remote urls.
-  if (path.startsWith('//')) {
+  if (parsedPath.startsWith('//')) {
     return false;
   }
   return true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,8 +20,7 @@ export function normalizePath(filePath) {
   // Also we need to strip leading slash '/' from pathname.
   // Decode component which is encoded when converting to a URL, for example
   // space (%20).
-  const components = pathname.split('/');
-  return components.reduce((prior, component) => {
+  return pathname.split('/').reduce((prior, component) => {
     if (prior) {
       return path.join(prior, decodeURIComponent(component));
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import url from 'url';
+import path from 'path';
 
 import { URL } from 'whatwg-url';
 import jed from 'jed';
@@ -10,12 +11,19 @@ import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
 
 const SOURCE_MAP_RE = new RegExp(/\/\/[#@]\s(source(?:Mapping)?URL)=\s*(\S+)/);
 
-export function normalizePath(iconPath) {
-  // Convert the icon path to a URL so we can strip any fragments and resolve
+export function normalizePath(filePath) {
+  // Convert the file path to a URL so we can strip any fragments and resolve
   // . and .. automatically. We need an absolute URL to use as a base so we're
   // using https://example.com/.
   const { pathname } = new URL(iconPath, 'https://example.com/');
-  return pathname.slice(1);
+  // Split pathname into directories and join them with OS specific separator.
+  // Also strip leading slash '/'.
+  // Decode components which is encoded when converting to a URL, for example
+  // space (%20).
+  const dir = pathname.split("/");
+  return dir.reduce((p, c) =>
+    p && path.join(p, decodeURIComponent(c)) || decodeURIComponent(c)
+  );
 }
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ export function normalizePath(filePath) {
   // . and .. automatically. We need an absolute URL to use as a base so we're
   // using https://example.com/.
   const { pathname } = new URL(filePath, 'https://example.com/');
-  return decodeURIComponent(pathname).slice(1).replace(/\//g, path.sep);
+  return path.normalize(decodeURIComponent(pathname).slice(1));
 }
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,7 @@ export function normalizePath(filePath) {
   // Convert the file path to a URL so we can strip any fragments and resolve
   // . and .. automatically. We need an absolute URL to use as a base so we're
   // using https://example.com/.
-  const { pathname } = new URL(iconPath, 'https://example.com/');
+  const { pathname } = new URL(filePath, 'https://example.com/');
   // Split pathname into directories and join them with OS specific separator.
   // Also strip leading slash '/'.
   // Decode components which is encoded when converting to a URL, for example

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -367,15 +367,15 @@ describe('utils.parseCspPolicy', () => {
 
 
 describe('utils.normalizePath', () => {
-  it('should normalize given "absolute" path to relative', () => {
-    const result = path.join('foo', 'bar');
-    expect(utils.normalizePath('/foo/bar')).toEqual(result);
+  it('should normalize given "absolute" path to relative path', () => {
+    const result = path.join('foo', 'bar', 'baz');
+    expect(utils.normalizePath('/foo/bar/baz')).toEqual(result);
   });
 
   it('should normalize ./ and ../ relative paths', () => {
-    const result = path.join('foo', 'bar');
-    expect(utils.normalizePath('./foo/bar')).toEqual(result);
-    expect(utils.normalizePath('baz/../foo/bar')).toEqual(result);
+    const result = path.join('foo', 'bar', 'baz');
+    expect(utils.normalizePath('./foo/bar/baz')).toEqual(result);
+    expect(utils.normalizePath('qux/../foo/bar/baz')).toEqual(result);
   });
 
   it('should handle space(s) within path correctly', () => {

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { oneLine } from 'common-tags';
 
 import * as utils from 'utils';
@@ -360,5 +362,14 @@ describe('utils.parseCspPolicy', () => {
     const parsedPolicy = utils.parseCspPolicy('DEFAULT-SRC \'NoNe\'');
 
     expect(parsedPolicy['default-src']).toEqual(['\'none\'']);
+  });
+});
+
+
+describe('utils.normalizePath', () => {
+  it('should normalize ./ and ../ relative paths', () => {
+    const result = path.join('foo', 'bar');
+    expect(utils.normalizePath('./foo/bar')).toEqual(result);
+    expect(utils.normalizePath('baz/../foo/bar')).toEqual(result);
   });
 });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -367,14 +367,19 @@ describe('utils.parseCspPolicy', () => {
 
 
 describe('utils.normalizePath', () => {
-  it('should normalize "absolute" path', () => {
+  it('should normalize given "absolute" path to relative', () => {
     const result = path.join('foo', 'bar');
     expect(utils.normalizePath('/foo/bar')).toEqual(result);
   });
 
-  it('should normalize ./ and ../ relative path', () => {
+  it('should normalize ./ and ../ relative paths', () => {
     const result = path.join('foo', 'bar');
     expect(utils.normalizePath('./foo/bar')).toEqual(result);
     expect(utils.normalizePath('baz/../foo/bar')).toEqual(result);
+  });
+
+  it('should handle space(s) within path correctly', () => {
+    const result = path.join('foo', 'bar baz');
+    expect(utils.normalizePath('foo/bar baz')).toEqual(result);
   });
 });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -378,8 +378,13 @@ describe('utils.normalizePath', () => {
     expect(utils.normalizePath('qux/../foo/bar/baz')).toEqual(result);
   });
 
-  it('should handle space(s) within path correctly', () => {
-    const result = path.join('foo', 'bar baz');
-    expect(utils.normalizePath('foo/bar baz')).toEqual(result);
+  it('should normalize path with fragment identifier', () => {
+    const result = path.join('foo', 'bar', 'baz');
+    expect(utils.normalizePath('foo/bar/baz#qux')).toEqual(result);
+  });
+
+  it('should handle spaces within path', () => {
+    const result = path.join('foo', 'bar baz', 'qux');
+    expect(utils.normalizePath('foo/bar baz/qux')).toEqual(result);
   });
 });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -383,7 +383,7 @@ describe('utils.normalizePath', () => {
     expect(utils.normalizePath('foo/bar/baz#qux')).toEqual(result);
   });
 
-  it('should handle spaces within path', () => {
+  it('should not escape spaces within path', () => {
     const result = path.join('foo', 'bar baz', 'qux');
     expect(utils.normalizePath('foo/bar baz/qux')).toEqual(result);
   });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -367,7 +367,12 @@ describe('utils.parseCspPolicy', () => {
 
 
 describe('utils.normalizePath', () => {
-  it('should normalize ./ and ../ relative paths', () => {
+  it('should normalize "absolute" path', () => {
+    const result = path.join('foo', 'bar');
+    expect(utils.normalizePath('/foo/bar')).toEqual(result);
+  });
+
+  it('should normalize ./ and ../ relative path', () => {
     const result = path.join('foo', 'bar');
     expect(utils.normalizePath('./foo/bar')).toEqual(result);
     expect(utils.normalizePath('baz/../foo/bar')).toEqual(result);


### PR DESCRIPTION
Previously the normalizePath() function was used inside `src/parsers/manifestjson.js`, but now it has been moved to `src/utils.js` and been exported.
However, unit test of normalizePath() is not prepared.

In this PR, together with addition of unit test, I refactored function to fix some issues.

Refactored things are:
* It did not decode after converting to URL, so for example, if the path contained spaces it was not processed properly.
  Decoding character is added.
* Linter throws file not found error on Windows.
  Converted slashes `/` to OS specific separators.
