### PR TITLE
Get rid of getConfig() calls for ManifestJSONParser

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ import yargs from 'yargs';
 import { oneLine } from 'common-tags';
 
 import log from 'logger';
+import options from 'yargs-options';
 
 import { version } from '../package';
 
@@ -32,65 +33,7 @@ export function getConfig({ useCLI = true, argv } = {}) {
   return cliArgv
     .usage(`Usage: ./$0 [options] addon-package-or-dir \n\n
       Add-ons Linter (JS Edition) v${version}`)
-    .option('log-level', {
-      describe: 'The log-level to generate',
-      type: 'string',
-      default: 'fatal',
-      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
-    })
-    .option('warnings-as-errors', {
-      describe: 'Treat warning as errors',
-      type: 'boolean',
-      default: false,
-    })
-    .option('output', {
-      alias: 'o',
-      describe: 'The type of output to generate',
-      type: 'string',
-      default: 'text',
-      choices: ['json', 'text'],
-    })
-    .option('metadata', {
-      describe: 'Output only metadata as JSON',
-      type: 'boolean',
-      default: 'false',
-    })
-    .option('pretty', {
-      describe: 'Prettify JSON output',
-      type: 'boolean',
-      default: false,
-    })
-    .option('stack', {
-      describe: 'Show stacktraces when errors are thrown',
-      type: 'boolean',
-      default: false,
-    })
-    .option('boring', {
-      describe: 'Disables colorful shell output',
-      type: 'boolean',
-      default: false,
-    })
-    .option('self-hosted', {
-      describe: 'Disables messages related to hosting on addons.mozilla.org.',
-      type: 'boolean',
-      default: false,
-    })
-    .option('langpack', {
-      describe: 'Treat this package as a WebExtension Language Pack.',
-      type: 'boolean',
-      default: false,
-    })
-    .option('scan-file', {
-      alias: ['f'],
-      describe: 'Scan a selected file',
-      type: 'string',
-      requiresArg: true,
-    })
-    .option('disable-linter-rules', {
-      describe: 'Disable list of comma separated eslint rules',
-      type: 'string',
-      requiresArg: true,
-    })
+    .options(options)
     // Require one non-option.
     .demand(1)
     .help('help')

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -7,10 +7,10 @@ import { oneLine } from 'common-tags';
 import probeImageSize from 'probe-image-size';
 import upath from 'upath';
 
+import { getDefaultConfigValue } from 'yargs-options';
 import {
   validateAddon, validateLangPack, validateStaticTheme,
 } from 'schema/validator';
-import { getConfig } from 'cli';
 import { MANIFEST_JSON, PACKAGE_EXTENSION, CSP_KEYWORD_RE, IMAGE_FILE_EXTENSIONS, LOCALES_DIRECTORY, MESSAGES_JSON } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -38,8 +38,8 @@ async function getImageMetadata(io, iconPath) {
 export default class ManifestJSONParser extends JSONParser {
   constructor(jsonString, collector, {
     filename = MANIFEST_JSON, RelaxedJSON = RJSON,
-    selfHosted = getConfig().argv.selfHosted,
-    isLanguagePack = getConfig().argv.langpack,
+    selfHosted = getDefaultConfigValue('self-hosted'),
+    isLanguagePack = getDefaultConfigValue('langpack'),
     io = null,
   } = {}) {
     super(jsonString, collector, { filename });

--- a/src/yargs-options.js
+++ b/src/yargs-options.js
@@ -1,0 +1,63 @@
+const options = {
+  'log-level': {
+    describe: 'The log-level to generate',
+    type: 'string',
+    default: 'fatal',
+    choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
+  },
+  'warnings-as-errors': {
+    describe: 'Treat warning as errors',
+    type: 'boolean',
+    default: false,
+  },
+  output: {
+    alias: 'o',
+    describe: 'The type of output to generate',
+    type: 'string',
+    default: 'text',
+    choices: ['json', 'text'],
+  },
+  metadata: {
+    describe: 'Output only metadata as JSON',
+    type: 'boolean',
+    default: 'false',
+  },
+  pretty: {
+    describe: 'Prettify JSON output',
+    type: 'boolean',
+    default: false,
+  },
+  stack: {
+    describe: 'Show stacktraces when errors are thrown',
+    type: 'boolean',
+    default: false,
+  },
+  boring: {
+    describe: 'Disables colorful shell output',
+    type: 'boolean',
+    default: false,
+  },
+  'self-hosted': {
+    describe: 'Disables messages related to hosting on addons.mozilla.org.',
+    type: 'boolean',
+    default: false,
+  },
+  langpack: {
+    describe: 'Treat this package as a WebExtension Language Pack.',
+    type: 'boolean',
+    default: false,
+  },
+  'scan-file': {
+    alias: ['f'],
+    describe: 'Scan a selected file',
+    type: 'string',
+    requiresArg: true,
+  },
+  'disable-linter-rules': {
+    describe: 'Disable list of comma separated eslint rules',
+    type: 'string',
+    requiresArg: true,
+  },
+};
+
+export default options;

--- a/src/yargs-options.js
+++ b/src/yargs-options.js
@@ -61,3 +61,10 @@ const options = {
 };
 
 export default options;
+
+export function getDefaultConfigValue(name) {
+  if (options[name] && 'default' in options[name]) {
+    return options[name].default;
+  }
+  return undefined;
+}

--- a/tests/test.yargs-options.js
+++ b/tests/test.yargs-options.js
@@ -1,0 +1,11 @@
+import { getDefaultConfigValue } from 'yargs-options';
+
+describe('getDefaultConfigValue()', () => {
+  it('should return the default value', () => {
+    expect(getDefaultConfigValue('self-hosted')).toEqual(false);
+  });
+
+  it('should return undefined for unknown option', () => {
+    expect(getDefaultConfigValue('unknown')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #1925.

* [x] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.