### PR TITLE
fix(static-themes): Warn on LWT aliases used in a static theme manifest.

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -132,6 +132,7 @@ Rules are sorted by severity.
 
 | Message code                         | Severity | Description                                                 |
 | ------------------------------------ | -------- | ----------------------------------------------------------- |
+| `MANIFEST_THEME_LWT_ALIAS`           | warning  | Theme LWT aliases are deprecated                            |
 | `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning  | Theme image file extension should match its mime type       |
 | `MANIFEST_THEME_IMAGE_NOT_FOUND`     | error    | Theme images must not be missing                            |
 | `MANIFEST_THEME_IMAGE_CORRUPTED`     | error    | Theme images must not be corrupted                          |

--- a/src/const.js
+++ b/src/const.js
@@ -124,6 +124,13 @@ export const MIME_TO_FILE_EXTENSIONS = {
 // List of the mime types for the allowed static theme images.
 export const STATIC_THEME_IMAGE_MIMES = Object.keys(MIME_TO_FILE_EXTENSIONS);
 
+// List of deprecated static theme's LWT aliases.
+export const STATIC_THEME_LWT_ALIASES = [
+  '/theme/images/headerURL',
+  '/theme/colors/accentcolor',
+  '/theme/colors/textcolor',
+];
+
 // A list of magic numbers that we won't allow.
 export const FLAGGED_FILE_MAGIC_NUMBERS = [
   [0x4d, 0x5a], // EXE or DLL,

--- a/src/const.js
+++ b/src/const.js
@@ -124,11 +124,12 @@ export const MIME_TO_FILE_EXTENSIONS = {
 // List of the mime types for the allowed static theme images.
 export const STATIC_THEME_IMAGE_MIMES = Object.keys(MIME_TO_FILE_EXTENSIONS);
 
-// List of deprecated static theme's LWT aliases.
-export const STATIC_THEME_LWT_ALIASES = [
+// List of the "schema data paths" of the deprecated static theme's LWT aliases.
+export const DEPRECATED_STATIC_THEME_LWT_ALIASES = [
   '/theme/images/headerURL',
   '/theme/colors/accentcolor',
   '/theme/colors/textcolor',
+  '/theme/colors/toolbar_text',
 ];
 
 // A list of magic numbers that we won't allow.

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -298,6 +298,17 @@ export function corruptIconFile({ path }) {
   };
 }
 
+export const MANIFEST_THEME_LWT_ALIAS = {
+  code: 'MANIFEST_THEME_LWT_ALIAS',
+  message: i18n._('This theme LWT alias is deprecated.'),
+  // TODO: update the short link included in the description with one that
+  // points directly to a section which describes the changes needed.
+  description: i18n._(
+    'See https://mzl.la/1ZOhoEN (MDN Docs) for more information.'
+  ),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_THEME_IMAGE_NOT_FOUND = 'MANIFEST_THEME_IMAGE_NOT_FOUND';
 export function manifestThemeImageMissing(path, type) {
   return {

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -301,10 +301,8 @@ export function corruptIconFile({ path }) {
 export const MANIFEST_THEME_LWT_ALIAS = {
   code: 'MANIFEST_THEME_LWT_ALIAS',
   message: i18n._('This theme LWT alias is deprecated.'),
-  // TODO: update the short link included in the description with one that
-  // points directly to a section which describes the changes needed.
   description: i18n._(
-    'See https://mzl.la/1ZOhoEN (MDN Docs) for more information.'
+    'See https://mzl.la/2T11Lkc (MDN Docs) for more information.'
   ),
   file: MANIFEST_JSON,
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -203,7 +203,7 @@ export default class ManifestJSONParser extends JSONParser {
         // Overwrite the message with the shorter one included in the linter messages.
         overrides.message = baseObject.message;
       }
-      // TODO: add a messages.MANIFEST_FIELD_DEPRECATED and ensure that deprecated
+      // TODO(#2462): add a messages.MANIFEST_FIELD_DEPRECATED and ensure that deprecated
       // properties are handled properly (e.g. we should also detect when the deprecated
       // keyword is actually used to warn the developer of additional properties not
       // explicitly defined in the schemas).

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -16,6 +16,7 @@ import {
   validateStaticTheme,
 } from 'schema/validator';
 import {
+  DEPRECATED_STATIC_THEME_LWT_ALIASES,
   MANIFEST_JSON,
   PACKAGE_EXTENSION,
   CSP_KEYWORD_RE,
@@ -24,7 +25,6 @@ import {
   MESSAGES_JSON,
   MIME_TO_FILE_EXTENSIONS,
   STATIC_THEME_IMAGE_MIMES,
-  STATIC_THEME_LWT_ALIASES,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -197,7 +197,7 @@ export default class ManifestJSONParser extends JSONParser {
     } else if (error.keyword === 'deprecated') {
       if (
         this.isStaticTheme &&
-        STATIC_THEME_LWT_ALIASES.includes(error.dataPath)
+        DEPRECATED_STATIC_THEME_LWT_ALIASES.includes(error.dataPath)
       ) {
         baseObject = messages.MANIFEST_THEME_LWT_ALIAS;
         // Overwrite the message with the shorter one included in the linter messages.

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -236,8 +236,8 @@ export default class ManifestJSONParser extends JSONParser {
     // that are just warnings should be added to this array.
     const warnings = [
       messages.MANIFEST_PERMISSIONS.code,
-      // Remove the following once the LWT aliases deprecated property should
-      // become errors on submission.
+      // TODO(#2463): Remove the following once the LWT aliases deprecated
+      // property should become errors on submission.
       messages.MANIFEST_THEME_LWT_ALIAS.code,
     ];
     let validate = validateAddon;

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -5,7 +5,7 @@ import { deepPatch } from 'schema/deepmerge';
 import schemaObject from 'schema/imported/manifest';
 import themeSchemaObject from 'schema/imported/theme';
 import messagesSchemaObject from 'schema/messages';
-import { STATIC_THEME_LWT_ALIASES } from 'const';
+import { DEPRECATED_STATIC_THEME_LWT_ALIASES } from 'const';
 
 import {
   imageDataOrStrictRelativeUrl,
@@ -58,7 +58,7 @@ validator.addFormat(
 
 validator.addKeyword('deprecated', {
   validate: function validateDeprecated(message, propValue, schema, dataPath) {
-    if (!STATIC_THEME_LWT_ALIASES.includes(dataPath)) {
+    if (!DEPRECATED_STATIC_THEME_LWT_ALIASES.includes(dataPath)) {
       // Do not emit errors for every deprecated property, as it may introduce
       // regressions due to unexpected new deprecation messages raised as errors,
       // better to deal with it separately.

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -5,6 +5,7 @@ import { deepPatch } from 'schema/deepmerge';
 import schemaObject from 'schema/imported/manifest';
 import themeSchemaObject from 'schema/imported/theme';
 import messagesSchemaObject from 'schema/messages';
+import { STATIC_THEME_LWT_ALIASES } from 'const';
 
 import {
   imageDataOrStrictRelativeUrl,
@@ -54,6 +55,27 @@ validator.addFormat(
   'imageDataOrStrictRelativeUrl',
   imageDataOrStrictRelativeUrl
 );
+
+validator.addKeyword('deprecated', {
+  validate: function validateDeprecated(message, propValue, schema, dataPath) {
+    if (!STATIC_THEME_LWT_ALIASES.includes(dataPath)) {
+      // Do not emit errors for every deprecated property, as it may introduce
+      // regressions due to unexpected new deprecation messages raised as errors,
+      // better to deal with it separately.
+      return true;
+    }
+
+    validateDeprecated.errors = [
+      {
+        keyword: 'deprecated',
+        message,
+      },
+    ];
+
+    return false;
+  },
+  errors: true,
+});
 
 function filterErrors(errors) {
   if (errors) {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -195,11 +195,11 @@ export function validStaticThemeManifestJSON(extra) {
         version: '1.0',
         theme: {
           images: {
-            headerURL: 'weta.png',
+            theme_frame: 'weta.png',
           },
           colors: {
-            accentcolor: '#adb09f',
-            textcolor: '#000',
+            frame: '#adb09f',
+            tab_background_text: '#000',
             background_tab_text: 'rgba(255, 192, 0, 0)',
             toolbar_text: 'rgb(255, 255, 255),',
             toolbar_field_text: 'hsl(120, 100%, 50%)',

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -201,7 +201,7 @@ export function validStaticThemeManifestJSON(extra) {
             frame: '#adb09f',
             tab_background_text: '#000',
             background_tab_text: 'rgba(255, 192, 0, 0)',
-            toolbar_text: 'rgb(255, 255, 255),',
+            bookmark_text: 'rgb(255, 255, 255),',
             toolbar_field_text: 'hsl(120, 100%, 50%)',
           },
         },

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1541,9 +1541,15 @@ describe('ManifestJSONParser', () => {
         linter.collector,
         { io: { files: { 'options.html': '' } } }
       );
+
+      // Ignore warnings triggered by the rules related to mdn-browser-compat-data.
+      const warnings = linter.collector.warnings.filter((msg) => {
+        return msg.code !== 'KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION';
+      });
+
       expect(manifestJSONParser.isValid).toBeTruthy();
       expect(linter.collector.errors.length).toBe(0);
-      expect(linter.collector.warnings.length).toBe(0);
+      expect(warnings.length).toBe(0);
     });
   });
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -2088,7 +2088,7 @@ describe('ManifestJSONParser', () => {
             frame: '#adb09f',
             tab_background_text: '#000',
             background_tab_text: 'rgba(255, 192, 0, 0)',
-            toolbar_text: 'rgb(255, 255, 255),',
+            bookmark_text: 'rgb(255, 255, 255),',
             toolbar_field_text: 'hsl(120, 100%, 50%)',
           },
         },
@@ -2121,6 +2121,7 @@ describe('ManifestJSONParser', () => {
             colors: {
               accentcolor: '#000',
               textcolor: '#000',
+              toolbar_text: '#000',
             },
           },
         });
@@ -2154,6 +2155,10 @@ describe('ManifestJSONParser', () => {
           {
             ...commonWarnProps,
             dataPath: '/theme/colors/textcolor',
+          },
+          {
+            ...commonWarnProps,
+            dataPath: '/theme/colors/toolbar_text',
           },
         ];
 


### PR DESCRIPTION
This PR introduces a new `MANIFEST_THEME_LWT_ALIAS` rule, which is meant to warn the static themes authors of the incoming deprecation of the LWT alias properties.

In this PR this rule is currently considered a warning, which should be turned into an error once we want to prevent new theme submission from using this LWT aliases. 

Fixes #2259 

TODO lists:

- [x] double check with @nt1m that I didn't missed any static theme LWT aliases that should be marked as deprecated
  - [x] add `toolbar_text` to the deprecated aliases (aliased to `bookmark_text`, see [Bug 1472740 comment 8](https://bugzilla.mozilla.org/show_bug.cgi?id=1472740#c8))
- [x] double check with @eviljeff any additional part that may need to happen on the AMO server side (e.g. as part of the conversion of the LWT themes into static themes, we may want to avoid any of the LWT alias properties that are going to be deprecated) 
- [x] submit mozilla-central patch to add the deprecated property on the theme API schemas (as part of  [Bug 1472740 Remove aliased property names from themes](https://bugzilla.mozilla.org/show_bug.cgi?id=1472740))
- [x] rebase this PR on a recent repository head (so that this PR is rebased on top of the imported API schemas introduced in #2325)
- [x] fix test failure related to the linter warnings generated by the mdn-browser-compat-data validation rules 
- [x] change the short link included in the linting rule message's description property to one that points to a section of an MDN doc page which help the author to apply the needed changes (mdn/sprints#821)
- [x] file a follow up to turn `MANIFEST_THEME_LWT_ALIAS` rule from a warning into an error (#2463)
- [x] file a follow up to handle the `deprecated` keyword for the other API schemas (prevented in this PR to avoid regressions unrelated to the goal of this particular issue) (filed as #2462)