### PR TITLE
feat(firefox-api-schema): Import Firefox 65.0b4 APIs schema

### DIFF
--- a/scripts/download-import-tag
+++ b/scripts/download-import-tag
@@ -2,9 +2,9 @@
 # Download a mozilla-unified tag into a temporary file
 #
 # Usage:
-#  * run `bin/list-firefox-tags 59` (change release as necessary) to list available tags
-#  * import the schema by running `bin/download-import-tag FIREFOX_60_0b10_RELEASE` (change the tag as necessary)
-
+#  * run `scripts/list-firefox-tags 59` (change release as necessary) to list available tags
+#  * import the schema by running `scripts/download-import-tag FIREFOX_60_0b10_RELEASE`
+#    (change the tag as necessary)
 
 if [ ! -e "tmp/$1.tar.gz" ]; then
     echo "tmp/$1.tar.gz doesn't exist, downloading..."
@@ -13,7 +13,7 @@ else
     echo "tmp/$1.tar.gz already exists, please make sure it's valid!"
 fi
 
-echo "Importing with bin/firefox-schema-import tmp/$1.tar.gz"
+echo "Importing with scripts/firefox-schema-import tmp/$1.tar.gz"
 
 # Now import the schema from that tag
-bin/firefox-schema-import "tmp/$1.tar.gz"
+scripts/firefox-schema-import "tmp/$1.tar.gz"

--- a/scripts/firefox-schema-import
+++ b/scripts/firefox-schema-import
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 let filePath;
 require('@babel/register');
 

--- a/scripts/list-firefox-tags
+++ b/scripts/list-firefox-tags
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-curl -s https://hg.mozilla.org/mozilla-unified/tags | grep -o "FIREFOX_$1[_a-zA-Z0-9]*" | sort -r | uniq | xargs -L1 echo bin/download-import-tag
+curl -s https://hg.mozilla.org/mozilla-unified/tags | grep -o "FIREFOX_$1[_a-zA-Z0-9]*" | sort -r | uniq | xargs -L1 echo scripts/download-import-tag

--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -83,6 +83,10 @@
                   "type": "integer",
                   "deprecated": "Unsupported on Firefox."
                 },
+                "encoding": {
+                  "type": "string",
+                  "description": "Encoding of the search term."
+                },
                 "is_default": {
                   "type": "boolean",
                   "description": "Sets the default engine to a built-in engine only."

--- a/src/schema/imported/context_menus.json
+++ b/src/schema/imported/context_menus.json
@@ -626,6 +626,11 @@
           "type": "string",
           "description": "The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu."
         },
+        "frameId": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The id of the frame of the element where the context menu was clicked."
+        },
         "frameUrl": {
           "type": "string",
           "description": " The URL of the frame of the element where the context menu was clicked, if it was in a frame."

--- a/src/schema/imported/downloads.json
+++ b/src/schema/imported/downloads.json
@@ -811,7 +811,8 @@
         },
         "totalBytesGreater": {
           "description": "Limits results to downloads whose totalBytes is greater than the given integer.",
-          "type": "number"
+          "type": "number",
+          "default": -1
         },
         "totalBytesLess": {
           "description": "Limits results to downloads whose totalBytes is less than the given integer.",

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -18,7 +18,11 @@
             "bufferSize": {
               "type": "integer",
               "minimum": 0,
-              "description": "The size in bytes of the buffer used to store profiling data. A larger value allows capturing a profile that covers a greater amount of time."
+              "description": "The maximum size in bytes of the buffer used to store profiling data. A larger value allows capturing a profile that covers a greater amount of time."
+            },
+            "windowLength": {
+              "type": "number",
+              "description": "The length of the window of time that's kept in the buffer. Any collected samples are discarded as soon as they are older than the number of seconds specified in this setting. Zero means no duration restriction."
             },
             "interval": {
               "type": "number",
@@ -149,7 +153,14 @@
         "stackwalk",
         "tasktracer",
         "threads",
-        "trackopts"
+        "trackopts",
+        "jstracer"
+      ]
+    },
+    "supports": {
+      "type": "string",
+      "enum": [
+        "windowLength"
       ]
     }
   }

