### PR TITLE
Add rules and messages that check if the used i18n messages exist in the default locale

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -24,6 +24,7 @@ export const ESLINT_RULE_MAPPING = {
   'content-scripts-file-absent': ESLINT_ERROR,
   'webextension-api-compat': ESLINT_WARNING,
   'webextension-api-compat-android': ESLINT_WARNING,
+  'message-exists': ESLINT_WARNING,
   ...EXTERNAL_RULE_MAPPING,
 };
 
@@ -209,3 +210,19 @@ export const MESSAGE_PLACEHOLDER_REGEXP = '\\$([a-zA-Z0-9_@]+)\\$';
 // yauzl should trow error with this message in case of corrupt zip file
 export const ZIP_LIB_CORRUPT_FILE_ERROR =
   'end of central directory record signature not found';
+
+// Localized values of manifest properties need to match this regexp.
+// This should match
+// https://searchfox.org/mozilla-central/rev/42c2ecdc429115c32e6bcb78bf087a228a051044/toolkit/components/extensions/ExtensionCommon.jsm#2010
+// Note that fluent based localization also allows dashes.
+export const MANFIEST_MESSAGE_NAME_REGEXP = '__MSG_([A-Za-z0-9@_]+?)__';
+
+// This should match https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#Predefined_messages
+export const PREDEFINED_MESSAGES = [
+  '@@extension_id',
+  '@@ui_locale',
+  '@@bidi_dir',
+  '@@bidi_reversed_dir',
+  '@@bidi_start_edge',
+  '@@bidi_end_edge',
+];

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -187,7 +187,35 @@ export const ANDROID_INCOMPATIBLE_API = {
   ),
 };
 
+export const MESSAGE_MISSING_IN_DEFAULT_LOCALE = {
+  code: 'MESSAGE_MISSING_IN_DEFAULT_LOCALE',
+  message: null,
+  messageFormat: i18n.sprintf(
+    i18n._(
+      'Message "%(message)s" not found for default locale "%(defaultLocale)s"'
+    ),
+    {
+      message: '{{message}}',
+      defaultLocale: '{{defaultLocale}}',
+    }
+  ),
+  description: i18n._('Message can not be translated in default locale'),
+};
+
+export const MESSAGE_MISSING_PLACEHOLDER_IN_DEFAULT_LOCALE = {
+  cose: 'MESSAGE_MISSING_PLACEHOLDER_IN_DEFAULT_LOCALE',
+  message: null,
+  messageFormat: i18n._(
+    'Message "{{message}} has no placeholder {{placeholder}} in default locale "{{defaultLocale}}"'
+  ),
+  description: i18n._(
+    'Message does not use a placeholder in the default locale'
+  ),
+};
+
 export const ESLINT_OVERWRITE_MESSAGE = {
+  'message-exists': MESSAGE_MISSING_IN_DEFAULT_LOCALE,
+  'message-placeholder-exists': MESSAGE_MISSING_PLACEHOLDER_IN_DEFAULT_LOCALE,
   'no-eval': DANGEROUS_EVAL,
   'no-implied-eval': NO_IMPLIED_EVAL,
   'no-new-func': DANGEROUS_EVAL,

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -522,3 +522,18 @@ export function permissionFirefoxAndroidUnsupportedByMinVersion(
     file: MANIFEST_JSON,
   };
 }
+
+const MISSING_MESSAGE_IN_DEFAULT_LOCALE = 'MISSING_MESSAGE_IN_DEFAULT_LOCALE';
+export function missingMessageInDefaultLocale({ message, defaultLocale }) {
+  return {
+    code: MISSING_MESSAGE_IN_DEFAULT_LOCALE,
+    message: i18n._('Message can not be translated in default locale'),
+    description: i18n.sprintf(
+      i18n._(
+        'Message "%(message)s" not found for default locale "(%defaultLocale)s"'
+      ),
+      { message, defaultLocale }
+    ),
+    file: MANIFEST_JSON,
+  };
+}

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -102,6 +102,25 @@ export default class ManifestJSONParser extends JSONParser {
       );
       this.io = io;
       this._validate();
+
+      if (this.parsedJSON.default_locale) {
+        try {
+          // TODO should this also have the relaxed parsing? -> optimally this would use the same parser run as the check for the messages.json file.
+          this.defaultMessages = JSON.parse(
+            this.io.getFile(
+              path.join(
+                LOCALES_DIRECTORY,
+                this.parsedJSON.default_locale,
+                MESSAGES_JSON
+              )
+            )
+          );
+        } catch (error) {
+          // If the default messages.json contains errors the default
+          // message checking is disabled. Errors in the file will
+          // be reported by the locale-messagesjson parser.
+        }
+      }
     }
   }
 
