### PR TITLE
Import Firefox 60 schemas again

### DIFF
--- a/src/schema/imported/devtools.json
+++ b/src/schema/imported/devtools.json
@@ -1,7 +1,7 @@
 {
   "id": "devtools",
   "permissions": [
-    "devtools"
+    "manifest:devtools_page"
   ],
   "allowedContexts": [
     "devtools",

--- a/src/schema/imported/dns.json
+++ b/src/schema/imported/dns.json
@@ -1,0 +1,95 @@
+{
+  "id": "dns",
+  "description": "Asynchronous DNS API",
+  "permissions": [
+    "dns"
+  ],
+  "functions": [
+    {
+      "name": "resolve",
+      "type": "function",
+      "description": "Resolves a hostname to a DNS record.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "hostname",
+          "type": "string"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ResolveFlags"
+            },
+            {
+              "name": "flags",
+              "optional": true,
+              "default": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "Permission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "dns"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "dns#/definitions/Permission": {
+      "namespace": "manifest",
+      "type": "Permission"
+    }
+  },
+  "types": {
+    "DNSRecord": {
+      "type": "object",
+      "description": "An object encapsulating a DNS Record.",
+      "properties": {
+        "canonicalName": {
+          "type": "string",
+          "description": "The canonical hostname for this record.  this value is empty if the record was not fetched with the 'canonical_name' flag."
+        },
+        "isTRR": {
+          "type": "string",
+          "description": "Record retreived with TRR."
+        },
+        "addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "isTRR",
+        "addresses"
+      ]
+    },
+    "ResolveFlags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow_name_collisions",
+          "bypass_cache",
+          "canonical_name",
+          "disable_ipv4",
+          "disable_ipv6",
+          "disable_trr",
+          "offline",
+          "priority_low",
+          "priority_medium",
+          "speculate"
+        ]
+      }
+    }
+  }
+}

--- a/src/schema/imported/downloads.json
+++ b/src/schema/imported/downloads.json
@@ -521,7 +521,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -534,9 +534,9 @@
     }
   },
   "refs": {
-    "downloads#/definitions/Permission": {
+    "downloads#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -12,6 +12,7 @@ import contentScripts from './content_scripts.json';
 import contextualIdentities from './contextual_identities.json';
 import cookies from './cookies.json';
 import devtools from './devtools.json';
+import dns from './dns.json';
 import downloads from './downloads.json';
 import events from './events.json';
 import experiments from './experiments.json';
@@ -62,6 +63,7 @@ export default [
   contextualIdentities,
   cookies,
   devtools,
+  dns,
   downloads,
   events,
   experiments,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -411,6 +411,9 @@
           "$ref": "cookies#/definitions/OptionalPermission"
         },
         {
+          "$ref": "downloads#/definitions/OptionalPermission"
+        },
+        {
           "$ref": "find#/definitions/OptionalPermission"
         },
         {
@@ -464,7 +467,7 @@
           "$ref": "devtools#/definitions/Permission"
         },
         {
-          "$ref": "downloads#/definitions/Permission"
+          "$ref": "dns#/definitions/Permission"
         },
         {
           "$ref": "experiments#/definitions/Permission"

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -42,9 +42,132 @@
   ],
   "events": [
     {
-      "name": "onProxyError",
+      "name": "onRequest",
+      "type": "function",
+      "description": "Fired when proxy data is needed for a request.",
+      "parameters": [
+        {
+          "type": "object",
+          "name": "details",
+          "properties": {
+            "requestId": {
+              "type": "string",
+              "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request."
+            },
+            "url": {
+              "type": "string"
+            },
+            "method": {
+              "type": "string",
+              "description": "Standard HTTP method."
+            },
+            "frameId": {
+              "type": "integer",
+              "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab."
+            },
+            "parentFrameId": {
+              "type": "integer",
+              "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "originUrl": {
+              "type": "string",
+              "description": "URL of the resource that triggered this request."
+            },
+            "documentUrl": {
+              "type": "string",
+              "description": "URL of the page into which the requested resource will be loaded."
+            },
+            "tabId": {
+              "type": "integer",
+              "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab."
+            },
+            "type": {
+              "allOf": [
+                {
+                  "$ref": "webRequest#/types/ResourceType"
+                },
+                {
+                  "description": "How the requested resource will be used."
+                }
+              ]
+            },
+            "timeStamp": {
+              "type": "number",
+              "description": "The time when this signal is triggered, in milliseconds since the epoch."
+            },
+            "ip": {
+              "type": "string",
+              "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address."
+            },
+            "fromCache": {
+              "type": "boolean",
+              "description": "Indicates if this response was fetched from disk cache."
+            },
+            "requestHeaders": {
+              "allOf": [
+                {
+                  "$ref": "webRequest#/types/HttpHeaders"
+                },
+                {
+                  "description": "The HTTP request headers that are going to be sent out with this request."
+                }
+              ]
+            }
+          },
+          "required": [
+            "requestId",
+            "url",
+            "method",
+            "frameId",
+            "parentFrameId",
+            "tabId",
+            "type",
+            "timeStamp",
+            "fromCache"
+          ]
+        }
+      ],
+      "extraParameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "webRequest#/types/RequestFilter"
+            },
+            {
+              "name": "filter",
+              "description": "A set of filters that restricts the events that will be sent to this listener."
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "optional": true,
+          "name": "extraInfoSpec",
+          "description": "Array of extra information that should be passed to the listener function.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "requestHeaders"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "onError",
       "type": "function",
       "description": "Notifies about proxy script errors.",
+      "parameters": [
+        {
+          "name": "error",
+          "type": "object"
+        }
+      ]
+    },
+    {
+      "name": "onProxyError",
+      "type": "function",
+      "description": "Please use $(ref:proxy.onError).",
       "parameters": [
         {
           "name": "error",

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -163,6 +163,9 @@
         "colors": {
           "type": "object",
           "properties": {
+            "tab_selected": {
+              "$ref": "#/types/ThemeColor"
+            },
             "accentcolor": {
               "$ref": "#/types/ThemeColor"
             },
@@ -175,13 +178,16 @@
             "textcolor": {
               "$ref": "#/types/ThemeColor"
             },
-            "background_tab_text": {
+            "tab_background_text": {
               "$ref": "#/types/ThemeColor"
             },
             "tab_loading": {
               "$ref": "#/types/ThemeColor"
             },
             "tab_text": {
+              "$ref": "#/types/ThemeColor"
+            },
+            "tab_line": {
               "$ref": "#/types/ThemeColor"
             },
             "toolbar": {

--- a/src/schema/imported/top_sites.json
+++ b/src/schema/imported/top_sites.json
@@ -20,9 +20,11 @@
               "items": {
                 "type": "string"
               },
-              "description": "Which providers to get top sites from. Possible values are \"places\" and \"activityStream\"."
+              "description": "Which providers to get top sites from. Possible values are \"places\" and \"activityStream\".",
+              "default": []
             }
           },
+          "default": {},
           "optional": true
         },
         {


### PR DESCRIPTION
Fixes #1893, Supports #1898.

The last import must have pulled an initial build instead of the latest beta. I think there is only one beta tag on mozilla-central so that would be the one from a couple weeks before the actual code freeze.

We'll want to update the import script to use the changes from #1795.