### PR TITLE
Add ES6 module support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,8 +2,7 @@ bin/download-import-tag
 bin/list-firefox-tags
 dist
 coverage
-tests/fixtures/jslibs
-tests/fixtures/coinminers
+tests/fixtures/**
 tests/**/*.json
 src/schema/imported/index.js
 locale/

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "es6-promisify": "5.0.0",
     "eslint": "5.0.1",
     "eslint-plugin-no-unsafe-innerhtml": "1.0.16",
+    "eslint-visitor-keys": "1.0.0",
+    "espree": "4.0.0",
     "esprima": "3.1.3",
     "first-chunk-stream": "2.0.0",
     "fluent-syntax": "^0.7.0",

--- a/src/linter.js
+++ b/src/linter.js
@@ -1,4 +1,4 @@
-import { extname } from 'path';
+import path from 'path';
 
 import columnify from 'columnify';
 import chalk from 'chalk';
@@ -294,12 +294,12 @@ export default class Linter {
   getScanner(filename) {
     if (filename.match(constants.HIDDEN_FILE_REGEX) ||
         filename.match(constants.FLAGGED_FILE_REGEX) ||
-        constants.FLAGGED_FILE_EXTENSIONS.includes(extname(filename)) ||
+        constants.FLAGGED_FILE_EXTENSIONS.includes(path.extname(filename)) ||
         filename.match(constants.ALREADY_SIGNED_REGEX)) {
       return FilenameScanner;
     }
 
-    switch (extname(filename)) {
+    switch (path.extname(filename)) {
       case '.css':
         return CSSScanner;
       case '.html':
@@ -473,7 +473,7 @@ export default class Linter {
       await this.scanFiles(filesWithoutJSLibraries);
 
       this.print(deps._console);
-      // This is skipped in the code coverage because the
+      // This is skipped in code coverage because the
       // test runs against un-instrumented code.
       /* istanbul ignore if */
       if (this.config.runAsBinary === true) {

--- a/tests/fixtures/webextension_es6_module/background.js
+++ b/tests/fixtures/webextension_es6_module/background.js
@@ -1,0 +1,5 @@
+import {ES_MODULE, HELLO} from './constant.js';
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log(`${HELLO} ${ES_MODULE}!`);
+});

--- a/tests/fixtures/webextension_es6_module/constant.js
+++ b/tests/fixtures/webextension_es6_module/constant.js
@@ -1,0 +1,2 @@
+export const HELLO = 'Hello';
+export const ES_MODULE = 'ES module';

--- a/tests/fixtures/webextension_es6_module/manifest.json
+++ b/tests/fixtures/webextension_es6_module/manifest.json
@@ -1,0 +1,14 @@
+{
+  "applications": {
+    "gecko": {
+      "id": "webExtTest@asamuzak.jp"
+    }
+  },
+  "description": "WebExtensions ES module test",
+  "manifest_version": 2,
+  "name": "WebExtensions test",
+  "permissions": [
+    "activeTab"
+  ],
+  "version": "0.0.2"
+}

--- a/tests/fixtures/webextension_es6_module/manifest.json
+++ b/tests/fixtures/webextension_es6_module/manifest.json
@@ -1,7 +1,7 @@
 {
   "applications": {
     "gecko": {
-      "id": "webExtTest@asamuzak.jp"
+      "id": "@webextension-guid"
     }
   },
   "description": "WebExtensions ES module test",


### PR DESCRIPTION
This implements ES6 module support.

This parses JavaScript files and tries to figure out their sourceType
from how the AST is structured.

We default to `module` but if there are syntax errors fall back to
`script`. We do not read the `<script type="module"` part of HTML files
anymore.

This may not be perfect but it's pretty close to what we want. We may catch too much but can always be more restrictive once this new code proves useful in production.

Fixes https://github.com/mozilla/addons-linter/issues/1775