### PR TITLE
Import Firefox 72 schema update from Beta 4.

### DIFF
--- a/src/schema/imported/bookmarks.json
+++ b/src/schema/imported/bookmarks.json
@@ -149,11 +149,11 @@
       "parameters": [
         {
           "name": "query",
-          "description": "Either a string of words and quoted phrases that are matched against bookmark URLs and titles, or an object. If an object, the properties <code>query</code>, <code>url</code>, and <code>title</code> may be specified and bookmarks matching all specified properties will be produced.",
+          "description": "Either a string of words that are matched against bookmark URLs and titles, or an object. If an object, the properties <code>query</code>, <code>url</code>, and <code>title</code> may be specified and bookmarks matching all specified properties will be produced.",
           "anyOf": [
             {
               "type": "string",
-              "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles."
+              "description": "A string of words that are matched against bookmark URLs and titles."
             },
             {
               "type": "object",
@@ -161,7 +161,7 @@
               "properties": {
                 "query": {
                   "type": "string",
-                  "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles."
+                  "description": "A string of words that are matched against bookmark URLs and titles."
                 },
                 "url": {
                   "type": "string",

--- a/src/schema/imported/browser_action.json
+++ b/src/schema/imported/browser_action.json
@@ -467,6 +467,17 @@
               "name": "tab"
             }
           ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/OnClickData"
+            },
+            {
+              "name": "info",
+              "optional": true
+            }
+          ]
         }
       ]
     }
@@ -568,6 +579,33 @@
         {
           "type": "null"
         }
+      ]
+    },
+    "OnClickData": {
+      "type": "object",
+      "description": "Information sent when a browser action is clicked.",
+      "properties": {
+        "modifiers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Shift",
+              "Alt",
+              "Command",
+              "Ctrl",
+              "MacCtrl"
+            ]
+          },
+          "description": "An array of keyboard modifiers that were held while the menu item was clicked."
+        },
+        "button": {
+          "type": "integer",
+          "description": "An integer value of button by which menu item was clicked."
+        }
+      },
+      "required": [
+        "modifiers"
       ]
     }
   }

--- a/src/schema/imported/browser_settings.json
+++ b/src/schema/imported/browser_settings.json
@@ -45,6 +45,16 @@
         }
       ]
     },
+    "ftpProtocolEnabled": {
+      "allOf": [
+        {
+          "$ref": "types#/types/Setting"
+        },
+        {
+          "description": "This boolean setting controls whether the FTP protocol is enabled."
+        }
+      ]
+    },
     "homepageOverride": {
       "allOf": [
         {

--- a/src/schema/imported/captive_portal.json
+++ b/src/schema/imported/captive_portal.json
@@ -4,6 +4,18 @@
   "permissions": [
     "captivePortal"
   ],
+  "properties": {
+    "canonicalURL": {
+      "allOf": [
+        {
+          "$ref": "types#/types/Setting"
+        },
+        {
+          "description": "Return the canonical captive-portal detection URL. Read-only."
+        }
+      ]
+    }
+  },
   "functions": [
     {
       "name": "getState",

--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -30,7 +30,7 @@
                 },
                 "favicon_url": {
                   "type": "string",
-                  "format": "url",
+                  "format": "relativeUrl",
                   "preprocess": "localize"
                 },
                 "suggest_url": {
@@ -126,7 +126,8 @@
                       },
                       "pref": {
                         "type": "string",
-                        "description": "The preference to retreive the value from."
+                        "description": "The preference to retrieve the value from.",
+                        "preprocess": "localize"
                       },
                       "purpose": {
                         "type": "string",

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -177,7 +177,8 @@
         "jsallocations",
         "nostacksampling",
         "nativeallocations",
-        "preferencereads"
+        "preferencereads",
+        "ipcmessages"
       ]
     },
     "supports": {

--- a/src/schema/imported/i18n.json
+++ b/src/schema/imported/i18n.json
@@ -125,6 +125,12 @@
       "properties": {
         "default_locale": {
           "type": "string"
+        },
+        "l10n_resources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -178,9 +178,26 @@
                   }
                 },
                 "content_security_policy": {
-                  "type": "string",
-                  "format": "contentSecurityPolicy",
-                  "onError": "warn"
+                  "onError": "warn",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "contentSecurityPolicy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "extension_pages": {
+                          "type": "string",
+                          "format": "contentSecurityPolicy"
+                        },
+                        "content_scripts": {
+                          "type": "string",
+                          "format": "contentSecurityPolicy"
+                        }
+                      }
+                    }
+                  ]
                 },
                 "permissions": {
                   "type": "array",

--- a/src/schema/imported/page_action.json
+++ b/src/schema/imported/page_action.json
@@ -279,6 +279,17 @@
               "name": "tab"
             }
           ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/OnClickData"
