### PR TITLE
fix: Validate manifest CSP properties in v3 format

### DIFF
--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -49,27 +49,31 @@ export const MANIFEST_VERSION_INVALID = {
   file: MANIFEST_JSON,
 };
 
-export const MANIFEST_CSP = {
-  // Note: don't change this 'code' without updating addons-server first, as
-  // it depends on it to detect add-ons with a custom content security policy.
-  code: 'MANIFEST_CSP',
-  message: i18n._(oneLine`
-    "content_security_policy" allows remote code execution in manifest.json`),
-  description: i18n._(
-    'A custom content_security_policy needs additional review.'
-  ),
-  file: MANIFEST_JSON,
-};
+export const MANIFEST_CSP = 'MANIFEST_CSP';
+export function manifestCsp(property) {
+  return {
+    // Note: don't change this 'code' without updating addons-server first, as
+    // it depends on it to detect add-ons with a custom content security policy.
+    code: MANIFEST_CSP,
+    message: i18n._(oneLine`
+      "${property}" allows remote code execution in manifest.json`),
+    description: i18n._(`A custom ${property} needs additional review.`),
+    file: MANIFEST_JSON,
+  };
+}
 
-export const MANIFEST_CSP_UNSAFE_EVAL = {
-  code: 'MANIFEST_CSP_UNSAFE_EVAL',
-  message: i18n._(oneLine`
-    Using 'eval' has strong security and performance implications.`),
-  description: i18n._(oneLine`
-    In most cases the same result can be achieved differently,
-    therefore it is generally prohibited`),
-  file: MANIFEST_JSON,
-};
+export const MANIFEST_CSP_UNSAFE_EVAL = 'MANIFEST_CSP_UNSAFE_EVAL';
+export function manifestCspUnsafeEval(property) {
+  return {
+    code: MANIFEST_CSP_UNSAFE_EVAL,
+    message: i18n._(oneLine`
+      ${property} allows 'eval', which has strong security and performance implications.`),
+    description: i18n._(oneLine`
+      In most cases the same result can be achieved differently,
+      therefore it is generally prohibited`),
+    file: MANIFEST_JSON,
+  };
+}
 
 export const PROP_NAME_INVALID = {
   code: 'PROP_NAME_INVALID',

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -678,6 +678,20 @@ export default class ManifestJSONParser extends JSONParser {
   }
 
   validateCspPolicy(policy) {
+    if (typeof policy === 'string') {
+      this.validateCspPolicyString(policy, 'content_security_policy');
+    } else if (policy != null) {
+      const keys = Object.keys(policy);
+      for (const key of keys) {
+        this.validateCspPolicyString(
+          policy[key],
+          `content_security_policy.${key}`
+        );
+      }
+    }
+  }
+
+  validateCspPolicyString(policy, manifestPropName) {
     const directives = parseCspPolicy(policy);
 
     // Not sure about FTP here but CSP spec treats ws/wss as
@@ -723,7 +737,7 @@ export default class ManifestJSONParser extends JSONParser {
               // 'script-src' makes it secure
               insecureSrcDirective = true;
             } else {
-              this.collector.addWarning(messages.MANIFEST_CSP);
+              this.collector.addWarning(messages.manifestCsp(manifestPropName));
             }
             continue;
           }
@@ -734,7 +748,9 @@ export default class ManifestJSONParser extends JSONParser {
           // Add a more detailed message for unsafe-eval to avoid confusion
           // about why it's forbidden.
           if (value === 'unsafe-eval') {
-            this.collector.addWarning(messages.MANIFEST_CSP_UNSAFE_EVAL);
+            this.collector.addWarning(
+              messages.manifestCspUnsafeEval(manifestPropName)
+            );
             continue;
           }
 
@@ -746,7 +762,7 @@ export default class ManifestJSONParser extends JSONParser {
               // 'script-src' makes it secure
               insecureSrcDirective = true;
             } else {
-              this.collector.addWarning(messages.MANIFEST_CSP);
+              this.collector.addWarning(messages.manifestCsp(manifestPropName));
             }
             continue;
           }
@@ -754,7 +770,7 @@ export default class ManifestJSONParser extends JSONParser {
       }
     }
     if (insecureSrcDirective) {
-      this.collector.addWarning(messages.MANIFEST_CSP);
+      this.collector.addWarning(messages.manifestCsp(manifestPropName));
     }
   }
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -853,6 +853,7 @@ describe('ManifestJSONParser', () => {
             `content_security_policy.${keys[i]}`
           );
         }
+        expect(warnings.length).toBe(3);
       });
     });
 
@@ -977,6 +978,7 @@ describe('ManifestJSONParser', () => {
           `content_security_policy.${keys[i]}`
         );
       }
