### PR TITLE
chore: Bump package version for release 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-linter",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2280,7 +2280,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -2292,7 +2291,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -2678,7 +2676,6 @@
     },
     "babel-gettext-extractor": {
       "version": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6",
-      "from": "babel-gettext-extractor@git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6",
       "dev": true,
       "requires": {
         "babel-core": "6.26.3",
@@ -4219,14 +4216,14 @@
       "resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.26.0.tgz",
       "integrity": "sha512-Cw0N6Hf8/y4vH9/NvDPGLd2+Mve9xs+41+sULJ4ODHuhZ+9CnJ2eMl2ju2udL/UACY0Vcxw3TzyoDRBNaU/0DQ==",
       "requires": {
-        "array-from": "~2.1.1",
-        "async": "~2.6.0",
-        "natural-compare-lite": "~1.4.0",
-        "pino": "~5.8.0",
-        "request": "~2.88.0",
-        "sha.js": "~2.4.4",
-        "source-map-support": "~0.5.4",
-        "yargs": "~12.0.1"
+        "array-from": "2.1.1",
+        "async": "2.6.1",
+        "natural-compare-lite": "1.4.0",
+        "pino": "5.8.0",
+        "request": "2.88.0",
+        "sha.js": "2.4.11",
+        "source-map-support": "0.5.6",
+        "yargs": "12.0.2"
       },
       "dependencies": {
         "pino": {
@@ -4234,14 +4231,14 @@
           "resolved": "https://registry.npmjs.org/pino/-/pino-5.8.0.tgz",
           "integrity": "sha512-L+nysfU1DMoMku+/4DTsBNFl/ajFzPWMGFQ7Gs3Cuo60Iya4ixPzHSxBUT6po2lQRexW9iEj8oCAIGpEXBeIZQ==",
           "requires": {
-            "fast-json-parse": "^1.0.3",
-            "fast-redact": "^1.2.0",
-            "fast-safe-stringify": "^2.0.6",
-            "flatstr": "^1.0.5",
-            "pino-std-serializers": "^2.3.0",
-            "pump": "^3.0.0",
-            "quick-format-unescaped": "^3.0.0",
-            "sonic-boom": "^0.6.1"
+            "fast-json-parse": "1.0.3",
+            "fast-redact": "1.3.0",
+            "fast-safe-stringify": "2.0.6",
+            "flatstr": "1.0.8",
+            "pino-std-serializers": "2.3.0",
+            "pump": "3.0.0",
+            "quick-format-unescaped": "3.0.0",
+            "sonic-boom": "0.6.1"
           }
         }
       }
@@ -5907,13 +5904,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -5926,18 +5921,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6040,8 +6032,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6051,7 +6042,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -6064,20 +6054,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -6094,7 +6081,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6167,8 +6153,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6178,7 +6163,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -6284,7 +6268,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -9095,8 +9078,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "1.0.0",
@@ -12349,7 +12331,7 @@
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.6.1.tgz",
       "integrity": "sha512-3qx6XXDeG+hPNa+jla1H6BMBLcjLl8L8NRERLVeIf/EuPqoqmq4K8owG29Xu7OypT/7/YT/0uKW6YitsKA+nLQ==",
       "requires": {
-        "flatstr": "^1.0.5"
+        "flatstr": "1.0.8"
       }
     },
     "sort-keys": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-linter",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "Mozilla Add-ons Linter",
   "main": "dist/addons-linter.js",
   "bin": {


### PR DESCRIPTION
This PR increase the package version to prepare the release of the new addons-linter 1.4.0 version on npm (which includes the new linting rules added in #2271 to fix #2051). 

Besides the change to the version in the "package.json" file, this PR also includes the updated "package-lock.json" file, as it hasn't been updated in the previous release 1.3.8 (it currently contains the changes applied from the last greenkeeper PR, which doesn't seem to use the exact versions as explicitly configured in the .npmrc file included in this repo).