### PR TITLE
chore(npmignore): Cleanup list of assets included in the released npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,21 +1,10 @@
-.babelrc
-.eslintignore
-.eslintrc
-.gitignore
-.grunt
-.npmignore
-.npmrc
-.travis.yml
-Gruntfile.js
-bower.json
-coverage/
-dist/tests.js
-dist/tests.js.map
-docs/
-karma.conf.js
-node_modules/
-src/
-tasks/
-tests/
-webpack.config.js
-locale/
+# Exclude everything by default.
+*
+
+# Only include in the released npm package the following globs.
+!package.json
+!LICENSE
+!README.md
+!bin/addons-linter
+!dist/addons-linter.*
+!dist/locale/**


### PR DESCRIPTION
This PR rewrites the .npmignore file to ensure that only the files needed in the released package are actually included.

The current .npmignore looks pretty outdated and so the package released on npm contains a long list of files that are not really of any use when the package is installed from a regular user, as it can be checked by looking at the following unpkg url: https://unpkg.com/addons-linter@0.41.0/

I propose to reverse the way we list the globs in the npmignore, so that we exclude everything by default, and then we just list all the globs related to the files that we actually want to be included in the released npm package.

(To be fair, I think that most of the files in `bin/`, besides the addons-linter one, should be moved in a separate directory, because they are not bin scripts of the package, but just "internal" nodejs utilities that we use from time to time during the development activities, e.g. to import a new version of the API schema files, manage the locales extraction and generation etc.).