@@ -813,17 +832,7 @@ export default class ManifestJSONParser extends JSONParser {
         this.parsedJSON.applications.gecko &&
         this.parsedJSON.applications.gecko.strict_min_version,
       defaultLocale: this.parsedJSON.default_locale,
-      defaultMessagesFile:
-        this.parsedJSON.default_locale &&
-        JSON.parse(
-          this.io.getFile(
-            path.join(
-              LOCALES_DIRECTORY,
-              this.parsedJSON.default_locale,
-              MANIFEST_JSON
-            )
-          )
-        ),
+      defaultMessagesFile: this.defaultMessages,
     };
   }
 }

--- a/src/rules/css/index.js
+++ b/src/rules/css/index.js
@@ -1,1 +1,2 @@
 export * from './invalidNesting';
+export * from './messageExists';

--- a/src/rules/css/messageExists.js
+++ b/src/rules/css/messageExists.js
@@ -1,0 +1,37 @@
+import {
+  getMessagesInFile,
+  getAvailableMessages,
+  getColumnAndLineFromOffset,
+} from 'utils';
+import { VALIDATION_WARNING } from 'const';
+import { missingMessageInDefaultLocale } from 'messages';
+
+export function messageExists(
+  cssNode,
+  filename,
+  { startLine, startColumn, addonMetadata = {} } = {}
+) {
+  if (!addonMetadata.defaultLocale) {
+    return [];
+  }
+  const rawNode = cssNode.toString();
+  const messages = getMessagesInFile(rawNode);
+  const availableMessages = getAvailableMessages(
+    addonMetadata.defaultMessagesFile
+  );
+  return messages
+    .filter((matchInfo) => !availableMessages.includes(matchInfo.message))
+    .map((matchInfo) => {
+      const location = getColumnAndLineFromOffset(rawNode, matchInfo.startsAt);
+      return {
+        ...missingMessageInDefaultLocale(
+          matchInfo.message,
+          addonMetadata.defaultLocale
+        ),
+        type: VALIDATION_WARNING,
+        line: startLine + location.line,
+        column: startColumn + location.column,
+        file: filename,
+      };
+    });
+}

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -19,5 +19,6 @@ module.exports = {
     'webextension-api-compat': require('./webextension-api-compat').default,
     'webextension-api-compat-android': require('./webextension-api-compat-android')
       .default,
+    'message-exists': require('./message-exists').default,
   },
 };

--- a/src/rules/javascript/message-exists.js
+++ b/src/rules/javascript/message-exists.js
@@ -1,0 +1,51 @@
+import { getAvailableMessages, isBrowserNamespace } from 'utils';
+import { MESSAGE_MISSING_IN_DEFAULT_LOCALE } from 'messages';
+
+export default {
+  create(context) {
+    const {
+      defaultLocale,
+      defaultMessagesFile,
+    } = context.settings.addonMetadata;
+    if (!defaultLocale) {
+      return {};
+    }
+    const availableMessages = getAvailableMessages(defaultMessagesFile);
+    return {
+      MemberExpression(node) {
+        if (
+          !node.object.object ||
+          !isBrowserNamespace(node.object.object.name)
+        ) {
+          // Early return when it's not our case.
+          return;
+        }
+        const namespace = node.object.property.name;
+        const property = node.property.name;
+        // Namespace should be i18n function should be getMessage and it should be a call.
+        // I.E. browser.i18n.getMessage().
+        if (
+          namespace !== 'i18n' ||
+          property !== 'getMessage' ||
+          node.parent.type !== 'CallExpression'
+        ) {
+          return;
+        }
+        const message = node.parent.arguments[0];
+        if (message.type !== 'Literal') {
+          return;
+        }
+        if (!availableMessages.includes(message.value)) {
+          context.report(
+            node,
+            MESSAGE_MISSING_IN_DEFAULT_LOCALE.messageFormat,
+            {
+              message: message.value,
+              defaultLocale,
+            }
+          );
+        }
+      },
+    };
+  },
+};

