### PR TITLE
Search whole file for ES6 module detection

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -190,7 +190,9 @@ export default class JavaScriptScanner {
 
         if (Array.isArray(child)) {
           for (let j = 0; j < child.length; ++j) {
-            return this._getSourceType(child[j]);
+            if (this._getSourceType(child[j]) === 'module') {
+              return 'module';
+            }
           }
         } else {
           return this._getSourceType(child);

--- a/tests/fixtures/webextension_es6_module/constant.js
+++ b/tests/fixtures/webextension_es6_module/constant.js
@@ -1,2 +1,3 @@
-export const HELLO = 'Hello';
+let location = 'World';
+export const HELLO = 'Hello ' + location;
 export const ES_MODULE = 'ES module';

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -437,6 +437,18 @@ describe('JavaScript Scanner', () => {
       expect(jsScanner.sourceType).toEqual('module');
     });
 
+    it('should detect module (multiple statements)', async () => {
+      const code = oneLine`
+        let value = 0;
+        export { value };
+      `;
+
+      const jsScanner = new JavaScriptScanner(code, 'code.js');
+      await jsScanner.scan();
+
+      expect(jsScanner.sourceType).toEqual('module');
+    });
+
     it('should detect script', async () => {
       const code = oneLine`
         eval('foo');


### PR DESCRIPTION
_getSourceType was not walking the whole AST, so it would only detect
import/export statements if they were the first in the file.  This fixes
the recursion to walk the whole AST.

Fixes #2138