### PR TITLE
feat: detect API and manifest key incompatibilities with strict_min_version (#1493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Dependencies are automatically kept up-to-date using [greenkeeper](http://greenk
 | npm run test-coverage-once      | Runs the tests once with coverage                                                |
 | npm run test-integration-linter | Runs our integration test-suite                                                  |
 | npm run prettier                | Automatically format the whole code-base with Prettier                           |
-| npm run prettier-dev            | Automatically compare and format modified source files against the master branch   |
+| npm run prettier-dev            | Automatically compare and format modified source files against the master branch |
 
 ### Building
 

--- a/docs/import-firefox-schema.md
+++ b/docs/import-firefox-schema.md
@@ -29,5 +29,5 @@ And import the schema.
 
 ## Things to check for further updates
 
-* Review the schema update carefully and see if there are any updates that require additional linting / warning from the linter (e.g properties that are meant for internal add-ons and shouldn't be used by regular add-ons, ask around if unsure)
-* Check for custom format validations in ``src/schema/formats.js`` and update accordingly with upstream code (e.g ``manifestShortcutKey``)
+- Review the schema update carefully and see if there are any updates that require additional linting / warning from the linter (e.g properties that are meant for internal add-ons and shouldn't be used by regular add-ons, ask around if unsure)
+- Check for custom format validations in `src/schema/formats.js` and update accordingly with upstream code (e.g `manifestShortcutKey`)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -6,30 +6,32 @@ Rules are sorted by severity.
 
 ## JavaScript
 
-| Message code              | Severity | Description                                                      |
-| ------------------------- | -------- | ---------------------------------------------------------------- |
-| `KNOWN_LIBRARY`           | notice   | This is version of a JS library is known and generally accepted. |
-| `OPENDIALOG_NONLIT_URI`   | notice   | openDialog called with non-literal parameter.                    |
-| `EVENT_LISTENER_FOURTH`   | notice   | `addEventListener` called with truthy fourth argument.           |
-| `UNEXPECTED_GLOGAL_ARG`   | warning  | Unexpected global passed as an argument.                         |
-| `NO_IMPLIED_EVAL`         | warning  | disallow the use of `eval()`-like methods.                       |
-| `OPENDIALOG_REMOTE_URI`   | warning  | openDialog called with non-local URI.                            |
-| `NO_DOCUMENT_WRITE`       | warning  | Use of `document.write` strongly discouraged.                    |
-| `JS_SYNTAX_ERROR`         | warning  | JavaScript compile-time error.                                   |
-| `UNADVISED_LIBRARY`       | warning  | This version of a JS library is not recommended.                 |
-| `TABS_GETSELECTED`        | warning  | Deprecated API `tabs.getSelected`.                               |
-| `TABS_SENDREQUEST`        | warning  | Deprecated API `tabs.sendRequest`.                               |
-| `TABS_GETALLINWINDOW`     | warning  | Deprecated API `tabs.getAllInWindow`.                            |
-| `TABS_ONSELECTIONCHANGED` | warning  | Deprecated API `tabs.onSelectionChanged`.                        |
-| `TABS_ONACTIVECHANGED`    | warning  | Deprecated API `tabs.onActiveChanged`.                           |
-| `EXT_SENDREQUEST`         | warning  | Deprecated API `extension.sendRequest`.                          |
-| `EXT_ONREQUESTEXTERNAL`   | warning  | Deprecated API `extension.onRequestExternal`.                    |
-| `EXT_ONREQUEST`           | warning  | Deprecated API `extension.onRequest`.                            |
-| `APP_GETDETAILS`          | warning  | Deprecated API `app.getDetails`.                                 |
-| `STORAGE_LOCAL`           | warning  | Temporary IDs can cause issues with `storage.local`.             |
-| `STORAGE_SYNC`            | warning  | Temporary IDs can cause issues with `storage.sync`.              |
-| `IDENTITY_GETREDIRECTURL` | warning  | Temporary IDs can cause issues with `identity.getRedirectURL`.   |
-| `BANNED_LIBRARY`          | error    | This version of a JS library is banned for security reasons.     |
+| Message code               | Severity | Description                                                                            |
+| -------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `KNOWN_LIBRARY`            | notice   | This is version of a JS library is known and generally accepted.                       |
+| `OPENDIALOG_NONLIT_URI`    | notice   | openDialog called with non-literal parameter.                                          |
+| `EVENT_LISTENER_FOURTH`    | notice   | `addEventListener` called with truthy fourth argument.                                 |
+| `UNEXPECTED_GLOGAL_ARG`    | warning  | Unexpected global passed as an argument.                                               |
+| `NO_IMPLIED_EVAL`          | warning  | disallow the use of `eval()`-like methods.                                             |
+| `OPENDIALOG_REMOTE_URI`    | warning  | openDialog called with non-local URI.                                                  |
+| `NO_DOCUMENT_WRITE`        | warning  | Use of `document.write` strongly discouraged.                                          |
+| `JS_SYNTAX_ERROR`          | warning  | JavaScript compile-time error.                                                         |
+| `UNADVISED_LIBRARY`        | warning  | This version of a JS library is not recommended.                                       |
+| `TABS_GETSELECTED`         | warning  | Deprecated API `tabs.getSelected`.                                                     |
+| `TABS_SENDREQUEST`         | warning  | Deprecated API `tabs.sendRequest`.                                                     |
+| `TABS_GETALLINWINDOW`      | warning  | Deprecated API `tabs.getAllInWindow`.                                                  |
+| `TABS_ONSELECTIONCHANGED`  | warning  | Deprecated API `tabs.onSelectionChanged`.                                              |
+| `TABS_ONACTIVECHANGED`     | warning  | Deprecated API `tabs.onActiveChanged`.                                                 |
+| `EXT_SENDREQUEST`          | warning  | Deprecated API `extension.sendRequest`.                                                |
+| `EXT_ONREQUESTEXTERNAL`    | warning  | Deprecated API `extension.onRequestExternal`.                                          |
+| `EXT_ONREQUEST`            | warning  | Deprecated API `extension.onRequest`.                                                  |
+| `APP_GETDETAILS`           | warning  | Deprecated API `app.getDetails`.                                                       |
+| `STORAGE_LOCAL`            | warning  | Temporary IDs can cause issues with `storage.local`.                                   |
+| `STORAGE_SYNC`             | warning  | Temporary IDs can cause issues with `storage.sync`.                                    |
+| `IDENTITY_GETREDIRECTURL`  | warning  | Temporary IDs can cause issues with `identity.getRedirectURL`.                         |
+| `BANNED_LIBRARY`           | error    | This version of a JS library is banned for security reasons.                           |
+| `INCOMPATIBLE_API`         | warning  | API not compatible with `applications.gecko.strict_min_version`                        |
+| `ANDROID_INCOMPATIBLE_API` | warning  | API not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
 
 ## Markup
 
@@ -49,9 +51,9 @@ Rules are sorted by severity.
 
 ## Content
 
-| Message code   | Severity | Description            |
-| -------------- | -------- | ---------------------- |
-| `HIDDEN_FILE`  | warning  | Hidden file flagged.     |
+| Message code   | Severity | Description             |
+| -------------- | -------- | ----------------------- |
+| `HIDDEN_FILE`  | warning  | Hidden file flagged.    |
 | `FLAGGED_FILE` | warning  | Flagged filename found. |
 
 ## Package layout
@@ -59,12 +61,12 @@ Rules are sorted by severity.
 | Message code               | Severity | Description                                         |
 | -------------------------- | -------- | --------------------------------------------------- |
 | `MOZILLA_COND_OF_USE`      | notice   | Mozilla conditions of use violation.                |
-| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                    |
-| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                        |
+| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                   |
+| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                       |
 | `DUPLICATE_XPI_ENTRY`      | warning  | Package contains duplicate entries                  |
 | `ALREADY_SIGNED`           | warning  | Already signed                                      |
 | `COINMINER_USAGE_DETECTED` | warning  | Firefox add-ons are not allowed to run coin miners. |
-| `BAD_ZIPFILE`              | error    | Bad zip file                                         |
+| `BAD_ZIPFILE`              | error    | Bad zip file                                        |
 | `FILE_TOO_LARGE`           | error    | File is too large to parse                          |
 
 ## Type detection
@@ -75,52 +77,56 @@ Rules are sorted by severity.
 
 ## Language packs
 
-| Message code   | Severity | Description                 |
-| -------------- | -------- | --------------------------- |
+| Message code   | Severity | Description                   |
+| -------------- | -------- | ----------------------------- |
 | FLUENT_INVALID | warning  | Invalid fluent template file. |
 
 ## Web Extensions / manifest.json
 
-| Message code                | Severity | Description                                                          |
-| --------------------------- | -------- | -------------------------------------------------------------------- |
-| `MANIFEST_UNUSED_UPDATE`    | notice   | update_url ignored in manifest.json                                  |
-| `PROP_VERSION_TOOLKIT_ONLY` | notice   | version is in the toolkit format in manifest.json                    |
-| `CORRUPT_ICON_FILE`         | warning  | Icons must not be corrupt                                            |
-| `MANIFEST_CSP`              | warning  | content_security_policy in manifest.json means more review           |
-| `MANIFEST_CSP_UNSAFE_EVAL`  | warning  | usage of 'unsafe-eval' is strongly discouraged                       |
-| `MANIFEST_PERMISSIONS`      | warning  | Unknown permission                                                   |
-| `NO_MESSAGES_FILE`          | warning  | When default_locale is specified a matching messages.json must exist |
-| `NO_DEFAULT_LOCALE`         | warning  | When \_locales directory exists, default_locale must exist           |
-| `UNSAFE_VAR_ASSIGNMENT`     | warning  | Assignment using dynamic, unsanitized values                         |
-| `UNSUPPORTED_API`           | warning  | Unsupported or unknown browser API                                   |
-| `DANGEROUS_EVAL`            | warning  | `eval` and the `Function` constructor are discouraged                |
-| `STRICT_MAX_VERSION`        | warning  | strict_max_version not required                                      |
-| `PREDEFINED_MESSAGE_NAME`   | warning  | String name is reserved for a predefined                             |
-| `MISSING_PLACEHOLDER`       | warning  | Placeholder for message is not                                       |
-| `WRONG_ICON_EXTENSION`      | error    | Icons must have valid extension                                      |
-| `MANIFEST_UPDATE_URL`       | error    | update_url not allowed in manifest.json                              |
-| `MANIFEST_FIELD_REQUIRED`   | error    | A required field is missing                                          |
-| `MANIFEST_FIELD_INVALID`    | error    | A field is invalid                                                   |
-| `MANIFEST_BAD_PERMISSION`   | error    | Bad permission                                                       |
-| `JSON_BLOCK_COMMENTS`       | error    | Block Comments are not allowed in JSON                               |
-| `MANIFEST_INVALID_CONTENT`  | error    | This add-on contains forbidden content                               |
-| `CONTENT_SCRIPT_NOT_FOUND`  | error    | Content script file could not be found                               |
-| `CONTENT_SCRIPT_EMPTY`      | error    | Content script file name should not be empty                         |
-| `NO_MESSAGE`                | error    | Translation string is missing the message                            |
-| `INVALID_MESSAGE_NAME`      | error    | String name contains invalid characters                              |
-| `INVALID_PLACEHOLDER_NAME`  | error    | Placeholder name contains invalid characters                         |
-| `NO_PLACEHOLDER_CONTENT`    | error    | Placeholder is missing the content                                   |
-| `JSON_INVALID`              | error    | JSON is not well formed                                              |
-| `JSON_DUPLICATE_KEY`        | error    | Duplicate key in JSON                                                |
-| `MANIFEST_VERSION_INVALID`  | error    | manifest_version in manifest.json is not valid.                      |
-| `PROP_NAME_MISSING`         | error    | name property missing from manifest.json                             |
-| `PROP_NAME_INVALID`         | error    | name property is invalid in manifest.json                            |
-| `PROP_VERSION_MISSING`      | error    | version property missing from manifest.json                          |
-| `PROP_VERSION_INVALID`      | error    | version is invalid in manifest.json                                  |
-| `MANIFEST_DICT_NOT_FOUND`   | error    | A dictionary file defined in the manifest could not be found         |
-| `MANIFEST_MULTIPLE_DICTS`   | error    | Multiple dictionaries found                                          |
-| `MANIFEST_EMPTY_DICTS`      | error    | Empty `dictionaries` object                                          |
-| `MANIFEST_DICT_MISSING_ID`  | error    | Missing `applications.gecko.id` property for a dictionary            |
+| Message code                                            | Severity | Description                                                                                     |
+| ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `MANIFEST_UNUSED_UPDATE`                                | notice   | update_url ignored in manifest.json                                                             |
+| `PROP_VERSION_TOOLKIT_ONLY`                             | notice   | version is in the toolkit format in manifest.json                                               |
+| `CORRUPT_ICON_FILE`                                     | warning  | Icons must not be corrupt                                                                       |
+| `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
+| `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
+| `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
+| `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
+| `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
+| `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |
+| `UNSUPPORTED_API`                                       | warning  | Unsupported or unknown browser API                                                              |
+| `DANGEROUS_EVAL`                                        | warning  | `eval` and the `Function` constructor are discouraged                                           |
+| `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
+| `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
+| `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
+| `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |
+| `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                         |
+| `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
+| `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
+| `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
+| `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
+| `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
+| `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |
+| `CONTENT_SCRIPT_EMPTY`                                  | error    | Content script file name should not be empty                                                    |
+| `NO_MESSAGE`                                            | error    | Translation string is missing the message                                                       |
+| `INVALID_MESSAGE_NAME`                                  | error    | String name contains invalid characters                                                         |
+| `INVALID_PLACEHOLDER_NAME`                              | error    | Placeholder name contains invalid characters                                                    |
+| `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                              |
+| `JSON_INVALID`                                          | error    | JSON is not well formed                                                                         |
+| `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                           |
+| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid.                                                 |
+| `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                        |
+| `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                       |
+| `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                     |
+| `PROP_VERSION_INVALID`                                  | error    | version is invalid in manifest.json                                                             |
+| `MANIFEST_DICT_NOT_FOUND`                               | error    | A dictionary file defined in the manifest could not be found                                    |
+| `MANIFEST_MULTIPLE_DICTS`                               | error    | Multiple dictionaries found                                                                     |
+| `MANIFEST_EMPTY_DICTS`                                  | error    | Empty `dictionaries` object                                                                     |
+| `MANIFEST_DICT_MISSING_ID`                              | error    | Missing `applications.gecko.id` property for a dictionary                                       |
+| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`                | warning  | Manifest key not compatible with `applications.gecko.strict_min_version`                        |
+| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
+| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
 
 ### Static Theme / manifest.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,6 +8949,14 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "mdn-browser-compat-data": {
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.58.tgz",
+      "integrity": "sha512-GAHF85Lez8ZMt/lBWr+eyBXUqwhSe1O0uEVX4bZ4bkZbnVi2y5gUsJ34iTUytLAj/PkpzQfBfBcUr3628c/mEA==",
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "glob": "7.1.3",
     "is-mergeable-object": "1.1.0",
     "jed": "1.1.1",
+    "mdn-browser-compat-data": "0.0.58",
     "os-locale": "3.0.1",
     "pino": "5.9.0",
     "po2json": "0.4.5",

--- a/src/const.js
+++ b/src/const.js
@@ -25,6 +25,8 @@ export const ESLINT_RULE_MAPPING = Object.assign(
     'webextension-api': ESLINT_WARNING,
     'webextension-unsupported-api': ESLINT_WARNING,
     'content-scripts-file-absent': ESLINT_ERROR,
+    'webextension-api-compat': ESLINT_WARNING,
+    'webextension-api-compat-android': ESLINT_WARNING,
   },
   EXTERNAL_RULE_MAPPING
 );

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -160,10 +160,34 @@ export const STORAGE_LOCAL = temporaryAPI('storage.local');
 export const STORAGE_SYNC = temporaryAPI('storage.sync');
 export const IDENTITY_GETREDIRECTURL = temporaryAPI('identity.getRedirectURL');
 
+export const INCOMPATIBLE_API = {
+  code: 'INCOMPATIBLE_API',
+  message: null,
+  messageFormat: i18n._(
+    '{{api}} is not supported in Firefox version {{minVersion}}'
+  ),
+  description: i18n._(
+    'This API is not implemented by the given minimum Firefox version'
+  ),
+};
+
+export const ANDROID_INCOMPATIBLE_API = {
+  code: 'ANDROID_INCOMPATIBLE_API',
+  message: null,
+  messageFormat: i18n._(
+    '{{api}} is not supported in Firefox for Android version {{minVersion}}'
+  ),
+  description: i18n._(
+    'This API is not implemented by the given minimum Firefox for Android version'
+  ),
+};
+
 export const ESLINT_OVERWRITE_MESSAGE = {
   'no-eval': DANGEROUS_EVAL,
   'no-implied-eval': NO_IMPLIED_EVAL,
   'no-new-func': DANGEROUS_EVAL,
   'no-unsafe-innerhtml/no-unsafe-innerhtml': UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT,
   'webextension-unsupported-api': UNSUPPORTED_API,
+  'webextension-api-compat': INCOMPATIBLE_API,
+  'webextension-api-compat-android': ANDROID_INCOMPATIBLE_API,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -418,3 +418,91 @@ export function noMessagesFileInLocales(path) {
     file: MANIFEST_JSON,
   };
 }
+
+export const KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION =
+  'KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION';
+export function keyFirefoxUnsupportedByMinVersion(
+  key,
+  minVersion,
+  versionAdded
+) {
+  return {
+    code: KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION,
+    message: i18n._(
+      'Manifest key not supported by the specified minimum Firefox version'
+    ),
+    description: i18n.sprintf(
+      i18n._(oneLine`"strict_min_version" requires Firefox %(minVersion)s, which
+        was released before version %(versionAdded)s introduced support for
+        "%(key)s".`),
+      { key, minVersion, versionAdded }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
+export const PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION =
+  'èERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION';
+export function permissionFirefoxUnsupportedByMinVersion(
+  key,
+  minVersion,
+  versionAdded
+) {
+  return {
+    code: PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION,
+    message: i18n._(
+      'Permission not supported by the specified minimum Firefox version'
+    ),
+    description: i18n.sprintf(
+      i18n._(oneLine`"strict_min_version" requires Firefox %(minVersion)s, which
+        was released before version %(versionAdded)s introduced support for
+        "%(key)s".`),
+      { key, minVersion, versionAdded }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
+export const KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION =
+  'KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION';
+export function keyFirefoxAndroidUnsupportedByMinVersion(
+  key,
+  minVersion,
+  versionAdded
+) {
+  return {
+    code: KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION,
+    message: i18n._(
+      'Manifest key not supported by the specified minimum Firefox for Android version'
+    ),
+    description: i18n.sprintf(
+      i18n._(oneLine`"strict_min_version" requires Firefox for Android
+        %(minVersion)s, which was released before version %(versionAdded)s
+        introduced support for "%(key)s".`),
+      { key, minVersion, versionAdded }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
+export const PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION =
+  'PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION';
+export function permissionFirefoxAndroidUnsupportedByMinVersion(
+  key,
+  minVersion,
+  versionAdded
+) {
+  return {
+    code: PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION,
+    message: i18n._(
+      'Permission not supported by the specified minimum Firefox for Android version'
+    ),
+    description: i18n.sprintf(
+      i18n._(oneLine`"strict_min_version" requires Firefox for Android
+        %(minVersion)s, which was released before version %(versionAdded)s
+        introduced support for "%(key)s".`),
+      { key, minVersion, versionAdded }
+    ),
+    file: MANIFEST_JSON,
+  };
+}

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -442,7 +442,7 @@ export function keyFirefoxUnsupportedByMinVersion(
 }
 
 export const PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION =
-  'èERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION';
+  'PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION';
 export function permissionFirefoxUnsupportedByMinVersion(
   key,
   minVersion,

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -14,5 +14,8 @@ module.exports = {
       .default,
     'webextension-unsupported-api': require('./webextension-unsupported-api')
       .default,
+    'webextension-api-compat': require('./webextension-api-compat').default,
+    'webextension-api-compat-android': require('./webextension-api-compat-android')
+      .default,
   },
 };

--- a/src/rules/javascript/webextension-api-compat-android.js
+++ b/src/rules/javascript/webextension-api-compat-android.js
@@ -1,0 +1,49 @@
+import bcd from 'mdn-browser-compat-data';
+
+import { ANDROID_INCOMPATIBLE_API } from 'messages/javascript';
+import {
+  isBrowserNamespace,
+  firefoxStrictMinVersion,
+  isCompatible,
+} from 'utils';
+import { hasBrowserApi } from 'schema/browser-apis';
+
+export default {
+  create(context) {
+    const minVersion =
+      context.settings.addonMetadata &&
+      firefoxStrictMinVersion({
+        applications: {
+          gecko: {
+            strict_min_version:
+              context.settings.addonMetadata.firefoxMinVersion,
+          },
+        },
+      });
+    if (minVersion) {
+      return {
+        MemberExpression(node) {
+          if (
+            !node.computed &&
+            node.object.object &&
+            isBrowserNamespace(node.object.object.name)
+          ) {
+            const namespace = node.object.property.name;
+            const property = node.property.name;
+            const api = `${namespace}.${property}`;
+            if (
+              hasBrowserApi(namespace, property) &&
+              !isCompatible(bcd, api, minVersion, 'firefox_android')
+            ) {
+              context.report(node, ANDROID_INCOMPATIBLE_API.messageFormat, {
+                api,
+                minVersion: context.settings.addonMetadata.firefoxMinVersion,
+              });
+            }
+          }
+        },
+      };
+    }
+    return {};
+  },
+};

--- a/src/rules/javascript/webextension-api-compat-android.js
+++ b/src/rules/javascript/webextension-api-compat-android.js
@@ -1,49 +1,17 @@
 import bcd from 'mdn-browser-compat-data';
 
 import { ANDROID_INCOMPATIBLE_API } from 'messages/javascript';
-import {
-  isBrowserNamespace,
-  firefoxStrictMinVersion,
-  isCompatible,
-} from 'utils';
+import { createCompatibilityRule } from 'utils';
 import { hasBrowserApi } from 'schema/browser-apis';
 
 export default {
   create(context) {
-    const minVersion =
-      context.settings.addonMetadata &&
-      firefoxStrictMinVersion({
-        applications: {
-          gecko: {
-            strict_min_version:
-              context.settings.addonMetadata.firefoxMinVersion,
-          },
-        },
-      });
-    if (minVersion) {
-      return {
-        MemberExpression(node) {
-          if (
-            !node.computed &&
-            node.object.object &&
-            isBrowserNamespace(node.object.object.name)
-          ) {
-            const namespace = node.object.property.name;
-            const property = node.property.name;
-            const api = `${namespace}.${property}`;
-            if (
-              hasBrowserApi(namespace, property) &&
-              !isCompatible(bcd, api, minVersion, 'firefox_android')
-            ) {
-              context.report(node, ANDROID_INCOMPATIBLE_API.messageFormat, {
-                api,
-                minVersion: context.settings.addonMetadata.firefoxMinVersion,
-              });
-            }
-          }
-        },
-      };
-    }
-    return {};
+    return createCompatibilityRule(
+      'firefox_android',
+      ANDROID_INCOMPATIBLE_API,
+      context,
+      bcd,
+      hasBrowserApi
+    );
   },
 };

--- a/src/rules/javascript/webextension-api-compat.js
+++ b/src/rules/javascript/webextension-api-compat.js
@@ -1,49 +1,17 @@
 import bcd from 'mdn-browser-compat-data';
 
 import { INCOMPATIBLE_API } from 'messages/javascript';
-import {
-  isBrowserNamespace,
-  firefoxStrictMinVersion,
-  isCompatible,
-} from 'utils';
+import { createCompatibilityRule } from 'utils';
 import { hasBrowserApi } from 'schema/browser-apis';
 
 export default {
   create(context) {
-    const minVersion =
-      context.settings.addonMetadata &&
-      firefoxStrictMinVersion({
-        applications: {
-          gecko: {
-            strict_min_version:
-              context.settings.addonMetadata.firefoxMinVersion,
-          },
-        },
-      });
-    if (minVersion) {
-      return {
-        MemberExpression(node) {
-          if (
-            !node.computed &&
-            node.object.object &&
-            isBrowserNamespace(node.object.object.name)
-          ) {
-            const namespace = node.object.property.name;
-            const property = node.property.name;
-            const api = `${namespace}.${property}`;
-            if (
-              hasBrowserApi(namespace, property) &&
-              !isCompatible(bcd, api, minVersion, 'firefox')
-            ) {
-              context.report(node, INCOMPATIBLE_API.messageFormat, {
-                api,
-                minVersion: context.settings.addonMetadata.firefoxMinVersion,
-              });
-            }
-          }
-        },
-      };
-    }
-    return {};
+    return createCompatibilityRule(
+      'firefox',
+      INCOMPATIBLE_API,
+      context,
+      bcd,
+      hasBrowserApi
+    );
   },
 };

--- a/src/rules/javascript/webextension-api-compat.js
+++ b/src/rules/javascript/webextension-api-compat.js
@@ -1,0 +1,49 @@
+import bcd from 'mdn-browser-compat-data';
+
+import { INCOMPATIBLE_API } from 'messages/javascript';
+import {
+  isBrowserNamespace,
+  firefoxStrictMinVersion,
+  isCompatible,
+} from 'utils';
+import { hasBrowserApi } from 'schema/browser-apis';
+
+export default {
+  create(context) {
+    const minVersion =
+      context.settings.addonMetadata &&
+      firefoxStrictMinVersion({
+        applications: {
+          gecko: {
+            strict_min_version:
+              context.settings.addonMetadata.firefoxMinVersion,
+          },
+        },
+      });
+    if (minVersion) {
+      return {
+        MemberExpression(node) {
+          if (
+            !node.computed &&
+            node.object.object &&
+            isBrowserNamespace(node.object.object.name)
+          ) {
+            const namespace = node.object.property.name;
+            const property = node.property.name;
+            const api = `${namespace}.${property}`;
+            if (
+              hasBrowserApi(namespace, property) &&
+              !isCompatible(bcd, api, minVersion, 'firefox')
+            ) {
+              context.report(node, INCOMPATIBLE_API.messageFormat, {
+                api,
+                minVersion: context.settings.addonMetadata.firefoxMinVersion,
+              });
+            }
+          }
+        },
+      };
+    }
+    return {};
+  },
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -365,3 +365,40 @@ export function couldBeMinifiedCode(code) {
     hugeLinesCount > hugeLinesThreshold
   );
 }
+
+export function firefoxStrictMinVersion(manifestJson) {
+  if (
+    manifestJson.applications &&
+    manifestJson.applications.gecko &&
+    manifestJson.applications.gecko.strict_min_version
+  ) {
+    return parseInt(
+      manifestJson.applications.gecko.strict_min_version.split('.')[0],
+      10
+    );
+  }
+  return null;
+}
+
+export function basicCompatVersionComparison(versionAdded, minVersion) {
+  const asNumber = parseInt(versionAdded, 10);
+  return !Number.isNaN(asNumber) && asNumber > minVersion;
+}
+
+export function isCompatible(bcd, path, minVersion, application) {
+  const steps = path.split('.');
+  let { api } = bcd.webextensions;
+  for (const step of steps) {
+    if (Object.prototype.hasOwnProperty.call(api, step)) {
+      api = api[step];
+    } else {
+      break;
+    }
+  }
+  // API namespace may be undocumented or not implemented, ignore in that case.
+  if (api.__compat) {
+    const versionAdded = api.__compat.support[application].version_added;
+    return !basicCompatVersionComparison(versionAdded, minVersion);
+  }
+  return true;
+}

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -132,7 +132,7 @@ export function validManifestJSON(extra) {
         applications: {
           gecko: {
             id: '{daf44bf7-a45e-4450-979c-91cf07434c3d}',
-            strict_min_version: '40.0.0',
+            strict_min_version: '48.0.0',
           },
         },
         version: '0.1',

--- a/tests/unit/rules/javascript/test.incompatible_browser_api.js
+++ b/tests/unit/rules/javascript/test.incompatible_browser_api.js
@@ -1,0 +1,66 @@
+import { VALIDATION_WARNING } from 'const';
+import JavaScriptScanner from 'scanners/javascript';
+
+describe('incompatible browser APIs', () => {
+  it('flags event that is not yet implemented at strict_min_version', async () => {
+    const code = 'browser.bookmarks.onChanged.addListener(() => {});';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { firefoxMinVersion: '50.0' },
+    });
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(1);
+    expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
+    expect(linterMessages[0].message).toEqual(
+      'bookmarks.onChanged is not supported in Firefox version 50.0'
+    );
+  });
+
+  it('flags method that is not yet implemented at strict_min_version', async () => {
+    const code = 'browser.clipboard.setImageData({}, "png");';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { firefoxMinVersion: '50.0' },
+    });
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(2);
+    for (const msg of linterMessages) {
+      expect(msg.type).toEqual(VALIDATION_WARNING);
+      expect(msg.message).toEqual(
+        expect.stringMatching(
+          /clipboard\.setImageData is not supported in Firefox(?: for Android)? version 50\.0/
+        )
+      );
+    }
+  });
+
+  it('does not flag APIs that are not implemented on Android', async () => {
+    const code = 'browser.browserAction.setBadgeText({ text: "lorem ipsum" });';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { firefoxMinVersion: '57.0a1' },
+    });
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(0);
+  });
+
+  it('does not flag method that is implemented in the strict_min_version', async () => {
+    const code = 'browser.clipboard.setImageData({}, "png");';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: { firefoxMinVersion: '57.0a1' },
+    });
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(0);
+  });
+
+  it('does not flag method that is not supported without strict_min_version', async () => {
+    const code = 'browser.clipboard.setImageData({}, "png");';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js', {
+      addonMetadata: {},
+    });
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages.length).toEqual(0);
+  });
+});


### PR DESCRIPTION
Fixes #1493

This is a first attempt at integrating the browser-compat-data from the MDN compatibility tables with the linter.
It currently checks for manifest keys, permissions and APIs to be supported by the given `strict_min_version` in the manifest for both Firefox and Firefox for Android. All produced messages are warnings. However, no warning is shown if Firefox or Firefox for Android do not implement an API and that is documented in the compat data. This is to avoid a lot of Firefox for Android spam, plus the totally unsupported APIs should be caught by the schemas.

I'm not quite happy with the amount of duplication of logic, even though it's subtly different for all cases, so improvement suggestions welcome! Further I'll happily add more tests, these are just the ones I could come up with.