### PR TITLE
chore(package): update webpack to version 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "request": "2.83.0",
     "sinon": "4.4.6",
     "tar": "4.4.1",
-    "webpack": "3.10.0"
+    "webpack": "4.4.1",
+    "webpack-cli": "2.0.13"
   },
   "dependencies": {
     "ajv": "6.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,9 @@ fs.readdirSync('node_modules')
 
 
 module.exports = {
+  // Set the webpack4 mode 'none' for compatibility with the behavior
+  // of the webpack3 bundling step.
+  mode: 'none',
   entry: './src/main.js',
   target: 'node',
   output: {


### PR DESCRIPTION
This pull request supersedes #1927, which fails on travis because webpack 4 also requires webpack-cli to be explicitly installed as a separate dev dependency.

This pull request also set the new webpack `mode` config property to `'none'`, which seems to restore most of the default behaviors of webpack3, otherwise the build step raise a number of `ModuleConcatenation bailout: Module is not an ECMAScript module` warning messages (and an additional warning message which complains about the missing `mode` config property and warns that webpack 4 will defaults to the new `mode: 'production'` behavior when the explicit `mode` is missing).

I also briefly tested locally that the new webpack4 bundle is able to run successfully from the addons-linter bin script (and that the `npm run extract-locales` script is able to extract the i18n strings as expected, given that it is also based on a webpack config and it could have been affected by a webpack upgrade).    