### PR TITLE
Use emcaVersion 2019 to support optional catch bindings.

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -65,7 +65,7 @@ export default class JavaScriptScanner {
         },
       },
       parserOptions: {
-        ecmaVersion: 2018,
+        ecmaVersion: 2019,
       },
       rules: _ruleMapping,
       plugins: ['no-unsafe-innerhtml'],

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -118,6 +118,17 @@ describe('JavaScript Scanner', () => {
     expect(linterMessages.length).toEqual(0);
   });
 
+  it('should support optional catch binding', async () => {
+    const code = oneLine`
+      try {} catch {}
+    `;
+
+    const jsScanner = new JavaScriptScanner(code, 'code.js');
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(0);
+  });
+
   it('should create an error message when encountering a syntax error', async () => {
     let code = 'var m = "d;';
     let jsScanner = new JavaScriptScanner(code, 'badcode.js');


### PR DESCRIPTION
Actually fixes #1958

Refs https://github.com/eslint/espree#what-ecmascript-2019-features-do-you-support