### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "dispensary": "0.39.0",
     "es6-promisify": "6.0.2",
     "eslint": "5.16.0",
-    "eslint-plugin-no-unsafe-innerhtml": "1.0.16",
     "eslint-visitor-keys": "1.1.0",
     "espree": "6.1.1",
     "esprima": "4.0.1",


### PR DESCRIPTION
Comments in tests suggest concepts were borrowed from `eslint-plugin-no-unsafe-innerhtml`, but as far as I can tell no reference to it exists in code. The package itself appears to have been renamed to `eslint-plugin-no-unsanitized` anyway. 

Found by searching for how an old version of `eslint` was being included in one of my projects that uses `web-ext`.