### PR TITLE
Try to fix renovate `supportPolicy` definition.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,11 +18,15 @@
         "*"
       ],
       "rangeStrategy": "pin"
-    }
+    },
+    {
+      "depTypeList": ["engines"],
+      "rangeStrategy": "auto"
+    },
+
   ],
   "stabilityDays": 7,
   "node": {
-    "enabled": true,
     "supportPolicy": ["lts"]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,7 @@
     {
       "depTypeList": ["engines"],
       "rangeStrategy": "auto"
-    },
-
+    }
   ],
   "stabilityDays": 7,
   "node": {


### PR DESCRIPTION
Fixes #2957 (hopefully)

This is explicitly setting the `engines` section to `auto` mode to ensure that our global `rangeStrategy` won't get used for nodejs engines so that our `supportPolicy` can be applied accordingly.

(or at least… that's what I hope reading docs and many many renovate.json files on github)