### PR TITLE
Remove sudo from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js:
   - 'v10.19.0'
   - 'v12.16.1'


### PR DESCRIPTION
`sudo` has been removed a while ago.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast