### PR TITLE
Use mozilla-unified to download and import Firefox schemas

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
+bin/download-import-tag
+bin/list-firefox-tags
 dist
 coverage
 tests/fixtures/jslibs

--- a/bin/download-import-tag
+++ b/bin/download-import-tag
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Download a mozilla-unified tag into a temporary file
+#
+# Usage:
+#  * run `bin/list-firefox-tags 59` (change release as necessary) to list available tags
+#  * import the schema by running `bin/download-import-tag FIREFOX_60_0b10_RELEASE` (change the tag as necessary)
+
+
+if [ ! -e "tmp/$1.tar.gz" ]; then
+    echo "tmp/$1.tar.gz doesn't exist, downloading..."
+    curl "https://hg.mozilla.org/mozilla-unified/archive/$1.tar.gz" > "tmp/$1.tar.gz"
+else
+    echo "tmp/$1.tar.gz already exists, please make sure it's valid!"
+fi
+
+echo "Importing with bin/firefox-schema-import tmp/$1.tar.gz"
+
+# Now import the schema from that tag
+bin/firefox-schema-import "tmp/$1.tar.gz"

--- a/bin/firefox-schema-import
+++ b/bin/firefox-schema-import
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-let version;
 let filePath;
 require('babel-register');
 
@@ -18,15 +17,8 @@ try {
   fs.statSync(arg);
   filePath = arg;
 } catch (e) {
-  if (/^[0-9]+$/.test(arg) || arg === 'nightly') {
-    version = arg;
-  }
-}
-
-
-if (!(filePath || version)) {
   // eslint-disable-next-line no-console
-  console.error(`Usage: ${process.argv[1]} version|filePath`);
+  console.error(`File not found: ${arg}\nUsage: ${process.argv[1]} filePath`);
   process.exit(1);
 }
 
@@ -50,7 +42,7 @@ emptyDir(importedDir, /.*\.json$/);
 emptyDir(importedDir, /index\.js$/);
 
 schemaImport.fetchSchemas(
-  { inputPath: filePath, outputPath: firefoxDir, version })
+  { inputPath: filePath, outputPath: firefoxDir })
   .then(() => {
     schemaImport.importSchemas(firefoxDir, updatesDir, importedDir);
   })

--- a/bin/list-firefox-tags
+++ b/bin/list-firefox-tags
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl -s https://hg.mozilla.org/mozilla-unified/tags | grep -o "FIREFOX_$1[_a-zA-Z0-9]*" | sort -r | uniq | xargs -L1 echo bin/download-import-tag


### PR DESCRIPTION
We need to start using mozilla-unified to download the schemas since mozilla-central is out of date by the time we import. This moves the download code into bash scripts and deletes the version/download code from the JS files.

New workflow:

```bash
~/w/addons-linter> bin/list-firefox-tags 60
bin/download-import-tag FIREFOX_60_0b6_RELEASE
bin/download-import-tag FIREFOX_60_0b6_BUILD1
bin/download-import-tag FIREFOX_60_0b5_RELEASE
bin/download-import-tag FIREFOX_60_0b5_BUILD1
bin/download-import-tag FIREFOX_60_0b4_RELEASE
bin/download-import-tag FIREFOX_60_0b4_BUILD1
bin/download-import-tag FIREFOX_60_0b3_RELEASE
bin/download-import-tag FIREFOX_60_0b3_BUILD1
~/w/addons-linter> bin/download-import-tag FIREFOX_60_0b6_RELEASE
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  364M    0  364M    0     0   976k      0 --:--:--  0:06:21 --:--:-- 1495k
Importing with bin/firefox-schema-import tmp/FIREFOX_60_0b6_RELEASE.tar.gz
```

Once that's done hopefully everything worked! If you need to make some updates and re-import then you can run `bin/firefox-schema-import tmp/FIREFOX_60_0b6_RELEASE.tar.gz` directly.