--- a/src/schema/imported/menus.json
+++ b/src/schema/imported/menus.json
@@ -625,6 +625,11 @@
           "type": "string",
           "description": "The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu."
         },
+        "frameId": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The id of the frame of the element where the context menu was clicked."
+        },
         "frameUrl": {
           "type": "string",
           "description": " The URL of the frame of the element where the context menu was clicked, if it was in a frame."

--- a/src/schema/imported/omnibox.json
+++ b/src/schema/imported/omnibox.json
@@ -93,7 +93,7 @@
           "properties": {
             "keyword": {
               "type": "string",
-              "pattern": "^[^?\\s:]([^\\s:]*[^/\\s:])?$"
+              "pattern": "^[^?\\s:][^\\s:]*$"
             }
           },
           "required": [

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -604,6 +604,11 @@
             "loadReplace": {
               "type": "boolean",
               "description": "Whether the load should replace the current history entry for the tab."
+            },
+            "successorTabId": {
+              "type": "integer",
+              "minimum": -1,
+              "description": "The ID of this tab's successor. If specified, the successor tab must be in the same window as this tab."
             }
           }
         },
@@ -1227,6 +1232,49 @@
           ]
         }
       ]
+    },
+    {
+      "name": "moveInSuccession",
+      "type": "function",
+      "async": true,
+      "description": "Removes an array of tabs from their lines of succession and prepends or appends them in a chain to another tab.",
+      "parameters": [
+        {
+          "name": "tabIds",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "minItems": 1,
+          "description": "An array of tab IDs to move in the line of succession. For each tab in the array, the tab's current predecessors will have their successor set to the tab's current successor, and each tab will then be set to be the successor of the previous tab in the array. Any tabs not in the same window as the tab indicated by the second argument (or the first tab in the array, if no second argument) will be skipped."
+        },
+        {
+          "name": "tabId",
+          "type": "integer",
+          "optional": true,
+          "default": -1,
+          "minimum": -1,
+          "description": "The ID of a tab to set as the successor of the last tab in the array, or $(ref:tabs.TAB_ID_NONE) to leave the last tab without a successor. If options.append is true, then this tab is made the predecessor of the first tab in the array instead."
+        },
+        {
+          "name": "options",
+          "type": "object",
+          "optional": true,
+          "properties": {
+            "append": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to move the tabs before (false) or after (true) tabId in the succession. Defaults to false."
+            },
+            "insert": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to link up the current predecessors or successor (depending on options.append) of tabId to the other side of the chain after it is prepended or appended. If true, one of the following happens: if options.append is false, the first tab in the array is set as the successor of any current predecessors of tabId; if options.append is true, the current successor of tabId is set as the successor of the last tab in the array. Defaults to false."
+            }
+          }
+        }
+      ]
     }
   ],
   "events": [
@@ -1467,6 +1515,11 @@
               "type": "integer",
               "minimum": 0,
               "description": "The ID of the tab that has become active."
+            },
+            "previousTabId": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The ID of the tab that was previously active, if that tab is still open."
             },
             "windowId": {
               "type": "integer",
@@ -1905,6 +1958,11 @@
         "attention": {
           "type": "boolean",
           "description": "Whether the tab is drawing attention."
+        },
+        "successorTabId": {
+          "type": "integer",
+          "minimum": -1,
+          "description": "The ID of this tab's successor, if any; $(ref:tabs.TAB_ID_NONE) otherwise."
         }
       },
       "required": [

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -194,7 +194,14 @@
               "maxItems": 15
             },
             "headerURL": {
-              "$ref": "manifest#/types/ImageDataOrExtensionURL"
+              "allOf": [
+                {
+                  "$ref": "manifest#/types/ImageDataOrExtensionURL"
+                },
+                {
+                  "deprecated": "Please use <em>theme.images.theme_frame</em>, this alias will be removed in Firefox 69."
+                }
+              ]
             },
             "theme_frame": {
               "$ref": "manifest#/types/ImageDataOrExtensionURL"
@@ -211,7 +218,14 @@
               "$ref": "#/types/ThemeColor"
             },
             "accentcolor": {
-              "$ref": "#/types/ThemeColor"
+              "allOf": [
+                {
+                  "$ref": "#/types/ThemeColor"
+                },
+                {
+                  "deprecated": "Please use <em>theme.colors.frame</em>, this alias will be removed in Firefox 69."
+                }
+              ]
             },
             "frame": {
               "$ref": "#/types/ThemeColor"
@@ -220,7 +234,14 @@
               "$ref": "#/types/ThemeColor"
             },
             "textcolor": {
-              "$ref": "#/types/ThemeColor"
+              "allOf": [
+                {
+                  "$ref": "#/types/ThemeColor"
+                },
+                {
+                  "deprecated": "Please use <em>theme.colors.tab_background_text</em>, this alias will be removed in Firefox 69."
+                }
+              ]
             },
             "tab_background_text": {
               "$ref": "#/types/ThemeColor"
@@ -241,7 +262,14 @@
               "$ref": "#/types/ThemeColor"
             },
             "toolbar_text": {
-              "$ref": "#/types/ThemeColor"
+              "allOf": [
+                {
+                  "$ref": "#/types/ThemeColor"
+                },
+                {
+                  "deprecated": "Please use <em>theme.colors.bookmark_text</em>, this alias will be removed in Firefox 69."
+                }
+              ]
             },
             "bookmark_text": {
               "$ref": "#/types/ThemeColor"

--- a/src/schema/imported/userScripts.json
+++ b/src/schema/imported/userScripts.json
@@ -21,30 +21,6 @@
           ]
         }
       ]
