### PR TITLE
Fix scanning for reserved filename in subfolders.

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -301,12 +301,14 @@ export default class Linter {
   }
 
   getScanner(filename) {
+    const filenameWithoutPath = path.basename(filename);
+
     if (
       filename.match(constants.HIDDEN_FILE_REGEX) ||
       filename.match(constants.FLAGGED_FILE_REGEX) ||
       constants.FLAGGED_FILE_EXTENSIONS.includes(path.extname(filename)) ||
       filename.match(constants.ALREADY_SIGNED_REGEX) ||
-      constants.RESERVED_FILENAMES.includes(filename)
+      constants.RESERVED_FILENAMES.includes(filenameWithoutPath)
     ) {
       return FilenameScanner;
     }

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -346,7 +346,7 @@ describe('Linter.getScanner()', () => {
     'wat.dll',
     'META-INF/manifest.mf',
     'mozilla-recommendation.json',
-    'some/subfolder/mozilla-recommendation.json'
+    'some/subfolder/mozilla-recommendation.json',
   ];
 
   shouldBeFilenameScanned.forEach((filename) => {

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -345,6 +345,8 @@ describe('Linter.getScanner()', () => {
     '__MACOSX/foo.txt',
     'wat.dll',
     'META-INF/manifest.mf',
+    'mozilla-recommendation.json',
+    'some/subfolder/mozilla-recommendation.json'
   ];
 
   shouldBeFilenameScanned.forEach((filename) => {


### PR DESCRIPTION
This is a regression from the recent feature to scan for reserved
filenames.

Fixes #2618
