### PR TITLE
chore(package): update markdown-it-anchor to version 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.clonedeep": "4.5.0",
     "lodash.ismatchwith": "4.4.0",
     "markdown-it": "8.4.1",
-    "markdown-it-anchor": "4.0.0",
+    "markdown-it-anchor": "5.0.1",
     "markdown-it-emoji": "1.4.0",
     "raw-loader": "0.5.1",
     "request": "2.87.0",


### PR DESCRIPTION
Closes #2043