+            },
+            {
+              "name": "info",
+              "optional": true
+            }
+          ]
         }
       ]
     }
@@ -341,6 +352,33 @@
       "additionalProperties": {},
       "postprocess": "convertImageDataToURL",
       "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element)."
+    },
+    "OnClickData": {
+      "type": "object",
+      "description": "Information sent when a page action is clicked.",
+      "properties": {
+        "modifiers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Shift",
+              "Alt",
+              "Command",
+              "Ctrl",
+              "MacCtrl"
+            ]
+          },
+          "description": "An array of keyboard modifiers that were held while the menu item was clicked."
+        },
+        "button": {
+          "type": "integer",
+          "description": "An integer value of button by which menu item was clicked."
+        }
+      },
+      "required": [
+        "modifiers"
+      ]
     }
   }
 }

--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -39,12 +39,23 @@
               "description": "Allow users to specify the media performance/privacy tradeoffs which impacts how WebRTC traffic will be routed and how much local address information is exposed. This preference's value is of type IPHandlingPolicy, defaulting to <code>default</code>."
             }
           ]
+        },
+        "tlsVersionRestriction": {
+          "allOf": [
+            {
+              "$ref": "types#/types/Setting"
+            },
+            {
+              "description": "This property controls the minimum and maximum TLS versions. This setting's value is an object of $(ref:tlsVersionRestrictionConfig)."
+            }
+          ]
         }
       },
       "required": [
         "networkPredictionEnabled",
         "peerConnectionEnabled",
-        "webRTCIPHandlingPolicy"
+        "webRTCIPHandlingPolicy",
+        "tlsVersionRestriction"
       ]
     },
     "services": {
@@ -198,6 +209,34 @@
         "proxy_only"
       ],
       "description": "The IP handling policy of WebRTC."
+    },
+    "tlsVersionRestrictionConfig": {
+      "type": "object",
+      "description": "An object which describes TLS minimum and maximum versions.",
+      "properties": {
+        "minimum": {
+          "type": "string",
+          "enum": [
+            "TLSv1",
+            "TLSv1.1",
+            "TLSv1.2",
+            "TLSv1.3",
+            "unknown"
+          ],
+          "description": "The minimum TLS version supported."
+        },
+        "maximum": {
+          "type": "string",
+          "enum": [
+            "TLSv1",
+            "TLSv1.1",
+            "TLSv1.2",
+            "TLSv1.3",
+            "unknown"
+          ],
+          "description": "The maximum TLS version supported."
+        }
+      }
     },
     "TrackingProtectionModeOption": {
       "type": "string",

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -102,6 +102,10 @@
                   "description": "Url classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -114,7 +118,8 @@
             "type",
             "timeStamp",
             "fromCache",
-            "urlClassification"
+            "urlClassification",
+            "thirdParty"
           ]
         }
       ],
@@ -148,18 +153,6 @@
       "name": "onError",
       "type": "function",
       "description": "Notifies about errors caused by the invalid use of the proxy API.",
