### PR TITLE
Fix absent content script detection.

### DIFF
--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -6,6 +6,7 @@ import { CONTENT_SCRIPT_NOT_FOUND, CONTENT_SCRIPT_EMPTY } from 'messages/javascr
 export default {
   create(context) {
     const dirname = path.dirname(context.getFilename());
+
     const existingFiles = context.settings.existingFiles || {};
     return {
       MemberExpression(node) {
@@ -41,10 +42,13 @@ export default {
           }
           let normalizedName = path.resolve(dirname, fileValue);
           if (path.isAbsolute(fileValue)) {
-            normalizedName = path.join(path.resolve('.'), path.normalize(fileValue));
+            normalizedName = path.join(dirname, path.normalize(fileValue));
           }
           let existingFileNames = Object.keys(existingFiles);
-          existingFileNames = existingFileNames.map((fileName) => path.resolve(fileName));
+
+          existingFileNames = existingFileNames.map((fileName) => {
+            return path.resolve(dirname, fileName);
+          });
 
           // If file exists then we are good.
           if (existingFileNames.includes(normalizedName)) {

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -40,10 +40,20 @@ export default {
             });
             return;
           }
-          let normalizedName = path.resolve(dirname, fileValue);
-          if (path.isAbsolute(fileValue)) {
-            normalizedName = path.join(dirname, path.normalize(fileValue));
+
+          // We can't reliably validate relative file names because their
+          // behavior depends on the current page and the behavior for
+          // Firefox and Chrome differntiates too. So we choose only to
+          // validate absolute file paths to avoid false positives.
+
+          if (!path.isAbsolute(fileValue)) {
+            return;
           }
+
+          const normalizedName = path.join(
+            dirname,
+            path.normalize(fileValue));
+
           let existingFileNames = Object.keys(existingFiles);
 
           existingFileNames = existingFileNames.map((fileName) => {

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -7,9 +7,9 @@ export default {
   create(context) {
     const existingFiles = Object.keys(
       context.settings.existingFiles || {}
-    ).map((fileName => {
+    ).map((fileName) => {
       return path.resolve('/', fileName);
-    }));
+    });
 
     return {
       MemberExpression(node) {

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -5,9 +5,8 @@ import { CONTENT_SCRIPT_NOT_FOUND, CONTENT_SCRIPT_EMPTY } from 'messages/javascr
 
 export default {
   create(context) {
-    const dirname = path.dirname(context.getFilename());
-
     const existingFiles = context.settings.existingFiles || {};
+
     return {
       MemberExpression(node) {
         if (!node.object.object || !isBrowserNamespace(node.object.object.name)) {

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -5,7 +5,11 @@ import { CONTENT_SCRIPT_NOT_FOUND, CONTENT_SCRIPT_EMPTY } from 'messages/javascr
 
 export default {
   create(context) {
-    const existingFiles = context.settings.existingFiles || {};
+    const existingFiles = Object.keys(
+      context.settings.existingFiles || {}
+    ).map((fileName => {
+      return path.resolve('/', fileName);
+    }));
 
     return {
       MemberExpression(node) {
@@ -50,12 +54,8 @@ export default {
 
           const normalizedName = path.resolve('/', path.normalize(fileValue));
 
-          const existingFileNames = Object.keys(existingFiles).map((fileName) => {
-            return path.resolve('/', fileName);
-          });
-
           // If file exists then we are good.
-          if (existingFileNames.includes(normalizedName)) {
+          if (existingFiles.includes(normalizedName)) {
             return;
           }
 

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -49,20 +49,17 @@ export default {
             return;
           }
 
-          const normalizedName = path.join(
-            dirname,
-            path.normalize(fileValue));
+          const normalizedName = path.resolve('/', path.normalize(fileValue));
 
-          let existingFileNames = Object.keys(existingFiles);
-
-          existingFileNames = existingFileNames.map((fileName) => {
-            return path.resolve(dirname, fileName);
+          const existingFileNames = Object.keys(existingFiles).map((fileName) => {
+            return path.resolve('/', fileName);
           });
 
           // If file exists then we are good.
           if (existingFileNames.includes(normalizedName)) {
             return;
           }
+
           // File not exists report an issue.
           context.report({
             loc: fileProperty.value.loc,

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -44,10 +44,13 @@ export default {
             return;
           }
 
-          // We can't reliably validate relative file names because their
-          // behaviour depends on the current page and the behaviour for
-          // Firefox and Chrome differentiates too. So we chose only to
-          // validate absolute file paths to avoid false positives.
+          // We can't reliably validate relative file names because they
+          // are resolved as relative to the current page url on Firefox
+          // and the rule itself doesn't know the path of the html file (or
+          // files) where the js file is going to be loaded, and so we chose
+          // to validate only the absolute file paths to avoid false positive.
+          // (Also note that Firefox and Chrome behave differently when
+          // resolving relative content script paths used in a tabs.executeScript API call).
           if (!path.isAbsolute(fileValue)) {
             return;
           }

--- a/src/rules/javascript/content-scripts-file-absent.js
+++ b/src/rules/javascript/content-scripts-file-absent.js
@@ -42,10 +42,9 @@ export default {
           }
 
           // We can't reliably validate relative file names because their
-          // behavior depends on the current page and the behavior for
-          // Firefox and Chrome differntiates too. So we choose only to
+          // behaviour depends on the current page and the behaviour for
+          // Firefox and Chrome differentiates too. So we chose only to
           // validate absolute file paths to avoid false positives.
-
           if (!path.isAbsolute(fileValue)) {
             return;
           }

--- a/tests/rules/javascript/test.content_scripts_file_absent.js
+++ b/tests/rules/javascript/test.content_scripts_file_absent.js
@@ -15,10 +15,8 @@ function createJsScanner(code, validatedFilename, existingFiles = {}) {
 describe('content_scripts_file_absent', () => {
   it('should show an error when content script is missing', async () => {
     const nonExistentFiles = [
-      'absentFile.js',
-
-      // Check that the rule is not detecting Object properties as existent files.
-      'constructor',
+      // absolute path since we don't validate relative paths
+      '/really/absent/absentFile.js',
     ];
 
     nonExistentFiles.forEach(async (filename) => {
@@ -27,9 +25,23 @@ describe('content_scripts_file_absent', () => {
       const jsScanner = createJsScanner(code, fileRequiresContentScript);
 
       const { linterMessages } = await jsScanner.scan();
+
       expect(linterMessages.length).toEqual(1);
       expect(linterMessages[0].code).toEqual(CONTENT_SCRIPT_NOT_FOUND.code);
       expect(linterMessages[0].type).toEqual(VALIDATION_ERROR);
+    });
+  });
+
+  it('should not show an error when relative content script is missing', async () => {
+    const nonExistentFiles = ['absentFile.js'];
+
+    nonExistentFiles.forEach(async (filename) => {
+      const code = `browser.tabs.executeScript({ file: '${filename}' });`;
+      const fileRequiresContentScript = 'file-requires-content-script.js';
+      const jsScanner = createJsScanner(code, fileRequiresContentScript);
+
+      const { linterMessages } = await jsScanner.scan();
+      expect(linterMessages.length).toEqual(0);
     });
   });
 

--- a/tests/rules/javascript/test.content_scripts_file_absent.js
+++ b/tests/rules/javascript/test.content_scripts_file_absent.js
@@ -14,35 +14,29 @@ function createJsScanner(code, validatedFilename, existingFiles = {}) {
 
 describe('content_scripts_file_absent', () => {
   it('should show an error when content script is missing', async () => {
-    const nonExistentFiles = [
-      // absolute path since we don't validate relative paths
-      '/really/absent/absentFile.js',
-    ];
+    // absolute path since we don't validate relative paths
+    const nonExistentFile = '/really/absent/absentFile.js';
 
-    nonExistentFiles.forEach(async (filename) => {
-      const code = `browser.tabs.executeScript({ file: '${filename}' });`;
-      const fileRequiresContentScript = 'file-requires-content-script.js';
-      const jsScanner = createJsScanner(code, fileRequiresContentScript);
+    const code = `browser.tabs.executeScript({ file: '${nonExistentFile}' });`;
+    const fileRequiresContentScript = 'file-requires-content-script.js';
+    const jsScanner = createJsScanner(code, fileRequiresContentScript);
 
-      const { linterMessages } = await jsScanner.scan();
+    const { linterMessages } = await jsScanner.scan();
 
-      expect(linterMessages.length).toEqual(1);
-      expect(linterMessages[0].code).toEqual(CONTENT_SCRIPT_NOT_FOUND.code);
-      expect(linterMessages[0].type).toEqual(VALIDATION_ERROR);
-    });
+    expect(linterMessages.length).toEqual(1);
+    expect(linterMessages[0].code).toEqual(CONTENT_SCRIPT_NOT_FOUND.code);
+    expect(linterMessages[0].type).toEqual(VALIDATION_ERROR);
   });
 
   it('should not show an error when relative content script is missing', async () => {
-    const nonExistentFiles = ['absentFile.js'];
+    const filename = ['absentFile.js'];
 
-    nonExistentFiles.forEach(async (filename) => {
-      const code = `browser.tabs.executeScript({ file: '${filename}' });`;
-      const fileRequiresContentScript = 'file-requires-content-script.js';
-      const jsScanner = createJsScanner(code, fileRequiresContentScript);
+    const code = `browser.tabs.executeScript({ file: '${filename}' });`;
+    const fileRequiresContentScript = 'file-requires-content-script.js';
+    const jsScanner = createJsScanner(code, fileRequiresContentScript);
 
-      const { linterMessages } = await jsScanner.scan();
-      expect(linterMessages.length).toEqual(0);
-    });
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(0);
   });
 
   it('should not show an error when content script file exists', async () => {

--- a/tests/rules/javascript/test.content_scripts_file_absent.js
+++ b/tests/rules/javascript/test.content_scripts_file_absent.js
@@ -13,7 +13,7 @@ function createJsScanner(code, validatedFilename, existingFiles = {}) {
 }
 
 describe('content_scripts_file_absent', () => {
-  it('should show an error when content script is missing', async () => {
+  it('should show an error for a missing absolute content script path', async () => {
     // absolute path since we don't validate relative paths
     const nonExistentFile = '/really/absent/absentFile.js';
 


### PR DESCRIPTION
Fixes #1920

This essentially always tries to resolve the `file` based on `dirname`
but properly normalizes absolute paths.

I hope this fixes most of the edge-cases we've seen.