### PR TITLE
fix(themes): Log validation errors on theme manifests using the deprecated LWT aliases

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -133,9 +133,9 @@ Rules are sorted by severity.
 
 | Message code                         | Severity | Description                                                 |
 | ------------------------------------ | -------- | ----------------------------------------------------------- |
-| `MANIFEST_THEME_LWT_ALIAS`           | warning  | Theme LWT aliases are deprecated                            |
 | `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning  | Theme image file extension should match its mime type       |
 | `MANIFEST_THEME_IMAGE_NOT_FOUND`     | error    | Theme images must not be missing                            |
 | `MANIFEST_THEME_IMAGE_CORRUPTED`     | error    | Theme images must not be corrupted                          |
 | `MANIFEST_THEME_IMAGE_WRONG_EXT`     | error    | Theme images must have one of the supported file extensions |
 | `MANIFEST_THEME_IMAGE_WRONG_MIME`    | error    | Theme images mime type must be a supported format           |
+| `MANIFEST_THEME_LWT_ALIAS`           | error    | Theme LWT aliases are deprecated                            |

--- a/src/const.js
+++ b/src/const.js
@@ -128,7 +128,6 @@ export const DEPRECATED_STATIC_THEME_LWT_ALIASES = [
   '/theme/images/headerURL',
   '/theme/colors/accentcolor',
   '/theme/colors/textcolor',
-  '/theme/colors/toolbar_text',
 ];
 
 // A list of magic numbers that we won't allow.

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -300,7 +300,7 @@ export function corruptIconFile({ path }) {
 
 export const MANIFEST_THEME_LWT_ALIAS = {
   code: 'MANIFEST_THEME_LWT_ALIAS',
-  message: i18n._('This theme LWT alias is deprecated.'),
+  message: i18n._('This theme LWT alias has been removed in Firefox 70.'),
   description: i18n._(
     'See https://mzl.la/2T11Lkc (MDN Docs) for more information.'
   ),

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -241,12 +241,7 @@ export default class ManifestJSONParser extends JSONParser {
   _validate() {
     // Not all messages returned by the schema are fatal to Firefox, messages
     // that are just warnings should be added to this array.
-    const warnings = [
-      messages.MANIFEST_PERMISSIONS.code,
-      // TODO(#2463): Remove the following once the LWT aliases deprecated
-      // property should become errors on submission.
-      messages.MANIFEST_THEME_LWT_ALIAS.code,
-    ];
+    const warnings = [messages.MANIFEST_PERMISSIONS.code];
     let validate = validateAddon;
 
     if (this.isStaticTheme) {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -2334,7 +2334,7 @@ describe('ManifestJSONParser', () => {
     });
 
     describe('deprecated LWT aliases', () => {
-      it('does add validation warnings for LWT alias manifest properties marked as deprecated', () => {
+      it('does add validation errors for LWT alias manifest properties marked as deprecated', () => {
         const linter = new Linter({ _: ['bar'] });
         const manifest = validStaticThemeManifestJSON({
           theme: {
@@ -2344,6 +2344,9 @@ describe('ManifestJSONParser', () => {
             colors: {
               accentcolor: '#000',
               textcolor: '#000',
+              // This is not a deprecated property anymore, but it is still
+              // part of this test to ensure we don't raise linting errors
+              // for it.
               toolbar_text: '#000',
             },
           },
@@ -2358,34 +2361,30 @@ describe('ManifestJSONParser', () => {
 
         expect(manifestJSONParser.isValid).toBeFalsy();
 
-        expect(errors).toEqual([]);
+        expect(warnings).toEqual([]);
 
-        const actualWarnings = warnings.map((warn) => {
-          const { code, dataPath, file, message, description } = warn;
+        const actualErrors = errors.map((err) => {
+          const { code, dataPath, file, message, description } = err;
           return { code, dataPath, file, message, description };
         });
 
-        const commonWarnProps = { ...messages.MANIFEST_THEME_LWT_ALIAS };
-        const expectedWarnings = [
+        const commonErrorProps = { ...messages.MANIFEST_THEME_LWT_ALIAS };
+        const expectedErrors = [
           {
-            ...commonWarnProps,
+            ...commonErrorProps,
             dataPath: '/theme/images/headerURL',
           },
           {
-            ...commonWarnProps,
+            ...commonErrorProps,
             dataPath: '/theme/colors/accentcolor',
           },
           {
-            ...commonWarnProps,
+            ...commonErrorProps,
             dataPath: '/theme/colors/textcolor',
-          },
-          {
-            ...commonWarnProps,
-            dataPath: '/theme/colors/toolbar_text',
           },
         ];
 
-        expect(actualWarnings).toEqual(expectedWarnings);
+        expect(actualErrors).toEqual(expectedErrors);
       });
     });
   });


### PR DESCRIPTION
This PR fixes #2463, follow up for #2259 (which started to log validation warning for these deprecated LWT aliases).

This is also related to [Bug 1472740](https://bugzilla.mozilla.org/show_bug.cgi?id=1472740), which tracks the changes on the Firefox side.

Some notes about this change:

- `toolbar_text` is not deprecated anymore (See [Bug 1472740 Comment 24](https://bugzilla.mozilla.org/show_bug.cgi?id=1472740#c24) for a rationale)
- The LWT aliases properties will be ignored on Firefox (starting from Firefox >= 70 if the patch is not going to be uplifted to 69), as it happens for any other unknown theme manifest property
- [The patch attached to Bug 1472740 ([D37891])](https://phabricator.services.mozilla.com/D37891) is going to update the deprecation message included in the schema to mention explicitly that the deprecated properties are being ignored (but it will not prevent the installation, as it also happens for any other unknown theme manifest property)