### PR TITLE
Add linting for all icons in manifest (#2677)

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -256,9 +256,7 @@ export default class Linter {
         selfHosted: this.config.selfHosted,
         io: this.io,
       });
-      if (manifestParser.parsedJSON.icons) {
-        await manifestParser.validateIcons();
-      }
+      await manifestParser.validateIcons();
       if (manifestParser.isStaticTheme) {
         await manifestParser.validateStaticThemeImages();
       }

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -256,6 +256,12 @@ export function assertHasMatchingError(errors, expected) {
   expect(errors.some((error) => isMatch(error, expected))).toBe(true);
 }
 
+export function assertHasMatchingErrorCount(errors, expected, count) {
+  expect(Array.isArray(errors)).toBe(true);
+  expect(errors.length).toBeGreaterThan(0);
+  expect(errors.filter((error) => isMatch(error, expected)).length).toBe(count);
+}
+
 export function getStreamableIO(files) {
   return {
     files,

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -9,6 +9,7 @@ import * as messages from 'messages';
 
 import {
   assertHasMatchingError,
+  assertHasMatchingErrorCount,
   validManifestJSON,
   validDictionaryManifestJSON,
   validLangpackManifestJSON,
@@ -1217,6 +1218,188 @@ describe('ManifestJSONParser', () => {
           'An icon defined in the manifest could not be found in the package.',
         description: 'Icon could not be found at "icons/icon-64.png".',
       });
+    });
+
+    it('adds an error if the browser_action icon is not in the package', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        browser_action: {
+          default_icon: {
+            32: 'icons/icon-32.png',
+            64: 'icons/icon-64.png',
+          },
+        },
+      });
+      const files = {
+        'icons/icon-32.png': EMPTY_PNG.toString('binary'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/icon-64.png".',
+      });
+    });
+
+    it('adds an error if the browser_action string icon is not in the package', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        browser_action: {
+          default_icon: 'icons/icon.png',
+        },
+      });
+      const files = {};
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/icon.png".',
+      });
+    });
+
+    it('adds an error if the browser_action theme icon is not in the package', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        browser_action: {
+          theme_icons: [
+            {
+              light: 'icons/light-32.png',
+              dark: 'icons/dark-32.png',
+              size: 32,
+            },
+          ],
+        },
+      });
+      const files = {
+        'icons/light-32.png': EMPTY_PNG.toString('binary'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/dark-32.png".',
+      });
+    });
+
+    it('adds an error if the page_action icon is not in the package', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        page_action: {
+          default_icon: {
+            32: 'icons/icon-32.png',
+            64: 'icons/icon-64.png',
+          },
+        },
+      });
+      const files = {
+        'icons/icon-32.png': EMPTY_PNG.toString('binary'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/icon-64.png".',
+      });
+    });
+
+    it('adds an error if the sidebar_action icon is not in the package', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        sidebar_action: {
+          default_icon: {
+            32: 'icons/icon-32.png',
+            64: 'icons/icon-64.png',
+          },
+        },
+      });
+      const files = {
+        'icons/icon-32.png': EMPTY_PNG.toString('binary'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(addonLinter.collector.errors, {
+        code: messages.MANIFEST_ICON_NOT_FOUND,
+        message:
+          'An icon defined in the manifest could not be found in the package.',
+        description: 'Icon could not be found at "icons/icon-64.png".',
+      });
+    });
+
+    it('filters duplicate errors if a missing icon is reused', async () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        browser_action: {
+          default_icon: {
+            32: 'icons/icon-32.png',
+            64: 'icons/icon-64.png',
+          },
+        },
+        sidebar_action: {
+          default_icon: {
+            32: 'icons/icon-32.png',
+            64: 'icons/icon-64.png',
+          },
+        },
+      });
+      const files = {
+        'icons/icon-32.png': EMPTY_PNG.toString('binary'),
+      };
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: getStreamableIO(files) }
+      );
+
+      await manifestJSONParser.validateIcons();
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingErrorCount(
+        addonLinter.collector.errors,
+        {
+          code: messages.MANIFEST_ICON_NOT_FOUND,
+          message:
+            'An icon defined in the manifest could not be found in the package.',
+          description: 'Icon could not be found at "icons/icon-64.png".',
+        },
+        1
+      );
     });
 
     it('adds a warning if the icon does not have a valid extension', async () => {


### PR DESCRIPTION
Fixes #2677

Add validation for icons in the `*_action` properties of manifest

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.
- [x] Add tests to cover the changes added in this PR.