--- a/src/rules/javascript/message-placeholder-exists.js
+++ b/src/rules/javascript/message-placeholder-exists.js
@@ -1,0 +1,78 @@
+import { getAvailableMessages, isBrowserNamespace } from 'utils';
+import { MESSAGE_MISSING_PLACEHOLDER_IN_DEFAULT_LOCALE } from 'messages';
+
+export default {
+  create(context) {
+    const {
+      defaultLocale,
+      defaultMessagesFile,
+    } = context.settings.addonMetadata;
+    if (!defaultLocale) {
+      return {};
+    }
+    const availableMessages = getAvailableMessages(defaultMessagesFile);
+    return {
+      MemberExpression(node) {
+        if (
+          !node.object.object ||
+          !isBrowserNamespace(node.object.object.name)
+        ) {
+          // Early return when it's not our case.
+          return;
+        }
+        const namespace = node.object.property.name;
+        const property = node.property.name;
+        // Namespace should be i18n function should be getMessage and it should be a call.
+        // I.E. browser.i18n.getMessage().
+        if (
+          namespace !== 'i18n' ||
+          property !== 'getMessage' ||
+          node.parent.type !== 'CallExpression'
+        ) {
+          return;
+        }
+        const message = node.parent.arguments[0];
+        if (message.type !== 'Literal') {
+          return;
+        }
+        if (
+          availableMessages.includes(message.value) &&
+          node.parent.arguments.length > 1 &&
+          Object.prototype.hasOwnProperty.call(
+            defaultMessagesFile,
+            message.value
+          )
+        ) {
+          const messageDefinition = defaultMessagesFile[message.value];
+          const placeholders =
+            messageDefinition.placeholders &&
+            Object.entries(messageDefinition.placeholders);
+          const placeholderCount =
+            (node.parent.arguments[1].type === 'ArrayExpression'
+              ? node.parent.arguments[1].elements.length
+              : node.parent.arguments.length) - 1;
+          for (let i = 1; i <= placeholderCount; ++i) {
+            const placeholderString = `$${i}`;
+            if (
+              !messageDefinition.message.includes(placeholderString) &&
+              (!placeholders ||
+                !placeholders.some((placeholder) =>
+                  placeholder.content.includes(placeholderString)
+                ))
+            ) {
+              context.report(
+                node,
+                MESSAGE_MISSING_PLACEHOLDER_IN_DEFAULT_LOCALE.messageFormat,
+                {
+                  message: message.value,
+                  defaultLocale,
+                  placeholder: i,
+                }
+              );
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import url from 'url';
+import nodePath from 'path';
 
 import upath from 'upath';
 import { URL } from 'whatwg-url';
@@ -8,7 +9,14 @@ import { oneLine } from 'common-tags';
 import osLocale from 'os-locale';
 
 import log from 'logger';
-import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
+import {
+  PACKAGE_TYPES,
+  LOCAL_PROTOCOLS,
+  MANFIEST_MESSAGE_NAME_REGEXP,
+  PREDEFINED_MESSAGES,
+  MESSAGES_JSON,
+  LOCALES_DIRECTORY,
+} from 'const';
 
 /* global nodeRequire, localesRoot */
 
@@ -444,4 +452,39 @@ export function createCompatibilityRule(
     };
   }
   return {};
+}
+
+export function getMessagesInFile(rawFile) {
+  const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
+  const messages = [];
+
+  let match = messageNameRegexp.exec(rawFile);
+  while (match !== null) {
+    const message = match[1];
+    const startsAt = messageNameRegexp.lastIndex - message.length;
+    messages.push({
+      message,
+      startsAt,
+    });
+    match = messageNameRegexp.exec(rawFile);
+  }
+  return messages;
+}
+
+export function getAvailableMessages(messagesJson) {
+  try {
+    return Object.keys(messagesJson).concat(PREDEFINED_MESSAGES);
+  } catch (error) {
+    return [];
+  }
+}
+
+export function getColumnAndLineFromOffset(rawFile, offset) {
+  const lines = rawFile.slice(0, offset).split('/n');
+  const line = lines.length;
+  const column = lines.pop().length;
+  return {
+    column,
+    line,
+  };
 }


### PR DESCRIPTION
Fixes #1807 

Right now this PR contains:

- a check for message.json that all `__MSG_[message]__` usages point to a string that exists in the default_locale
- a rule for JS code to ensure that the first parameter, if a literal, to `i18n.getMessage` is a string that exists in the default_locale
- a rule for JS code to ensure that the placeholders passed to `i18n.getMessage` are present in the source string in the default_locale
- a rule for CSS to check that all `__MSG_[message]__` usages point to a string that exists in the default_locale
- support for the built in messages for all of these rules (the @@ messages)

What's missing:

- [ ] Rebase/resolve conflicts/make eslint 7 compatible
- [ ] Tests for the manifest check
- [ ] Tests for the JS message rule
- [ ] Tests for the JS message placeholder rule
- [ ] Tests for the CSS message rule
- [ ] Documentation of the rules
- [ ] A fail safe if the default_locale's message.json is not valid JSON, because currently that breaks the metadata object