### PR TITLE
Replace setupTestFrameworkScriptFile with setupFilesAfterEnv

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     // Alias tests for tests to be able to import helpers.
     '^tests/(.*)$': '<rootDir>/tests/$1',
   },
-  setupTestFrameworkScriptFile: '<rootDir>/tests/setup.js',
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/tests/fixtures/',


### PR DESCRIPTION
#### Checklist
- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.

Fixes #2515

Updates Jest config to fix the following deprecation warning:

```
  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.
```