### PR TITLE
Raise an error and not a notice when no manifest is found

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -268,7 +268,7 @@ export default class Linter {
       _log.warn(
         `No ${constants.MANIFEST_JSON} was found in the package metadata`
       );
-      this.collector.addNotice(messages.TYPE_NO_MANIFEST_JSON);
+      this.collector.addError(messages.TYPE_NO_MANIFEST_JSON);
       this.addonMetadata = {};
     }
     this.addonMetadata.totalScannedFileSize = 0;

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -997,15 +997,13 @@ describe('Linter.extractMetadata()', () => {
     };
 
     class FakeXpi extends FakeIOBase {
-      async getFile(path) {
-        return fs.readFileSync(
-          `tests/fixtures/jslibs/${fakeFiles[path]}`,
-          'utf-8'
-        );
+      async getFile(filename) {
+        return this.getFileAsString(filename);
       }
 
       async getFiles() {
         const files = {};
+        files['manifest.json'] = { uncompressedSize: 839 };
         Object.keys(fakeFiles).forEach((filename) => {
           files[filename] = { uncompressedSize: 5 };
         });
@@ -1013,7 +1011,15 @@ describe('Linter.extractMetadata()', () => {
       }
 
       async getFilesByExt() {
-        return Object.keys(fakeFiles);
+        return Object.keys(fakeFiles).concat([constants.MANIFEST_JSON]);
+      }
+
+      async getFileAsString(filename) {
+        return filename === constants.MANIFEST_JSON
+           ? validManifestJSON() : fs.readFileSync(
+          `tests/fixtures/jslibs/${fakeFiles[filename]}`,
+          'utf-8'
+        );
       }
     }
 
@@ -1028,8 +1034,8 @@ describe('Linter.extractMetadata()', () => {
     });
 
     const { notices } = addonLinter.collector;
-    expect(notices.length).toEqual(2);
-    expect(notices[1].code).toEqual(messages.KNOWN_LIBRARY.code);
+    expect(notices.length).toEqual(1);
+    expect(notices[0].code).toEqual(messages.KNOWN_LIBRARY.code);
   });
 
   it('should not scan known JS libraries', async () => {

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -1016,10 +1016,11 @@ describe('Linter.extractMetadata()', () => {
 
       async getFileAsString(filename) {
         return filename === constants.MANIFEST_JSON
-           ? validManifestJSON() : fs.readFileSync(
-          `tests/fixtures/jslibs/${fakeFiles[filename]}`,
-          'utf-8'
-        );
+          ? validManifestJSON()
+          : fs.readFileSync(
+              `tests/fixtures/jslibs/${fakeFiles[filename]}`,
+              'utf-8'
+            );
       }
     }
 

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -689,7 +689,7 @@ describe('Linter.getAddonMetadata()', () => {
     expect(FakeManifestParser.firstCall.args[2].selfHosted).toEqual(true);
   });
 
-  it('should collect notices if no manifest', async () => {
+  it('should error if no manifest', async () => {
     const addonLinter = new Linter({ _: ['bar'] });
     addonLinter.io = {
       getFiles: async () => {
@@ -697,9 +697,9 @@ describe('Linter.getAddonMetadata()', () => {
       },
     };
     await addonLinter.getAddonMetadata();
-    const { notices } = addonLinter.collector;
-    expect(notices.length).toEqual(1);
-    expect(notices[0].code).toEqual(messages.TYPE_NO_MANIFEST_JSON.code);
+    const { errors } = addonLinter.collector;
+    expect(errors.length).toEqual(1);
+    expect(errors[0].code).toEqual(messages.TYPE_NO_MANIFEST_JSON.code);
   });
 
   it('should validate static theme images defined in the manifest', async () => {


### PR DESCRIPTION
Helps https://github.com/mozilla/addons-server/issues/10635

My plan is to reverse the checks we're doing in addons-server so that if no `install.rdf` is found (and it's not a search engine), we just fire the linter, and the linter will return the appropriate error. For that to work I need this notice to be an error instead.