-    },
-    {
-      "name": "setScriptAPIs",
-      "permissions": [
-        "manifest:user_scripts.api_script"
-      ],
-      "allowedContexts": [
-        "content",
-        "content_only"
-      ],
-      "type": "function",
-      "description": "Provides a set of custom API methods available to the registered userScripts",
-      "parameters": [
-        {
-          "allOf": [
-            {
-              "$ref": "#/types/ExportedAPIMethods"
-            },
-            {
-              "name": "exportedAPIMethods"
-            }
-          ]
-        }
-      ]
     }
   ],
   "definitions": {
@@ -154,16 +130,65 @@
           "parameters": []
         }
       ]
-    },
-    "ExportedAPIMethods": {
-      "type": "object",
-      "description": "A set of API methods provided by the extensions to its userScripts",
-      "additionalProperties": {
-        "type": "function"
-      }
     }
   },
   "allowedContexts": [
     "content"
+  ],
+  "events": [
+    {
+      "name": "onBeforeScript",
+      "permissions": [
+        "manifest:user_scripts.api_script"
+      ],
+      "allowedContexts": [
+        "content",
+        "content_only"
+      ],
+      "type": "function",
+      "description": "Event called when a new userScript global has been created",
+      "parameters": [
+        {
+          "type": "object",
+          "name": "userScript",
+          "properties": {
+            "metadata": {
+              "description": "The userScript metadata (as set in userScripts.register)"
+            },
+            "global": {
+              "description": "The userScript global"
+            },
+            "defineGlobals": {
+              "type": "function",
+              "description": "Exports all the properties of a given plain object as userScript globals",
+              "parameters": [
+                {
+                  "type": "object",
+                  "name": "sourceObject",
+                  "description": "A plain object whose properties are exported as userScript globals"
+                }
+              ]
+            },
+            "export": {
+              "type": "function",
+              "description": "Convert a given value to make it accessible to the userScript code",
+              "parameters": [
+                {
+                  "name": "value",
+                  "description": "A value to convert into an object accessible to the userScript"
+                }
+              ],
+              "returns": {}
+            }
+          },
+          "required": [
+            "metadata",
+            "global",
+            "defineGlobals",
+            "export"
+          ]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This PR contains:

- some minor follow up fixes related to the changes introduced by #2309 (which moved the "schema import" scripts from `bin/` to `scripts/`)
- Import Firefox 65.0b4 APIs schema 

The changes included in this PR are also helpful to be able to rebase and complete #2283 on top of the updated Firefox beta API schemas (and replace the "deprecated LWT theme property aliases" warning messages that I have temporarily imported in #2283 to be able to test it while we were waiting for Firefox 65 to reach beta).