### PR TITLE
Initialized the yarn command for extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "grunt start",
     "build": "grunt build",
     "eslint": "eslint bin/* .",
+    "extract-locales": "webpack --verbose --bail --display-error-details --progress --colors --config webpack.l10n.config.babel.js",
     "test": "jest --runInBand --watch 'tests/.*'",
     "test-coverage": "jest --runInBand --coverage --watch 'tests/.*'",
     "test-once": "jest --runInBand",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.json'],
     modules: [
+      'src',
       'node_modules',
     ],
   },


### PR DESCRIPTION
In continuation to https://github.com/mozilla/addons-linter/pull/1739
This PR adds a new yarn command, 
```
yarn extract-locales
```

This is still a work in progress. 
The documentation over at grunt : https://gruntjs.com/configuring-tasks#options
states that we can override the options parameter, but this does not seem to work. 

Am I missing something?