### PR TITLE
Fix RESERVED_FILENAME message construction.

### DIFF
--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -86,6 +86,7 @@ export const COINMINER_USAGE_DETECTED = {
 
 export const RESERVED_FILENAME = {
   code: 'RESERVED_FILENAME',
-  message: i18n._(oneLine`Files whose names are reserved have been found in
+  message: i18n._('Reserved filename found.'),
+  description: i18n._(oneLine`Files whose names are reserved have been found in
     the add-on. Please refrain from using them and rename your files.`),
 };

--- a/tests/unit/scanners/test.filename.js
+++ b/tests/unit/scanners/test.filename.js
@@ -159,7 +159,7 @@ describe('Reserved file names', () => {
       const { linterMessages } = await filenameScanner.scan();
       expect(linterMessages.length).toEqual(1);
       expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
-      expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
+      expect(linterMessages[0].message).toEqual('Reserved filename found.');
       expect(linterMessages[0].description.startsWith('Files whose names are reserved')).toEqual(true)
       expect(linterMessages[0].file).toEqual(filePath);
     });

--- a/tests/unit/scanners/test.filename.js
+++ b/tests/unit/scanners/test.filename.js
@@ -160,7 +160,7 @@ describe('Reserved file names', () => {
       expect(linterMessages.length).toEqual(1);
       expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
       expect(linterMessages[0].message).toEqual('Reserved filename found.');
-      expect(linterMessages[0].description.startsWith('Files whose names are reserved')).toEqual(true)
+      expect(linterMessages[0].description).toMatch(/^Files whose names are reserved/)
       expect(linterMessages[0].file).toEqual(filePath);
     });
   });

--- a/tests/unit/scanners/test.filename.js
+++ b/tests/unit/scanners/test.filename.js
@@ -160,7 +160,9 @@ describe('Reserved file names', () => {
       expect(linterMessages.length).toEqual(1);
       expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
       expect(linterMessages[0].message).toEqual('Reserved filename found.');
-      expect(linterMessages[0].description).toMatch(/^Files whose names are reserved/)
+      expect(linterMessages[0].description).toMatch(
+        /^Files whose names are reserved/
+      );
       expect(linterMessages[0].file).toEqual(filePath);
     });
   });

--- a/tests/unit/scanners/test.filename.js
+++ b/tests/unit/scanners/test.filename.js
@@ -159,6 +159,8 @@ describe('Reserved file names', () => {
       const { linterMessages } = await filenameScanner.scan();
       expect(linterMessages.length).toEqual(1);
       expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
+      expect(linterMessages[0].code).toEqual(messages.RESERVED_FILENAME.code);
+      expect(linterMessages[0].description.startsWith('Files whose names are reserved')).toEqual(true)
       expect(linterMessages[0].file).toEqual(filePath);
     });
   });


### PR DESCRIPTION
In 3888a7d I introduced reserved
filename scanning and forgot to define a `description` property on the
`RESERVED_FILENAME` message.

The `description` is needed to be properly exposable to the JSON and
text exports.