### PR TITLE
Rename 'prepublish' to 'prepublishOnly'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish-rules": "bin/build-rules && cp node_modules/gfm.css/gfm.css docs/html/gfm.css && bin/publish-rules",
     "gen-contributing-toc": "doctoc CONTRIBUTING.md",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect",
+    "prepublishOnly": "npm run snyk-protect",
     "prepare": "npm run snyk-protect"
   },
   "repository": {


### PR DESCRIPTION
This got deprecated in npm 6, see
https://github.com/npm/npm/issues/10074 for much much more details.

This will also run snyk just once in our CI environment instead of twice.