### PR TITLE
fix: Add browser_specific_settings as alias for applications in manifest

### DIFF
--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -151,8 +151,8 @@ function temporaryAPI(api) {
     message: i18n._(`"${api}" can cause issues when loaded temporarily`),
     description: i18n._(oneLine`This API can cause issues when loaded
       temporarily using about:debugging in Firefox unless you specify
-      applications > gecko > id in the manifest. Please see:
-      https://mzl.la/2hizK4a for more.`),
+      applications|browser_specific_settings > gecko > id in the manifest.
+      Please see: https://mzl.la/2hizK4a for more.`),
   };
 }
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -101,8 +101,10 @@ export const PROP_VERSION_TOOLKIT_ONLY = {
 export const MANIFEST_UPDATE_URL = {
   code: 'MANIFEST_UPDATE_URL',
   message: i18n._('"update_url" is not allowed.'),
-  description: i18n._(oneLine`"applications.gecko.update_url" is not allowed
-    for Mozilla-hosted add-ons.`),
+  description: i18n._(oneLine`
+    "applications.gecko.update_url" or
+    "browser_specific_settings.gecko.update_url" are not allowed for
+    Mozilla-hosted add-ons.`),
   file: MANIFEST_JSON,
 };
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -70,6 +70,12 @@ export default class ManifestJSONParser extends JSONParser {
       };
     } else {
       // We've parsed the JSON; now we can validate the manifest.
+      if (
+        this.parsedJSON.browser_specific_settings &&
+        !this.parsedJSON.applications
+      ) {
+        this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;
+      }
       this.selfHosted = selfHosted;
       this.isLanguagePack = Object.prototype.hasOwnProperty.call(
         this.parsedJSON,

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -70,10 +70,7 @@ export default class ManifestJSONParser extends JSONParser {
       };
     } else {
       // We've parsed the JSON; now we can validate the manifest.
-      if (
-        this.parsedJSON.browser_specific_settings &&
-        !this.parsedJSON.applications
-      ) {
+      if (this.parsedJSON.browser_specific_settings) {
         this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;
       }
       this.selfHosted = selfHosted;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -70,12 +70,6 @@ export default class ManifestJSONParser extends JSONParser {
       };
     } else {
       // We've parsed the JSON; now we can validate the manifest.
-      if (
-        this.parsedJSON.browser_specific_settings &&
-        this.parsedJSON.browser_specific_settings.gecko
-      ) {
-        this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;
-      }
       this.selfHosted = selfHosted;
       this.isLanguagePack = Object.prototype.hasOwnProperty.call(
         this.parsedJSON,
@@ -172,6 +166,13 @@ export default class ManifestJSONParser extends JSONParser {
           this.isValid = false;
         }
       });
+    }
+
+    if (
+      this.parsedJSON.browser_specific_settings &&
+      this.parsedJSON.browser_specific_settings.gecko
+    ) {
+      this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;
     }
 
     if (this.parsedJSON.content_security_policy) {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -70,7 +70,10 @@ export default class ManifestJSONParser extends JSONParser {
       };
     } else {
       // We've parsed the JSON; now we can validate the manifest.
-      if (this.parsedJSON.browser_specific_settings) {
+      if (
+        this.parsedJSON.browser_specific_settings &&
+        this.parsedJSON.browser_specific_settings.gecko
+      ) {
         this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;
       }
       this.selfHosted = selfHosted;

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -46,15 +46,29 @@ describe('ManifestJSONParser', () => {
     const addonLinter = new Linter({ _: ['bar'] });
     const json = validManifestJSON({
       applications: undefined,
-      browser_specific_settings: { gecko: { id: 'foo@baa' } },
+      browser_specific_settings: {
+        gecko: {
+          id: 'foo@baa',
+          update_url: '',
+        },
+      },
     });
     const manifestJSONParser = new ManifestJSONParser(
       json,
       addonLinter.collector
     );
-    expect(manifestJSONParser.isValid).toEqual(true);
     const metadata = manifestJSONParser.getMetadata();
     expect(metadata.id).toEqual('foo@baa');
+
+    // Verify that any lint error added from the schema
+    // validation is not produced twice.
+    expect(manifestJSONParser.isValid).toEqual(false);
+    expect(addonLinter.collector.errors.length).toEqual(1);
+    assertHasMatchingError(addonLinter.collector.errors, {
+      code: messages.JSON_INVALID.code,
+      message: /update_url" should match format "secureUrl"/,
+      dataPath: '/browser_specific_settings/gecko/update_url',
+    });
   });
 
   describe('id', () => {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -46,7 +46,7 @@ describe('ManifestJSONParser', () => {
     const addonLinter = new Linter({ _: ['bar'] });
     const json = validManifestJSON({
       applications: undefined,
-      browser_specific_settings: {gecko: { id: 'foo@baa' } },
+      browser_specific_settings: { gecko: { id: 'foo@baa' } },
     });
     const manifestJSONParser = new ManifestJSONParser(
       json,

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -42,6 +42,21 @@ describe('ManifestJSONParser', () => {
     expect(metadata.version).toEqual(null);
   });
 
+  it('should see browser_specific_settings as alias of applications', () => {
+    const addonLinter = new Linter({ _: ['bar'] });
+    const json = validManifestJSON({
+      applications: undefined,
+      browser_specific_settings: {gecko: { id: 'foo@baa' } },
+    });
+    const manifestJSONParser = new ManifestJSONParser(
+      json,
+      addonLinter.collector
+    );
+    expect(manifestJSONParser.isValid).toEqual(true);
+    const metadata = manifestJSONParser.getMetadata();
+    expect(metadata.id).toEqual('foo@baa');
+  });
+
   describe('id', () => {
     it('should return the correct id', () => {
       const addonLinter = new Linter({ _: ['bar'] });


### PR DESCRIPTION
This PR supersedes #2285, it contains all the changes from the original PR with the following additions:

- the small fix suggested in the last review comment applied on top of the existing changes (See https://github.com/mozilla/addons-linter/pull/2285#discussion_r236677072)
- verify the above fix in the unit tests (with some small additions to the new test case added in the original PR)

(This PR doesn't include yet the additional warning message, tracked by #2294).

Fixes #2285 
Fixes #2280