### PR TITLE
Remove greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 node_js:
   - '8'
   - '10'
-before_install:
-- npm install -g greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
 script:
   - npm run test-ci
   - node bin/build-locales
@@ -21,7 +18,6 @@ notifications:
     on_failure: always
 after_script:
   - npm run publish-coverage
-  - greenkeeper-lockfile-upload
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
Greenkeeper supports updating package-lock.json without greenkeeper-lockfile now, so we no longer need this.