### PR TITLE
Add `langpack` to API usage example to avoid cli barf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ const linter = linter.createInstance({
     output: 'none',
     boring: false,
     selfHosted: false,
+    langpack: false,
     // Lint only the selected files
     //   scanFile: ['path/...', ...]
     //


### PR DESCRIPTION
It's a pretty difficult dance to avoid cli.js code. If at any point when trying to use `addons-linter` via API instead of via the cli.js you inadvertently trigger a call to `getConfig()` from cli.js, the help text will be printed, along with an "insufficient arguments" error, and the program will immediately exit(1).

In #1613, an [additional call was added to parsers/manifestjson.js](https://github.com/mozilla/addons-linter/blob/master/src/parsers/manifestjson.js#L40) to set the default for an unprovided `langpack` config parameter.

I've added the config parameter to README.md to bring the API example up-to-date.