### PR TITLE
feat: support multi-version BCD and ignore versions with flags

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -385,8 +385,17 @@ export function basicCompatVersionComparison(versionAdded, minVersion) {
   return !Number.isNaN(asNumber) && asNumber > minVersion;
 }
 
+/**
+ * @param {*} supportInfo - bcd support info of a feature
+ * @returns {string|boolean} The first version number to suppor the feature
+ *          or a boolean indicating if the feature is at all supported.
+ */
 function firstStableVersion(supportInfo) {
-  return supportInfo.reduce((versionAdded, supportEntry) => {
+  let supportInfoArray = supportInfo;
+  if (!Array.isArray(supportInfo)) {
+    supportInfoArray = [supportInfo];
+  }
+  return supportInfoArray.reduce((versionAdded, supportEntry) => {
     if (
       !Object.prototype.hasOwnProperty.call(supportEntry, 'flags') &&
       (!versionAdded ||
@@ -414,10 +423,7 @@ export function isCompatible(bcd, path, minVersion, application) {
   // API namespace may be undocumented or not implemented, ignore in that case.
   if (api.__compat) {
     const supportInfo = api.__compat.support[application];
-    const versionAdded = Array.isArray(supportInfo)
-      ? firstStableVersion(supportInfo)
-      : !Object.prototype.hasOwnProperty.call(supportInfo, 'flags') &&
-        supportInfo.version_added;
+    const versionAdded = firstStableVersion(supportInfo);
     return !basicCompatVersionComparison(versionAdded, minVersion);
   }
   return true;

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -606,4 +606,105 @@ describe('isCompatible', () => {
       )
     ).toBe(true);
   });
+
+  it('should be compatible if version is behind flag and no other version is available', () => {
+    expect(
+      isCompatible(
+        getBCD({
+          foo: {
+            __compat: {
+              support: { firefox: { flags: [], version_added: true } },
+            },
+          },
+        }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(true);
+  });
+
+  it('should be compatible if version is behind flag starting at a later release', () => {
+    expect(
+      isCompatible(
+        getBCD({
+          foo: {
+            __compat: {
+              support: { firefox: { flags: [], version_added: '61' } },
+            },
+          },
+        }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(true);
+  });
+
+  it('should be compatible with multiple support versions', () => {
+    expect(
+      isCompatible(
+        getBCD({
+          foo: {
+            __compat: {
+              support: {
+                firefox: [
+                  { version_added: '60' },
+                  { flags: [], version_added: '59' },
+                ],
+              },
+            },
+          },
+        }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(true);
+  });
+
+  it('should be incompatible with multiple support versions', () => {
+    expect(
+      isCompatible(
+        getBCD({
+          foo: {
+            __compat: {
+              support: {
+                firefox: [
+                  { version_added: '61' },
+                  { flags: [], version_added: '59' },
+                ],
+              },
+            },
+          },
+        }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(false);
+  });
+
+  it('should be compatible with oldest viable compat entry', () => {
+    expect(
+      isCompatible(
+        getBCD({
+          foo: {
+            __compat: {
+              support: {
+                firefox: [
+                  { version_added: '61' },
+                  { version_added: '60' },
+                  { flags: [], version_added: '59' },
+                ],
+              },
+            },
+          },
+        }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(true);
+  });
 });

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -1,4 +1,5 @@
 import { oneLine } from 'common-tags';
+import bcd from 'mdn-browser-compat-data';
 
 import {
   buildI18nObject,
@@ -535,6 +536,13 @@ describe('isCompatible', () => {
       api: data,
     },
   });
+  const getBCDForFeature = (
+    supportData,
+    { apiName = 'foo', appName = 'firefox' } = {}
+  ) =>
+    getBCD({
+      [apiName]: { __compat: { support: { [appName]: supportData } } },
+    });
 
   it('should be true if the given key path is not in the object', () => {
     expect(isCompatible(getBCD({}), 'foo.bar', 60, 'firefox')).toBe(true);
@@ -543,9 +551,7 @@ describe('isCompatible', () => {
   it('should be true if the given key path has a compatibility of false', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: { __compat: { support: { firefox: { version_added: false } } } },
-        }),
+        getBCDForFeature({ version_added: false }),
         'foo',
         60,
         'firefox'
@@ -556,9 +562,7 @@ describe('isCompatible', () => {
   it('should be true if the given key path is compatible with the minVersion', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: { __compat: { support: { firefox: { version_added: '60' } } } },
-        }),
+        getBCDForFeature({ version_added: '60' }),
         'foo',
         60,
         'firefox'
@@ -567,16 +571,13 @@ describe('isCompatible', () => {
   });
 
   it('should be false if the given key path is incompatible with the minVersion', () => {
+    const appName = 'firefox_android';
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: { support: { firefox_android: { version_added: '61' } } },
-          },
-        }),
+        getBCDForFeature({ version_added: '61' }, { appName }),
         'foo',
         60,
-        'firefox_android'
+        appName
       )
     ).toBe(false);
   });
@@ -584,9 +585,7 @@ describe('isCompatible', () => {
   it('should fall back to deepest matching compat info', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: { __compat: { support: { firefox: { version_added: '61' } } } },
-        }),
+        getBCDForFeature({ version_added: '61' }),
         'foo.bar',
         60,
         'firefox'
@@ -597,9 +596,7 @@ describe('isCompatible', () => {
   it('should be compatible if no specific version is specified', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: { __compat: { support: { firefox: { version_added: true } } } },
-        }),
+        getBCDForFeature({ version_added: true }),
         'foo.bar',
         60,
         'firefox'
@@ -610,13 +607,7 @@ describe('isCompatible', () => {
   it('should be compatible if version is behind flag and no other version is available', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: {
-              support: { firefox: { flags: [], version_added: true } },
-            },
-          },
-        }),
+        getBCDForFeature({ flags: [], version_added: true }),
         'foo',
         60,
         'firefox'
@@ -627,13 +618,7 @@ describe('isCompatible', () => {
   it('should be compatible if version is behind flag starting at a later release', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: {
-              support: { firefox: { flags: [], version_added: '61' } },
-            },
-          },
-        }),
+        getBCDForFeature({ flags: [], version_added: '61' }),
         'foo',
         60,
         'firefox'
@@ -644,18 +629,10 @@ describe('isCompatible', () => {
   it('should be compatible with multiple support versions', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: {
-              support: {
-                firefox: [
-                  { version_added: '60' },
-                  { flags: [], version_added: '59' },
-                ],
-              },
-            },
-          },
-        }),
+        getBCDForFeature([
+          { version_added: '60' },
+          { flags: [], version_added: '59' },
+        ]),
         'foo',
         60,
         'firefox'
@@ -666,18 +643,10 @@ describe('isCompatible', () => {
   it('should be incompatible with multiple support versions', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: {
-              support: {
-                firefox: [
-                  { version_added: '61' },
-                  { flags: [], version_added: '59' },
-                ],
-              },
-            },
-          },
-        }),
+        getBCDForFeature([
+          { version_added: '61' },
+          { flags: [], version_added: '59' },
+        ]),
         'foo',
         60,
         'firefox'
@@ -688,23 +657,35 @@ describe('isCompatible', () => {
   it('should be compatible with oldest viable compat entry', () => {
     expect(
       isCompatible(
-        getBCD({
-          foo: {
-            __compat: {
-              support: {
-                firefox: [
-                  { version_added: '61' },
-                  { version_added: '60' },
-                  { flags: [], version_added: '59' },
-                ],
-              },
-            },
-          },
-        }),
+        getBCDForFeature([
+          { version_added: '61' },
+          { version_added: '60' },
+          { flags: [], version_added: '59' },
+        ]),
         'foo',
         60,
         'firefox'
       )
     ).toBe(true);
+  });
+
+  it('should report devtools.network.onRequestFinished as compatible for Firefox 60', () => {
+    expect(
+      isCompatible(bcd, 'devtools.network.onRequestFinished', 60, 'firefox')
+    ).toBe(true);
+  });
+
+  it('should report devtools.network.onRequestFinished as incompatible for Firefox 60', () => {
+    expect(
+      isCompatible(bcd, 'devtools.network.onRequestFinished', 59, 'firefox')
+    ).toBe(false);
+  });
+
+  it('should report runtime.getURL as compatible for Firefox 45', () => {
+    expect(isCompatible(bcd, 'runtime.getURL', 45, 'firefox')).toBe(true);
+  });
+
+  it('should report runtime.getURL as incompatible for Firefox 44', () => {
+    expect(isCompatible(bcd, 'runtime.getURL', 44, 'firefox')).toBe(false);
   });
 });

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -675,7 +675,7 @@ describe('isCompatible', () => {
     ).toBe(true);
   });
 
-  it('should report devtools.network.onRequestFinished as incompatible for Firefox 60', () => {
+  it('should report devtools.network.onRequestFinished as incompatible for Firefox 59', () => {
     expect(
       isCompatible(bcd, 'devtools.network.onRequestFinished', 59, 'firefox')
     ).toBe(false);


### PR DESCRIPTION
Fixes #2944 

This makes the compat checker consider versions that require some flag to be set (either runtime or about:config) to not support a feature. Further it adds support for more complex ways of noting compat data where the support level changes between browser versions.