### PR TITLE
Reference "jest" plugin in tests/.eslintrc

### DIFF
--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -11,6 +11,7 @@
     "sinon": true,
   },
   "plugins": [
+    "jest",
     "promise",
   ],
   "rules": {


### PR DESCRIPTION
Without referencing the plugin, trying to lint individual files in the tests/ directory fails with the following error:

```
$ ./node_modules/.bin/eslint tests/unit/io/test.crx.js
Error: path/to/addons-linter/tests/.eslintrc:
        Environment key "jest/globals" is unknown
```