### PR TITLE
chore(locales): Applied some minor changes to the locales scripts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     "env",
-    "stage-2"
+    "stage-2",
+    "es2015"
   ],
   "plugins": [
     "transform-class-properties",

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+/* eslint-disable global-require */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/bin/create-locales
+++ b/bin/create-locales
@@ -1,4 +1,6 @@
-const fs = require('fs');
+#!/usr/bin/env node
+/* eslint-disable global-require */
+
 const path = require('path');
 
 const shell = require('shelljs');
@@ -9,22 +11,22 @@ const localeDir = path.join(__dirname, '../locale');
 const templateDir = path.join(localeDir, 'templates/LC_MESSAGES');
 const supportedLangs = config.langs;
 
-let outputFile;
+if (!shell.which('msginit')) {
+  shell.echo('This script requires msginit');
+  shell.exit(1);
+}
 
 for (let i = 0; i < supportedLangs.length; i++) {
   const locale = supportedLangs[i];
-  shell.exec(`mkdir -p ${localeDir}/${locale}/LC_MESSAGES/`);
-  outputFile = path.join(localeDir, locale, 'LC_MESSAGES', `messages.po`);
-  try {
-    fs.statSync(outputFile);
-    // eslint-disable-next-line no-console
-    console.log(`${outputFile} already exists skipping`);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      shell.exec(`msginit --no-translator --input=${templateDir}/messages.pot
-                  --output-file=${outputFile} -l ${locale}`.replace('\n', ' '));
-    } else {
-      throw e;
-    }
+  const outputFile = path.join(localeDir, locale, 'LC_MESSAGES', `messages.po`);
+
+  shell.mkdir('-p', `${localeDir}/${locale}/LC_MESSAGES/`);
+
+  if (shell.test('-e', outputFile)) {
+    shell.echo(`${outputFile} already exists, skipped.`);
+    continue; // eslint-disable-line no-continue
   }
+
+  shell.exec(`msginit --no-translator --input=${templateDir}/messages.pot
+              --output-file=${outputFile} -l ${locale}`.replace('\n', ' '));
 }

--- a/bin/merge-locales
+++ b/bin/merge-locales
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+/* eslint-disable global-require */
+
 const path = require('path');
 
 const glob = require('glob');
@@ -7,6 +10,11 @@ const localeDir = path.join(__dirname, '../locale');
 
 const poFiles = glob.sync(`${localeDir}/**/messages.po`);
 const template = path.join(localeDir, `templates/LC_MESSAGES/messages.pot`);
+
+if (!shell.which('msgmerge')) {
+  shell.echo('This script requires msgmerge');
+  shell.exit(1);
+}
 
 poFiles.forEach((poFile) => {
   const dir = path.dirname(poFile);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.6.1",
+    "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
     "babel-runtime": "6.26.0",
     "comment-json": "1.1.3",


### PR DESCRIPTION
This PR contains some minor changes applied on the locales scripts.

In particular:

- explicitly add babel-preset-es2015 to the devDependencies (because it is used in the "webpack extract locales" config file and we want to be sure that the flattening of the npm dependencies doesn't make it suddenly disappear from the root "node_modules/" dir: https://github.com/mozilla/addons-linter/blob/2cf2439df54ab959aa7307f62970346b7dd609cf/webpack.l10n.config.babel.js#L10)

- add the executable permission to the locales bin scripts and the shebang (so that the script can be executed directly on *nix)

- check the presence of the needed cli utils (eg. msginit and msgmerge) and then early exit and log a proper error message when they can't be found

- use `shell.test('-e', outputFile)` instead of using `fs.statSync(outputFile);` inside a try catch, to check if the file exists (mainly to make it a bit cleaner and easier to read, but it seems to make the script faster as a side-effect for some reasons) 