### PR TITLE
chore(package): update sinon to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "markdown-it-emoji": "1.4.0",
     "raw-loader": "0.5.1",
     "request": "2.83.0",
-    "sinon": "4.4.6",
+    "sinon": "5.0.0",
     "tar": "4.4.1",
     "webpack": "3.10.0"
   },


### PR DESCRIPTION
Closes #1928 

(the previous sinon 4.4.7 version doesn't seem to exist anymore and both travis and appveyors fails to install that dependency, e.g.: https://travis-ci.org/mozilla/addons-linter/jobs/356424545#L469)