-      "parameters": [
-        {
-          "name": "error",
-          "type": "object"
-        }
-      ]
-    },
-    {
-      "name": "onProxyError",
-      "type": "function",
-      "deprecated": "proxy.onProxyError has been deprecated and will be removed in Firefox 71. Use proxy.onError instead.",
-      "description": "Please use $(ref:proxy.onError).",
       "parameters": [
         {
           "name": "error",
@@ -243,6 +236,11 @@
         "proxyDNS": {
           "type": "boolean",
           "description": "Proxy DNS when using SOCKS v5."
+        },
+        "respectBeConservative": {
+          "type": "boolean",
+          "default": true,
+          "description": " If true (the default value), do not use newer TLS protocol features that might have interoperability problems on the Internet. This is intended only for use with critical infrastructure like the updates, and is only available to privileged addons."
         }
       }
     }

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -131,6 +131,91 @@
       ]
     },
     {
+      "name": "keyedScalarAdd",
+      "type": "function",
+      "description": "Adds the value to the given keyed scalar.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The scalar name"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The key name"
+        },
+        {
+          "name": "value",
+          "type": "integer",
+          "minimum": 1,
+          "description": "The numeric value to add to the scalar. Only unsigned integers supported."
+        }
+      ]
+    },
+    {
+      "name": "keyedScalarSet",
+      "type": "function",
+      "description": "Sets the keyed scalar to the given value. Throws if the value type doesn't match the scalar type.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The scalar name."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The key name."
+        },
+        {
+          "name": "value",
+          "description": "The value to set the scalar to.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "keyedScalarSetMaximum",
+      "type": "function",
+      "description": "Sets the keyed scalar to the maximum of the current and the passed value",
+      "async": true,
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The scalar name."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The key name."
+        },
+        {
+          "name": "value",
+          "type": "integer",
+          "minimum": 0,
+          "description": "The numeric value to set the scalar to. Only unsigned integers supported."
+        }
+      ]
+    },
+    {
       "name": "recordEvent",
       "type": "function",
       "description": "Record an event in Telemetry. Throws when trying to record an unknown event.",

--- a/src/schema/imported/test.json
+++ b/src/schema/imported/test.json
@@ -11,6 +11,17 @@
   "description": "none",
   "functions": [
     {
+      "name": "withHandlingUserInput",
+      "type": "function",
+      "description": "Calls the callback function wrapped with user input set.  This is only used for internal unit testing.",
+      "parameters": [
+        {
+          "type": "function",
+          "name": "callback"
+        }
+      ]
+    },
+    {
       "name": "notifyFail",
       "type": "function",
       "description": "Notifies the browser process that test code running in the extension failed.  This is only used for internal unit testing.",

--- a/src/schema/imported/types.json
+++ b/src/schema/imported/types.json
@@ -156,7 +156,6 @@
           "name": "onChange",
           "type": "function",
           "description": "Fired after the setting changes.",
-          "unsupported": true,
           "parameters": [
             {
               "type": "object",

--- a/src/schema/imported/urlbar.json
+++ b/src/schema/imported/urlbar.json
@@ -81,6 +81,56 @@
       ]
     }
   },
+  "functions": [
+    {
+      "name": "closeView",
+      "type": "function",
+      "async": true,
+      "description": "Closes the urlbar view in the current window.",
+      "parameters": []
+    },
+    {
+      "name": "focus",
+      "type": "function",
+      "async": true,
+      "description": "Focuses the urlbar in the current window.",
+      "parameters": [
+        {
+          "name": "select",
+          "type": "boolean",
+          "optional": true,
+          "default": false,
+          "description": "If true, the text in the urlbar will also be selected."
+        }
+      ]
+    },
+    {
+      "name": "search",
+      "type": "function",
+      "async": true,
+      "description": "Starts a search in the urlbar in the current window.",
+      "parameters": [
+        {
+          "name": "searchString",
+          "type": "string",
+          "description": "The search string."
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/SearchOptions"
+            },
+            {
+              "name": "options",
+              "optional": true,
+              "default": {},
+              "description": "Options for the search."
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "events": [
     {
       "name": "onBehaviorRequested",
@@ -116,6 +166,32 @@
         ],
         "description": "The behavior of the provider for the query."
       }
+    },
+    {
+      "name": "onEngagement",
+      "type": "function",
+      "description": "This event is fired when the user starts and ends an engagement with the urlbar.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/EngagementState"
+            },
+            {
+              "name": "state",
+              "description": "The state of the engagement."
+            }
+          ]
+        }
+      ],
+      "extraParameters": [
+        {
+          "name": "providerName",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "description": "The name of the provider that will listen for engagement events."
+        }
+      ]
     },
     {
       "name": "onQueryCanceled",
@@ -185,11 +261,6 @@
           "name": "payload",
           "type": "object",
           "description": "The payload of the result that was picked."
-        },
-        {
-          "name": "details",
-          "type": "object",
-          "description": "Details about the pick. The specific properties depend on the result type."
         }
       ],
       "extraParameters": [
@@ -221,6 +292,16 @@
     }
   },
   "types": {
+    "EngagementState": {
+      "type": "string",
+      "enum": [
+        "start",
+        "engagement",
+        "abandonment",
+        "discard"
+      ],
+      "description": "The state of an engagement made with the urlbar by the user. <code>start</code>: The user has started an engagement. <code>engagement</code>: The user has completed an engagement by picking a result. <code>abandonment</code>: The user has abandoned their engagement, for example by blurring the urlbar. <code>discard</code>: The engagement ended in a way that should be ignored by listeners."
+    },
     "Query": {
       "type": "object",
       "description": "A query performed in the urlbar.",
@@ -302,6 +383,17 @@
         "url"
       ],
       "description": "Possible types of results. <code>remote_tab</code>: A synced tab from another device. <code>search</code>: A search suggestion from a search engine. <code>tab</code>: An open tab in the browser. <code>tip</code>: An actionable message to help the user with their query. <code>url</code>: A URL that's not one of the other types."
+    },
+    "SearchOptions": {
+      "type": "object",
+      "description": "Options to the <code>search</code> function.",
+      "properties": {
+        "focus": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to focus the input field and select its contents."
+        }
+      }
     },
     "SourceType": {
       "type": "string",

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -172,6 +172,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -182,7 +186,8 @@
             "parentFrameId",
             "tabId",
             "type",
-            "timeStamp"
+            "timeStamp",
+            "thirdParty"
           ]
         }
       ],