+      expect(warningsV3.length).toBe(3);
     });
   });
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -799,6 +799,7 @@ describe('ManifestJSONParser', () => {
         "default-src http:; worker-src: 'self'",
       ];
 
+      // Manifest v2 formats.
       invalidValues.forEach((invalidValue) => {
         const addonLinter = new Linter({ _: ['bar'] });
 
@@ -813,8 +814,45 @@ describe('ManifestJSONParser', () => {
 
         expect(manifestJSONParser.isValid).toEqual(true);
         const { warnings } = addonLinter.collector;
-        expect(warnings[0].code).toEqual(messages.MANIFEST_CSP.code);
+        expect(warnings[0].code).toEqual(messages.MANIFEST_CSP);
         expect(warnings[0].message).toContain('content_security_policy');
+      });
+
+      // Manifest v3 formats.
+      invalidValues.forEach((invalidValue) => {
+        const addonLinter = new Linter({ _: ['bar'] });
+
+        const contentSecurityPolicy = {
+          extension_pages: invalidValue,
+          content_scripts: invalidValue,
+          // Alias for content_scripts.
+          isolated_world: invalidValue,
+        };
+
+        const jsonV3 = validManifestJSON({
+          content_security_policy: contentSecurityPolicy,
+          applications: {
+            // The new content_security_policy syntax is only supported
+            // on Firefox >= 72.
+            gecko: { strict_min_version: '72.0' },
+          },
+        });
+
+        const manifestV3JSONParser = new ManifestJSONParser(
+          jsonV3,
+          addonLinter.collector
+        );
+
+        expect(manifestV3JSONParser.isValid).toEqual(true);
+        const { warnings } = addonLinter.collector;
+
+        const keys = Object.keys(contentSecurityPolicy);
+        for (let i = 0; i < keys.length; i++) {
+          expect(warnings[i].code).toEqual(messages.MANIFEST_CSP);
+          expect(warnings[i].message).toContain(
+            `content_security_policy.${keys[i]}`
+          );
+        }
       });
     });
 
@@ -845,6 +883,7 @@ describe('ManifestJSONParser', () => {
       validValues.forEach((validValue) => {
         const addonLinter = new Linter({ _: ['bar'] });
 
+        // Manifest v2 format.
         const json = validManifestJSON({
           content_security_policy: validValue,
         });
@@ -856,6 +895,28 @@ describe('ManifestJSONParser', () => {
 
         expect(manifestJSONParser.isValid).toEqual(true);
         expect(addonLinter.collector.warnings.length).toEqual(0);
+
+        // Manifest v3 format.
+        const jsonV3 = validManifestJSON({
+          content_security_policy: {
+            extension_pages: validValue,
+            content_scripts: validValue,
+            isolated_world: validValue,
+          },
+          applications: {
+            // The new content_security_policy syntax is only supported
+            // on Firefox >= 72.
+            gecko: { strict_min_version: '72.0' },
+          },
+        });
+
+        const manifestV3JSONParser = new ManifestJSONParser(
+          jsonV3,
+          addonLinter.collector
+        );
+
+        expect(manifestV3JSONParser.isValid).toEqual(true);
+        expect(addonLinter.collector.warnings.length).toEqual(0);
       });
     });
 
@@ -863,6 +924,7 @@ describe('ManifestJSONParser', () => {
       const invalidValue = "script-src 'self' 'unsafe-eval';";
       const addonLinter = new Linter({ _: ['bar'] });
 
+      // Manifest v2 formats.
       const json = validManifestJSON({
         content_security_policy: invalidValue,
       });
@@ -874,10 +936,47 @@ describe('ManifestJSONParser', () => {
 
       expect(manifestJSONParser.isValid).toEqual(true);
       const { warnings } = addonLinter.collector;
-      expect(warnings[0].code).toEqual(messages.MANIFEST_CSP_UNSAFE_EVAL.code);
+      expect(warnings[0].code).toEqual(messages.MANIFEST_CSP_UNSAFE_EVAL);
       expect(warnings[0].message).toEqual(
-        "Using 'eval' has strong security and performance implications."
+        messages.manifestCspUnsafeEval('content_security_policy').message
       );
+
+      // Clear any warnings and errors collected.
+      addonLinter.collector.warnings = [];
+      addonLinter.collector.errors = [];
+
+      // Manifest v3 formats.
+      const contentSecurityPolicy = {
+        extension_pages: invalidValue,
+        content_scripts: invalidValue,
+        // Alias for content_scripts.
+        isolated_world: invalidValue,
+      };
+
+      const jsonV3 = validManifestJSON({
+        content_security_policy: contentSecurityPolicy,
+        applications: {
+          // The new content_security_policy syntax is only supported
+          // on Firefox >= 72.
+          gecko: { strict_min_version: '72.0' },
+        },
+      });
+
+      const manifestV3JSONParser = new ManifestJSONParser(
+        jsonV3,
+        addonLinter.collector
+      );
+
+      expect(manifestV3JSONParser.isValid).toEqual(true);
+      const warningsV3 = addonLinter.collector.warnings;
+
+      const keys = Object.keys(contentSecurityPolicy);
+      for (let i = 0; i < keys.length; i++) {
+        expect(warningsV3[i].code).toEqual(messages.MANIFEST_CSP_UNSAFE_EVAL);
+        expect(warningsV3[i].message).toContain(
+          `content_security_policy.${keys[i]}`
+        );
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #3053
(also also unblock #3048)

This PR introduce some small changes needed to parse and validate the manifest CSP properties when they are expressed in the new v3 format:

```
  "content_security_policy": {
    "extension_pages": "...",
    "content_scripts": "...",
    // or "isolated_worlds" (which is the chrome compatible alias for the "content_scripts" one)
  }
```

Some other details related to this PR:
- the change is also covered by some additional automated tests.
- the validation messages now also contains the name of the CSP property related
  to the validation message, e.g.

```
Code                              Message                                         Description                                                                                 File                                     Line   Column
MANIFEST_CSP_UNSAFE_EVAL          content_security_policy.extension_pages         In most cases the same result can be achieved differently, therefore it is generally        manifest.json                            
                                  allows 'eval', which has strong security and    prohibited                                                                                                                           
                                  performance implications.
``` 