@@ -301,6 +306,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -311,7 +320,8 @@
             "parentFrameId",
             "tabId",
             "type",
-            "timeStamp"
+            "timeStamp",
+            "thirdParty"
           ]
         }
       ],
@@ -430,6 +440,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -440,7 +454,8 @@
             "parentFrameId",
             "tabId",
             "type",
-            "timeStamp"
+            "timeStamp",
+            "thirdParty"
           ]
         }
       ],
@@ -556,6 +571,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -568,7 +587,8 @@
             "type",
             "timeStamp",
             "statusLine",
-            "statusCode"
+            "statusCode",
+            "thirdParty"
           ]
         }
       ],
@@ -723,6 +743,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -738,7 +762,8 @@
             "challenger",
             "isProxy",
             "statusLine",
-            "statusCode"
+            "statusCode",
+            "thirdParty"
           ]
         },
         {
@@ -890,6 +915,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -903,7 +932,8 @@
             "timeStamp",
             "fromCache",
             "statusCode",
-            "statusLine"
+            "statusLine",
+            "thirdParty"
           ]
         }
       ],
@@ -1031,6 +1061,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -1045,7 +1079,8 @@
             "fromCache",
             "statusCode",
             "redirectUrl",
-            "statusLine"
+            "statusLine",
+            "thirdParty"
           ]
         }
       ],
@@ -1169,6 +1204,18 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
+            },
+            "requestSize": {
+              "type": "integer",
+              "description": "For http requests, the bytes transferred in the request. Only available in onCompleted."
+            },
+            "responseSize": {
+              "type": "integer",
+              "description": "For http requests, the bytes received in the request. Only available in onCompleted."
             }
           },
           "required": [
@@ -1183,7 +1230,10 @@
             "fromCache",
             "statusCode",
             "statusLine",
-            "urlClassification"
+            "urlClassification",
+            "thirdParty",
+            "requestSize",
+            "responseSize"
           ]
         }
       ],
@@ -1293,6 +1343,10 @@
                   "description": "Tracking classification if the request has been classified."
                 }
               ]
+            },
+            "thirdParty": {
+              "type": "boolean",
+              "description": "Indicates if this request and its content window hierarchy is third party."
             }
           },
           "required": [
@@ -1305,7 +1359,8 @@
             "type",
             "timeStamp",
             "fromCache",
-            "error"
+            "error",
+            "thirdParty"
           ]
         }
       ],
@@ -1772,7 +1827,7 @@
               "$ref": "#/types/UrlClassificationParty"
             },
             {
-              "description": "First party classification flags if the request has been classified."
+              "description": "Classification flags if the request has been classified and it is first party."
             }
           ]
         },
@@ -1782,7 +1837,7 @@
               "$ref": "#/types/UrlClassificationParty"
             },
             {
-              "description": "Third party classification flags if the request has been classified."
+              "description": "Classification flags if the request has been classified and it or its window hierarchy is third party."
             }
           ]
         }


### PR DESCRIPTION
Fixes #2935

This is based upon some initial work from #2955 to make it work but
doesn't contain that fix as it'll be fixd as part of #2955 (which is WIP, see https://github.com/mozilla/addons-linter/tree/2955-use-zip-for-schema-import)