### PR TITLE
Fixes #2158 - Including a new lint rule to check invalid extension name

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -6,26 +6,26 @@ Rules are sorted by severity.
 
 ## JavaScript
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `KNOWN_LIBRARY` | notice | This is version of a JS library is known and generally accepted. |
-| `OPENDIALOG_NONLIT_URI` | notice | openDialog called with non-literal parameter. |
-| `EVENT_LISTENER_FOURTH` | notice | `addEventListener` called with truthy fourth argument. |
-| `UNEXPECTED_GLOGAL_ARG` | warning | Unexpected global passed as an argument. |
-| `NO_IMPLIED_EVAL` | warning | disallow the use of `eval()`-like methods. |
-| `OPENDIALOG_REMOTE_URI` | warning | openDialog called with non-local URI. |
-| `NO_DOCUMENT_WRITE` | warning | Use of `document.write` strongly discouraged. |
-| `JS_SYNTAX_ERROR` | warning | JavaScript compile-time error. |
-| `UNADVISED_LIBRARY` | warning | This version of a JS library is not recommended. |
-| `DEPRECATED_API` | warning | API is deprecated. |
-| `STORAGE_SYNC` | warning | Temporary IDs can cause issues with `storage.sync`. |
-| `STORAGE_MANAGED` | warning | Temporary IDs can cause issues with `storage.managed`. |
-| `IDENTITY_GETREDIRECTURL` | warning | Temporary IDs can cause issues with `identity.getRedirectURL`. |
-| `RUNTIME_ONMESSAGEEXTERNAL` | warning | Temporary IDs can cause issues with `runtime.onMessageExternal`. |
-| `RUNTIME_ONCONNECTEXTERNAL` | warning | Temporary IDs can cause issues with `runtime.onConnectExternal`. |
-| `BANNED_LIBRARY` | error | This version of a JS library is banned for security reasons. |
-| `INCOMPATIBLE_API` | warning | API not compatible with `applications.gecko.strict_min_version` |
-| `ANDROID_INCOMPATIBLE_API` | warning | API not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| Message code               | Severity | Description                                                                            |
+| -------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `KNOWN_LIBRARY`            | notice   | This is version of a JS library is known and generally accepted.                       |
+| `OPENDIALOG_NONLIT_URI`    | notice   | openDialog called with non-literal parameter.                                          |
+| `EVENT_LISTENER_FOURTH`    | notice   | `addEventListener` called with truthy fourth argument.                                 |
+| `UNEXPECTED_GLOGAL_ARG`    | warning  | Unexpected global passed as an argument.                                               |
+| `NO_IMPLIED_EVAL`          | warning  | disallow the use of `eval()`-like methods.                                             |
+| `OPENDIALOG_REMOTE_URI`    | warning  | openDialog called with non-local URI.                                                  |
+| `NO_DOCUMENT_WRITE`        | warning  | Use of `document.write` strongly discouraged.                                          |
+| `JS_SYNTAX_ERROR`          | warning  | JavaScript compile-time error.                                                         |
+| `UNADVISED_LIBRARY`        | warning  | This version of a JS library is not recommended.                                       |
+| `DEPRECATED_API`           | warning  | API is deprecated.                                                                     |
+| `STORAGE_SYNC`             | warning  | Temporary IDs can cause issues with `storage.sync`.                                    |
+| `STORAGE_MANAGED`          | warning  | Temporary IDs can cause issues with `storage.managed`.                                 |
+| `IDENTITY_GETREDIRECTURL`  | warning  | Temporary IDs can cause issues with `identity.getRedirectURL`.                         |
+| `RUNTIME_ONMESSAGEEXTERNAL`| warning  | Temporary IDs can cause issues with `runtime.onMessageExternal`.                       |
+| `RUNTIME_ONCONNECTEXTERNAL`| warning  | Temporary IDs can cause issues with `runtime.onConnectExternal`.                       |
+| `BANNED_LIBRARY`           | error    | This version of a JS library is banned for security reasons.                           |
+| `INCOMPATIBLE_API`         | warning  | API not compatible with `applications.gecko.strict_min_version`                        |
+| `ANDROID_INCOMPATIBLE_API` | warning  | API not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
 
 ## Markup
 
@@ -38,10 +38,10 @@ Rules are sorted by severity.
 
 ### HTML
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `INLINE_SCRIPT` | warning | Inline script is disallowed by CSP. |
-| `REMOTE_SCRIPT` | warning | Remote scripts are not allowed as per Add-on Policies. |
+| Message code    | Severity | Description                                            |
+| --------------- | -------- | ------------------------------------------------------ |
+| `INLINE_SCRIPT` | warning  | Inline script is disallowed by CSP.                    |
+| `REMOTE_SCRIPT` | warning  | Remote scripts are not allowed as per Add-on Policies. |
 
 ## Content
 
@@ -52,23 +52,23 @@ Rules are sorted by severity.
 
 ## Package layout
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `MOZILLA_COND_OF_USE` | notice | Mozilla conditions of use violation. |
-| `FLAGGED_FILE_TYPE` | notice | (Binary) Flagged file type found. |
-| `FLAGGED_FILE_EXTENSION` | warning | Flagged file extensions found |
-| `DUPLICATE_XPI_ENTRY` | warning | Package contains duplicate entries |
-| `ALREADY_SIGNED` | warning | Already signed |
-| `COINMINER_USAGE_DETECTED` | warning | Firefox add-ons are not allowed to run coin miners. |
-| `BAD_ZIPFILE` | error | Bad zip file |
-| `FILE_TOO_LARGE` | error | File is too large to parse |
-| `RESERVED_FILENAME` | error | Reserved filename detected. |
+| Message code               | Severity | Description                                         |
+| -------------------------- | -------- | --------------------------------------------------- |
+| `MOZILLA_COND_OF_USE`      | notice   | Mozilla conditions of use violation.                |
+| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                   |
+| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                       |
+| `DUPLICATE_XPI_ENTRY`      | warning  | Package contains duplicate entries                  |
+| `ALREADY_SIGNED`           | warning  | Already signed                                      |
+| `COINMINER_USAGE_DETECTED` | warning  | Firefox add-ons are not allowed to run coin miners. |
+| `BAD_ZIPFILE`              | error    | Bad zip file                                        |
+| `FILE_TOO_LARGE`           | error    | File is too large to parse                          |
+| `RESERVED_FILENAME`        | error    | Reserved filename detected.                         |
 
 ## Type detection
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `TYPE_NO_MANIFEST_JSON` | notice | Add-on missing manifest_json for type detection. |
+| Message code            | Severity | Description                                      |
+| ----------------------- | -------- | ------------------------------------------------ |
+| `TYPE_NO_MANIFEST_JSON` | notice   | Add-on missing manifest_json for type detection. |
 
 ## Language packs
 
@@ -78,60 +78,60 @@ Rules are sorted by severity.
 
 ## Web Extensions / manifest.json
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `MANIFEST_UNUSED_UPDATE` | notice | update_url ignored in manifest.json |
-| `PROP_VERSION_TOOLKIT_ONLY` | notice | version is in the toolkit format in manifest.json |
-| `CORRUPT_ICON_FILE` | warning | Icons must not be corrupt |
-| `MANIFEST_CSP` | warning | content_security_policy in manifest.json means more review |
-| `MANIFEST_CSP_UNSAFE_EVAL` | warning | usage of 'unsafe-eval' is strongly discouraged |
-| `MANIFEST_PERMISSIONS` | warning | Unknown permission |
-| `NO_MESSAGES_FILE` | warning | When default_locale is specified a matching messages.json must exist |
-| `NO_DEFAULT_LOCALE` | warning | When \_locales directory exists, default_locale must exist |
-| `UNSAFE_VAR_ASSIGNMENT` | warning | Assignment using dynamic, unsanitized values |
-| `UNSUPPORTED_API` | warning | Unsupported or unknown browser API |
-| `DANGEROUS_EVAL` | warning | `eval` and the `Function` constructor are discouraged |
-| `STRICT_MAX_VERSION` | warning | strict_max_version not required |
-| `PREDEFINED_MESSAGE_NAME` | warning | String name is reserved for a predefined |
-| `MISSING_PLACEHOLDER` | warning | Placeholder for message is not |
-| `WRONG_ICON_EXTENSION` | error | Icons must have valid extension |
-| `MANIFEST_UPDATE_URL` | error | update_url not allowed in manifest.json |
-| `MANIFEST_FIELD_REQUIRED` | error | A required field is missing |
-| `MANIFEST_FIELD_INVALID` | error | A field is invalid |
-| `MANIFEST_FIELD_DEPRECATED` | error | A field is deprecated |
-| `MANIFEST_BAD_PERMISSION` | error | Bad permission |
-| `JSON_BLOCK_COMMENTS` | error | Block Comments are not allowed in JSON |
-| `MANIFEST_INVALID_CONTENT` | error | This add-on contains forbidden content |
-| `CONTENT_SCRIPT_NOT_FOUND` | error | Content script file could not be found |
-| `CONTENT_SCRIPT_EMPTY` | error | Content script file name should not be empty |
-| `NO_MESSAGE` | error | Translation string is missing the message |
-| `INVALID_MESSAGE_NAME` | error | String name contains invalid characters |
-| `INVALID_PLACEHOLDER_NAME` | error | Placeholder name contains invalid characters |
-| `NO_PLACEHOLDER_CONTENT` | error | Placeholder is missing the content |
-| `JSON_INVALID` | error | JSON is not well formed |
-| `JSON_DUPLICATE_KEY` | error | Duplicate key in JSON |
-| `MANIFEST_VERSION_INVALID` | error | manifest_version in manifest.json is not valid. |
-| `PROP_NAME_MISSING` | error | name property missing from manifest.json |
-| `PROP_NAME_INVALID` | error | name property is invalid in manifest.json |
-| `PROP_VERSION_MISSING` | error | version property missing from manifest.json |
-| `PROP_VERSION_INVALID` | error | version is invalid in manifest.json |
-| `MANIFEST_DICT_NOT_FOUND` | error | A dictionary file defined in the manifest could not be found |
-| `MANIFEST_MULTIPLE_DICTS` | error | Multiple dictionaries found |
-| `MANIFEST_EMPTY_DICTS` | error | Empty `dictionaries` object |
-| `MANIFEST_DICT_MISSING_ID` | error | Missing `applications.gecko.id` property for a dictionary |
-| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION` | warning | Manifest key not compatible with `applications.gecko.strict_min_version` |
-| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | warning | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
-| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION` | notice | Permission not compatible with `applications.gecko.strict_min_version` |
-| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
-| `PROP_NAME_NOT_ALLOWED` | error | name property must not contain the words `mozilla` or `firefox`. |
+| Message code                                            | Severity | Description                                                                                     |
+| ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `MANIFEST_UNUSED_UPDATE`                                | notice   | update_url ignored in manifest.json                                                             |
+| `PROP_VERSION_TOOLKIT_ONLY`                             | notice   | version is in the toolkit format in manifest.json                                               |
+| `CORRUPT_ICON_FILE`                                     | warning  | Icons must not be corrupt                                                                       |
+| `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
+| `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
+| `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
+| `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
+| `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
+| `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |
+| `UNSUPPORTED_API`                                       | warning  | Unsupported or unknown browser API                                                              |
+| `DANGEROUS_EVAL`                                        | warning  | `eval` and the `Function` constructor are discouraged                                           |
+| `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
+| `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
+| `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
+| `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |
+| `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                         |
+| `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
+| `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
+| `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
+| `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
+| `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
+| `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
+| `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |
+| `CONTENT_SCRIPT_EMPTY`                                  | error    | Content script file name should not be empty                                                    |
+| `NO_MESSAGE`                                            | error    | Translation string is missing the message                                                       |
+| `INVALID_MESSAGE_NAME`                                  | error    | String name contains invalid characters                                                         |
+| `INVALID_PLACEHOLDER_NAME`                              | error    | Placeholder name contains invalid characters                                                    |
+| `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                              |
+| `JSON_INVALID`                                          | error    | JSON is not well formed                                                                         |
+| `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                           |
+| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid.                                                 |
+| `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                        |
+| `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                       |
+| `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                     |
+| `PROP_VERSION_INVALID`                                  | error    | version is invalid in manifest.json                                                             |
+| `MANIFEST_DICT_NOT_FOUND`                               | error    | A dictionary file defined in the manifest could not be found                                    |
+| `MANIFEST_MULTIPLE_DICTS`                               | error    | Multiple dictionaries found                                                                     |
+| `MANIFEST_EMPTY_DICTS`                                  | error    | Empty `dictionaries` object                                                                     |
+| `MANIFEST_DICT_MISSING_ID`                              | error    | Missing `applications.gecko.id` property for a dictionary                                       |
+| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`                | warning  | Manifest key not compatible with `applications.gecko.strict_min_version`                        |
+| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
+| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
+| `PROP_NAME_NOT_ALLOWED`                                 | warning  | name property must not contain the words `mozilla` or `firefox`.                                |
 
 ### Static Theme / manifest.json
 
-| Message code | Severity | Description |
-| --- | --- | --- |
-| `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning | Theme image file extension should match its mime type |
-| `MANIFEST_THEME_IMAGE_NOT_FOUND` | error | Theme images must not be missing |
-| `MANIFEST_THEME_IMAGE_CORRUPTED` | error | Theme images must not be corrupted |
-| `MANIFEST_THEME_IMAGE_WRONG_EXT` | error | Theme images must have one of the supported file extensions |
-| `MANIFEST_THEME_IMAGE_WRONG_MIME` | error | Theme images mime type must be a supported format |
-| `MANIFEST_THEME_LWT_ALIAS` | error | Theme LWT aliases are deprecated |
+| Message code                         | Severity | Description                                                 |
+| ------------------------------------ | -------- | ----------------------------------------------------------- |
+| `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning  | Theme image file extension should match its mime type       |
+| `MANIFEST_THEME_IMAGE_NOT_FOUND`     | error    | Theme images must not be missing                            |
+| `MANIFEST_THEME_IMAGE_CORRUPTED`     | error    | Theme images must not be corrupted                          |
+| `MANIFEST_THEME_IMAGE_WRONG_EXT`     | error    | Theme images must have one of the supported file extensions |
+| `MANIFEST_THEME_IMAGE_WRONG_MIME`    | error    | Theme images mime type must be a supported format           |
+| `MANIFEST_THEME_LWT_ALIAS`           | error    | Theme LWT aliases are deprecated                            |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -6,26 +6,26 @@ Rules are sorted by severity.
 
 ## JavaScript
 
-| Message code               | Severity | Description                                                                            |
-| -------------------------- | -------- | -------------------------------------------------------------------------------------- |
-| `KNOWN_LIBRARY`            | notice   | This is version of a JS library is known and generally accepted.                       |
-| `OPENDIALOG_NONLIT_URI`    | notice   | openDialog called with non-literal parameter.                                          |
-| `EVENT_LISTENER_FOURTH`    | notice   | `addEventListener` called with truthy fourth argument.                                 |
-| `UNEXPECTED_GLOGAL_ARG`    | warning  | Unexpected global passed as an argument.                                               |
-| `NO_IMPLIED_EVAL`          | warning  | disallow the use of `eval()`-like methods.                                             |
-| `OPENDIALOG_REMOTE_URI`    | warning  | openDialog called with non-local URI.                                                  |
-| `NO_DOCUMENT_WRITE`        | warning  | Use of `document.write` strongly discouraged.                                          |
-| `JS_SYNTAX_ERROR`          | warning  | JavaScript compile-time error.                                                         |
-| `UNADVISED_LIBRARY`        | warning  | This version of a JS library is not recommended.                                       |
-| `DEPRECATED_API`           | warning  | API is deprecated.                                                                     |
-| `STORAGE_SYNC`             | warning  | Temporary IDs can cause issues with `storage.sync`.                                    |
-| `STORAGE_MANAGED`          | warning  | Temporary IDs can cause issues with `storage.managed`.                                 |
-| `IDENTITY_GETREDIRECTURL`  | warning  | Temporary IDs can cause issues with `identity.getRedirectURL`.                         |
-| `RUNTIME_ONMESSAGEEXTERNAL`| warning  | Temporary IDs can cause issues with `runtime.onMessageExternal`.                       |
-| `RUNTIME_ONCONNECTEXTERNAL`| warning  | Temporary IDs can cause issues with `runtime.onConnectExternal`.                       |
-| `BANNED_LIBRARY`           | error    | This version of a JS library is banned for security reasons.                           |
-| `INCOMPATIBLE_API`         | warning  | API not compatible with `applications.gecko.strict_min_version`                        |
-| `ANDROID_INCOMPATIBLE_API` | warning  | API not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `KNOWN_LIBRARY` | notice | This is version of a JS library is known and generally accepted. |
+| `OPENDIALOG_NONLIT_URI` | notice | openDialog called with non-literal parameter. |
+| `EVENT_LISTENER_FOURTH` | notice | `addEventListener` called with truthy fourth argument. |
+| `UNEXPECTED_GLOGAL_ARG` | warning | Unexpected global passed as an argument. |
+| `NO_IMPLIED_EVAL` | warning | disallow the use of `eval()`-like methods. |
+| `OPENDIALOG_REMOTE_URI` | warning | openDialog called with non-local URI. |
+| `NO_DOCUMENT_WRITE` | warning | Use of `document.write` strongly discouraged. |
+| `JS_SYNTAX_ERROR` | warning | JavaScript compile-time error. |
+| `UNADVISED_LIBRARY` | warning | This version of a JS library is not recommended. |
+| `DEPRECATED_API` | warning | API is deprecated. |
+| `STORAGE_SYNC` | warning | Temporary IDs can cause issues with `storage.sync`. |
+| `STORAGE_MANAGED` | warning | Temporary IDs can cause issues with `storage.managed`. |
+| `IDENTITY_GETREDIRECTURL` | warning | Temporary IDs can cause issues with `identity.getRedirectURL`. |
+| `RUNTIME_ONMESSAGEEXTERNAL` | warning | Temporary IDs can cause issues with `runtime.onMessageExternal`. |
+| `RUNTIME_ONCONNECTEXTERNAL` | warning | Temporary IDs can cause issues with `runtime.onConnectExternal`. |
+| `BANNED_LIBRARY` | error | This version of a JS library is banned for security reasons. |
+| `INCOMPATIBLE_API` | warning | API not compatible with `applications.gecko.strict_min_version` |
+| `ANDROID_INCOMPATIBLE_API` | warning | API not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
 
 ## Markup
 
@@ -38,10 +38,10 @@ Rules are sorted by severity.
 
 ### HTML
 
-| Message code    | Severity | Description                                            |
-| --------------- | -------- | ------------------------------------------------------ |
-| `INLINE_SCRIPT` | warning  | Inline script is disallowed by CSP.                    |
-| `REMOTE_SCRIPT` | warning  | Remote scripts are not allowed as per Add-on Policies. |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `INLINE_SCRIPT` | warning | Inline script is disallowed by CSP. |
+| `REMOTE_SCRIPT` | warning | Remote scripts are not allowed as per Add-on Policies. |
 
 ## Content
 
@@ -52,23 +52,23 @@ Rules are sorted by severity.
 
 ## Package layout
 
-| Message code               | Severity | Description                                         |
-| -------------------------- | -------- | --------------------------------------------------- |
-| `MOZILLA_COND_OF_USE`      | notice   | Mozilla conditions of use violation.                |
-| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                   |
-| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                       |
-| `DUPLICATE_XPI_ENTRY`      | warning  | Package contains duplicate entries                  |
-| `ALREADY_SIGNED`           | warning  | Already signed                                      |
-| `COINMINER_USAGE_DETECTED` | warning  | Firefox add-ons are not allowed to run coin miners. |
-| `BAD_ZIPFILE`              | error    | Bad zip file                                        |
-| `FILE_TOO_LARGE`           | error    | File is too large to parse                          |
-| `RESERVED_FILENAME`        | error    | Reserved filename detected.                         |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `MOZILLA_COND_OF_USE` | notice | Mozilla conditions of use violation. |
+| `FLAGGED_FILE_TYPE` | notice | (Binary) Flagged file type found. |
+| `FLAGGED_FILE_EXTENSION` | warning | Flagged file extensions found |
+| `DUPLICATE_XPI_ENTRY` | warning | Package contains duplicate entries |
+| `ALREADY_SIGNED` | warning | Already signed |
+| `COINMINER_USAGE_DETECTED` | warning | Firefox add-ons are not allowed to run coin miners. |
+| `BAD_ZIPFILE` | error | Bad zip file |
+| `FILE_TOO_LARGE` | error | File is too large to parse |
+| `RESERVED_FILENAME` | error | Reserved filename detected. |
 
 ## Type detection
 
-| Message code            | Severity | Description                                      |
-| ----------------------- | -------- | ------------------------------------------------ |
-| `TYPE_NO_MANIFEST_JSON` | notice   | Add-on missing manifest_json for type detection. |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `TYPE_NO_MANIFEST_JSON` | notice | Add-on missing manifest_json for type detection. |
 
 ## Language packs
 
@@ -78,59 +78,60 @@ Rules are sorted by severity.
 
 ## Web Extensions / manifest.json
 
-| Message code                                            | Severity | Description                                                                                     |
-| ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `MANIFEST_UNUSED_UPDATE`                                | notice   | update_url ignored in manifest.json                                                             |
-| `PROP_VERSION_TOOLKIT_ONLY`                             | notice   | version is in the toolkit format in manifest.json                                               |
-| `CORRUPT_ICON_FILE`                                     | warning  | Icons must not be corrupt                                                                       |
-| `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
-| `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
-| `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
-| `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
-| `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
-| `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |
-| `UNSUPPORTED_API`                                       | warning  | Unsupported or unknown browser API                                                              |
-| `DANGEROUS_EVAL`                                        | warning  | `eval` and the `Function` constructor are discouraged                                           |
-| `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
-| `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
-| `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
-| `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |
-| `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                         |
-| `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
-| `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
-| `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
-| `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
-| `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
-| `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
-| `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |
-| `CONTENT_SCRIPT_EMPTY`                                  | error    | Content script file name should not be empty                                                    |
-| `NO_MESSAGE`                                            | error    | Translation string is missing the message                                                       |
-| `INVALID_MESSAGE_NAME`                                  | error    | String name contains invalid characters                                                         |
-| `INVALID_PLACEHOLDER_NAME`                              | error    | Placeholder name contains invalid characters                                                    |
-| `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                              |
-| `JSON_INVALID`                                          | error    | JSON is not well formed                                                                         |
-| `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                           |
-| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid.                                                 |
-| `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                        |
-| `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                       |
-| `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                     |
-| `PROP_VERSION_INVALID`                                  | error    | version is invalid in manifest.json                                                             |
-| `MANIFEST_DICT_NOT_FOUND`                               | error    | A dictionary file defined in the manifest could not be found                                    |
-| `MANIFEST_MULTIPLE_DICTS`                               | error    | Multiple dictionaries found                                                                     |
-| `MANIFEST_EMPTY_DICTS`                                  | error    | Empty `dictionaries` object                                                                     |
-| `MANIFEST_DICT_MISSING_ID`                              | error    | Missing `applications.gecko.id` property for a dictionary                                       |
-| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`                | warning  | Manifest key not compatible with `applications.gecko.strict_min_version`                        |
-| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
-| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
-| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `MANIFEST_UNUSED_UPDATE` | notice | update_url ignored in manifest.json |
+| `PROP_VERSION_TOOLKIT_ONLY` | notice | version is in the toolkit format in manifest.json |
+| `CORRUPT_ICON_FILE` | warning | Icons must not be corrupt |
+| `MANIFEST_CSP` | warning | content_security_policy in manifest.json means more review |
+| `MANIFEST_CSP_UNSAFE_EVAL` | warning | usage of 'unsafe-eval' is strongly discouraged |
+| `MANIFEST_PERMISSIONS` | warning | Unknown permission |
+| `NO_MESSAGES_FILE` | warning | When default_locale is specified a matching messages.json must exist |
+| `NO_DEFAULT_LOCALE` | warning | When \_locales directory exists, default_locale must exist |
+| `UNSAFE_VAR_ASSIGNMENT` | warning | Assignment using dynamic, unsanitized values |
+| `UNSUPPORTED_API` | warning | Unsupported or unknown browser API |
+| `DANGEROUS_EVAL` | warning | `eval` and the `Function` constructor are discouraged |
+| `STRICT_MAX_VERSION` | warning | strict_max_version not required |
+| `PREDEFINED_MESSAGE_NAME` | warning | String name is reserved for a predefined |
+| `MISSING_PLACEHOLDER` | warning | Placeholder for message is not |
+| `WRONG_ICON_EXTENSION` | error | Icons must have valid extension |
+| `MANIFEST_UPDATE_URL` | error | update_url not allowed in manifest.json |
+| `MANIFEST_FIELD_REQUIRED` | error | A required field is missing |
+| `MANIFEST_FIELD_INVALID` | error | A field is invalid |
+| `MANIFEST_FIELD_DEPRECATED` | error | A field is deprecated |
+| `MANIFEST_BAD_PERMISSION` | error | Bad permission |
+| `JSON_BLOCK_COMMENTS` | error | Block Comments are not allowed in JSON |
+| `MANIFEST_INVALID_CONTENT` | error | This add-on contains forbidden content |
+| `CONTENT_SCRIPT_NOT_FOUND` | error | Content script file could not be found |
+| `CONTENT_SCRIPT_EMPTY` | error | Content script file name should not be empty |
+| `NO_MESSAGE` | error | Translation string is missing the message |
+| `INVALID_MESSAGE_NAME` | error | String name contains invalid characters |
+| `INVALID_PLACEHOLDER_NAME` | error | Placeholder name contains invalid characters |
+| `NO_PLACEHOLDER_CONTENT` | error | Placeholder is missing the content |
+| `JSON_INVALID` | error | JSON is not well formed |
+| `JSON_DUPLICATE_KEY` | error | Duplicate key in JSON |
+| `MANIFEST_VERSION_INVALID` | error | manifest_version in manifest.json is not valid. |
+| `PROP_NAME_MISSING` | error | name property missing from manifest.json |
+| `PROP_NAME_INVALID` | error | name property is invalid in manifest.json |
+| `PROP_VERSION_MISSING` | error | version property missing from manifest.json |
+| `PROP_VERSION_INVALID` | error | version is invalid in manifest.json |
+| `MANIFEST_DICT_NOT_FOUND` | error | A dictionary file defined in the manifest could not be found |
+| `MANIFEST_MULTIPLE_DICTS` | error | Multiple dictionaries found |
+| `MANIFEST_EMPTY_DICTS` | error | Empty `dictionaries` object |
+| `MANIFEST_DICT_MISSING_ID` | error | Missing `applications.gecko.id` property for a dictionary |
+| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION` | warning | Manifest key not compatible with `applications.gecko.strict_min_version` |
+| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | warning | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION` | notice | Permission not compatible with `applications.gecko.strict_min_version` |
+| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
+| `PROP_NAME_NOT_ALLOWED` | error | name property must not contain the words `mozilla` or `firefox`. |
 
 ### Static Theme / manifest.json
 
-| Message code                         | Severity | Description                                                 |
-| ------------------------------------ | -------- | ----------------------------------------------------------- |
-| `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning  | Theme image file extension should match its mime type       |
-| `MANIFEST_THEME_IMAGE_NOT_FOUND`     | error    | Theme images must not be missing                            |
-| `MANIFEST_THEME_IMAGE_CORRUPTED`     | error    | Theme images must not be corrupted                          |
-| `MANIFEST_THEME_IMAGE_WRONG_EXT`     | error    | Theme images must have one of the supported file extensions |
-| `MANIFEST_THEME_IMAGE_WRONG_MIME`    | error    | Theme images mime type must be a supported format           |
-| `MANIFEST_THEME_LWT_ALIAS`           | error    | Theme LWT aliases are deprecated                            |
+| Message code | Severity | Description |
+| --- | --- | --- |
+| `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning | Theme image file extension should match its mime type |
+| `MANIFEST_THEME_IMAGE_NOT_FOUND` | error | Theme images must not be missing |
+| `MANIFEST_THEME_IMAGE_CORRUPTED` | error | Theme images must not be corrupted |
+| `MANIFEST_THEME_IMAGE_WRONG_EXT` | error | Theme images must have one of the supported file extensions |
+| `MANIFEST_THEME_IMAGE_WRONG_MIME` | error | Theme images mime type must be a supported format |
+| `MANIFEST_THEME_LWT_ALIAS` | error | Theme LWT aliases are deprecated |

--- a/src/const.js
+++ b/src/const.js
@@ -217,3 +217,6 @@ export const MESSAGE_PLACEHOLDER_REGEXP = '\\$([a-zA-Z0-9_@]+)\\$';
 // yauzl should trow error with this message in case of corrupt zip file
 export const ZIP_LIB_CORRUPT_FILE_ERROR =
   'end of central directory record signature not found';
+
+// A list of not allowed words to use on extension name.
+export const NOT_ALLOWED_NAME_WORDS = ['mozilla', 'firefox'];

--- a/src/const.js
+++ b/src/const.js
@@ -214,6 +214,8 @@ export const LOCALES_DIRECTORY = '_locales';
 // https://searchfox.org/mozilla-central/rev/3abf6fa7e2a6d9a7bfb88796141b0f012e68c2db/toolkit/components/extensions/ExtensionCommon.jsm#1711
 export const MESSAGE_PLACEHOLDER_REGEXP = '\\$([a-zA-Z0-9_@]+)\\$';
 
+export const MANFIEST_MESSAGE_NAME_REGEXP = '__MSG_([A-Za-z0-9@_]+?)__';
+
 // yauzl should trow error with this message in case of corrupt zip file
 export const ZIP_LIB_CORRUPT_FILE_ERROR =
   'end of central directory record signature not found';

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -84,6 +84,17 @@ export const PROP_NAME_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX = {
+  code: 'PROP_NAME_NOT_ALLOWED',
+  message: i18n._(
+    'The "name" property must not contain the words "mozilla" or "firefox".'
+  ),
+  description: i18n._(
+    'See http://mzl.la/1STmr48 (MDN Docs) for more information.'
+  ),
+  file: MANIFEST_JSON,
+};
+
 export const PROP_VERSION_INVALID = {
   code: 'PROP_VERSION_INVALID',
   message: i18n._('The "version" property must be a string.'),

--- a/src/parsers/json.js
+++ b/src/parsers/json.js
@@ -4,7 +4,7 @@ import RJSON from 'relaxed-json';
 import * as messages from 'messages';
 
 export default class JSONParser {
-  constructor(jsonString, collector, { filename = null } = {}) {
+  constructor(jsonString, collector, addonMetadata, { filename = null } = {}) {
     // Add the JSON string to the object; we'll use this for testing.
     this._jsonString = jsonString;
 
@@ -18,6 +18,9 @@ export default class JSONParser {
     // This marks whether a JSON file is valid; in the case of the base JSON
     // parser, that's just whether it can be parsed and has duplicate keys.
     this.isValid = null;
+
+    // Provides access to addon information from scanners
+    this.addonMetadata = addonMetadata;
   }
 
   parse(RelaxedJSON = RJSON) {

--- a/src/parsers/locale-messagesjson.js
+++ b/src/parsers/locale-messagesjson.js
@@ -166,19 +166,17 @@ export default class LocaleMessagesJSONParser extends JSONParser {
         );
       }
 
-      if (messageNameMatch) {
-        const messageName = messageNameMatch[1];
+      if (messageNameMatch && message === messageNameMatch[1]) {
         let nameContainsInvalidWords = false;
-        if (message === messageName) {
-          const nameLowerCase = this.parsedJSON[message].message.toLowerCase();
-          nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
-            nameLowerCase.includes(word)
-          );
-        }
+        const nameLowerCase = this.parsedJSON[message].message.toLowerCase();
+        nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
+          nameLowerCase.includes(word)
+        );
         if (nameContainsInvalidWords) {
-          this.collector.addWarning(
-            messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
-          );
+          this.collector.addWarning({
+            ...messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX,
+            file: this.filename,
+          });
           this.isValid = false;
         }
       }

--- a/src/parsers/locale-messagesjson.js
+++ b/src/parsers/locale-messagesjson.js
@@ -99,6 +99,13 @@ export default class LocaleMessagesJSONParser extends JSONParser {
 
     const regexp = new RegExp(MESSAGE_PLACEHOLDER_REGEXP, 'ig');
     const visitedLowercaseMessages = [];
+    const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
+    let messageNameMatch = null;
+
+    if (this.addonMetadata && typeof this.addonMetadata.name === 'string') {
+      messageNameMatch = messageNameRegexp.exec(this.addonMetadata.name);
+    }
+
     Object.keys(this.parsedJSON).forEach((message) => {
       if (!visitedLowercaseMessages.includes(message.toLowerCase())) {
         visitedLowercaseMessages.push(message.toLowerCase());
@@ -159,26 +166,20 @@ export default class LocaleMessagesJSONParser extends JSONParser {
         );
       }
 
-      if (this.addonMetadata && typeof this.addonMetadata.name === 'string') {
-        const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
-        const match = messageNameRegexp.exec(this.addonMetadata.name);
-        if (match) {
-          const messageName = match[1];
-          let nameContainsInvalidWords = false;
-          if (message === messageName) {
-            const nameLowerCase = this.parsedJSON[
-              message
-            ].message.toLowerCase();
-            nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
-              nameLowerCase.includes(word)
-            );
-          }
-          if (nameContainsInvalidWords) {
-            this.collector.addWarning(
-              messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
-            );
-            this.isValid = false;
-          }
+      if (messageNameMatch) {
+        const messageName = messageNameMatch[1];
+        let nameContainsInvalidWords = false;
+        if (message === messageName) {
+          const nameLowerCase = this.parsedJSON[message].message.toLowerCase();
+          nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
+            nameLowerCase.includes(word)
+          );
+        }
+        if (nameContainsInvalidWords) {
+          this.collector.addWarning(
+            messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
+          );
+          this.isValid = false;
         }
       }
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -483,8 +483,7 @@ export default class ManifestJSONParser extends JSONParser {
 
     if (this.parsedJSON.name && typeof this.parsedJSON.name === 'string') {
       const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
-      const match = messageNameRegexp.exec(this.parsedJSON.name);
-      if (!match) {
+      if (!messageNameRegexp.exec(this.parsedJSON.name)) {
         const nameLowerCase = this.parsedJSON.name.toLowerCase();
         const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
           nameLowerCase.includes(word)

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -26,6 +26,7 @@ import {
   MIME_TO_FILE_EXTENSIONS,
   STATIC_THEME_IMAGE_MIMES,
   NOT_ALLOWED_NAME_WORDS,
+  MANFIEST_MESSAGE_NAME_REGEXP,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -481,24 +482,18 @@ export default class ManifestJSONParser extends JSONParser {
     }
 
     if (this.parsedJSON.name && typeof this.parsedJSON.name === 'string') {
-      const placeholderName = this.parsedJSON.name.replace(
-        /__MSG_([A-Za-z0-9@_]+?)__/g,
-        (match, messageName) => {
-          if (messageName) {
-            return messageName;
-          }
-          return null;
-        }
-      );
-      if (placeholderName) {
+      const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
+      const match = messageNameRegexp.exec(this.parsedJSON.name);
+      if (match) {
+        const messageName = match[1];
         // We've set global value to the extension name placeholder to use in locale-messages parser
-        global.placeholderExtensionName = placeholderName;
+        global.placeholderExtensionName = messageName;
       } else {
         const nameLowerCase = this.parsedJSON.name.toLowerCase();
         const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
           nameLowerCase.includes(word)
         );
-
+        console.log(`nameContainsInvalidWords -> ${nameContainsInvalidWords}`);
         if (nameContainsInvalidWords) {
           this.collector.addWarning(
             messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -25,6 +25,7 @@ import {
   MESSAGES_JSON,
   MIME_TO_FILE_EXTENSIONS,
   STATIC_THEME_IMAGE_MIMES,
+  NOT_ALLOWED_NAME_WORDS,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -476,6 +477,20 @@ export default class ManifestJSONParser extends JSONParser {
             }
           }
         });
+      }
+    }
+
+    if (this.parsedJSON.name) {
+      const nameLowerCase = String(this.parsedJSON.name).toLowerCase();
+      const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
+        nameLowerCase.includes(word)
+      );
+
+      if (nameContainsInvalidWords) {
+        this.collector.addError(
+          messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
+        );
+        this.isValid = false;
       }
     }
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -484,16 +484,11 @@ export default class ManifestJSONParser extends JSONParser {
     if (this.parsedJSON.name && typeof this.parsedJSON.name === 'string') {
       const messageNameRegexp = new RegExp(MANFIEST_MESSAGE_NAME_REGEXP, 'g');
       const match = messageNameRegexp.exec(this.parsedJSON.name);
-      if (match) {
-        const messageName = match[1];
-        // We've set global value to the extension name placeholder to use in locale-messages parser
-        global.placeholderExtensionName = messageName;
-      } else {
+      if (!match) {
         const nameLowerCase = this.parsedJSON.name.toLowerCase();
         const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
           nameLowerCase.includes(word)
         );
-        console.log(`nameContainsInvalidWords -> ${nameContainsInvalidWords}`);
         if (nameContainsInvalidWords) {
           this.collector.addWarning(
             messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -481,16 +481,30 @@ export default class ManifestJSONParser extends JSONParser {
     }
 
     if (this.parsedJSON.name && typeof this.parsedJSON.name === 'string') {
-      const nameLowerCase = this.parsedJSON.name.toLowerCase();
-      const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
-        nameLowerCase.includes(word)
+      const placeholderName = this.parsedJSON.name.replace(
+        /__MSG_([A-Za-z0-9@_]+?)__/g,
+        (match, messageName) => {
+          if (messageName) {
+            return messageName;
+          }
+          return null;
+        }
       );
-
-      if (nameContainsInvalidWords) {
-        this.collector.addWarning(
-          messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
+      if (placeholderName) {
+        // We've set global value to the extension name placeholder to use in locale-messages parser
+        global.placeholderExtensionName = placeholderName;
+      } else {
+        const nameLowerCase = this.parsedJSON.name.toLowerCase();
+        const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
+          nameLowerCase.includes(word)
         );
-        this.isValid = false;
+
+        if (nameContainsInvalidWords) {
+          this.collector.addWarning(
+            messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
+          );
+          this.isValid = false;
+        }
       }
     }
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -480,14 +480,14 @@ export default class ManifestJSONParser extends JSONParser {
       }
     }
 
-    if (this.parsedJSON.name) {
-      const nameLowerCase = String(this.parsedJSON.name).toLowerCase();
+    if (this.parsedJSON.name && typeof this.parsedJSON.name === 'string') {
+      const nameLowerCase = this.parsedJSON.name.toLowerCase();
       const nameContainsInvalidWords = NOT_ALLOWED_NAME_WORDS.some((word) =>
         nameLowerCase.includes(word)
       );
 
       if (nameContainsInvalidWords) {
-        this.collector.addError(
+        this.collector.addWarning(
           messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX
         );
         this.isValid = false;

--- a/src/scanners/json.js
+++ b/src/scanners/json.js
@@ -22,6 +22,7 @@ export default class JSONScanner extends BaseScanner {
       const localeMessagesJSONParser = new LocaleMessagesJSONParser(
         json,
         this.options.collector,
+        this.options.addonMetadata,
         { filename: this.filename }
       );
       localeMessagesJSONParser.parse();

--- a/tests/unit/parsers/test.locale-messagesjson.js
+++ b/tests/unit/parsers/test.locale-messagesjson.js
@@ -1,6 +1,7 @@
 import Linter from 'linter';
 import LocaleMessagesJSONParser from 'parsers/locale-messagesjson';
 import * as messages from 'messages';
+import { MESSAGES_JSON } from 'const';
 
 import { validLocaleMessagesJSON } from '../helpers';
 
@@ -285,6 +286,7 @@ describe('LocaleMessagesJSONParser', () => {
     expect(warnings[0].code).toEqual(
       messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX.code
     );
+    expect(warnings[0].file).toEqual(MESSAGES_JSON);
   });
 
   describe('getLowercasePlaceholders', () => {

--- a/tests/unit/parsers/test.locale-messagesjson.js
+++ b/tests/unit/parsers/test.locale-messagesjson.js
@@ -268,7 +268,6 @@ describe('LocaleMessagesJSONParser', () => {
 
   it('should not contain the words "mozilla" or "firefox" on localized extension name', () => {
     const addonLinter = new Linter({ _: ['bar'] });
-    global.placeholderExtensionName = 'extensionName';
     const localeMessagesJSONParser = new LocaleMessagesJSONParser(
       `{
   "extensionName": {
@@ -276,11 +275,11 @@ describe('LocaleMessagesJSONParser', () => {
     "description": "Name of the extension."    
   }
 }`,
-      addonLinter.collector
+      addonLinter.collector,
+      { name: '__MSG_extensionName__' }
     );
 
     localeMessagesJSONParser.parse();
-    global.placeholderExtensionName = undefined;
     expect(localeMessagesJSONParser.isValid).toEqual(false);
     const { warnings } = addonLinter.collector;
     expect(warnings[0].code).toEqual(

--- a/tests/unit/parsers/test.locale-messagesjson.js
+++ b/tests/unit/parsers/test.locale-messagesjson.js
@@ -266,6 +266,28 @@ describe('LocaleMessagesJSONParser', () => {
     );
   });
 
+  it('should not contain the words "mozilla" or "firefox" on localized extension name', () => {
+    const addonLinter = new Linter({ _: ['bar'] });
+    global.placeholderExtensionName = 'extensionName';
+    const localeMessagesJSONParser = new LocaleMessagesJSONParser(
+      `{
+  "extensionName": {
+    "message": "My Awesome Ext for Mozilla Firefox",
+    "description": "Name of the extension."    
+  }
+}`,
+      addonLinter.collector
+    );
+
+    localeMessagesJSONParser.parse();
+    global.placeholderExtensionName = undefined;
+    expect(localeMessagesJSONParser.isValid).toEqual(false);
+    const { warnings } = addonLinter.collector;
+    expect(warnings[0].code).toEqual(
+      messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX.code
+    );
+  });
+
   describe('getLowercasePlaceholders', () => {
     it('should return undefined if there are no placeholders defined', () => {
       const addonsLinter = new Linter({ _: ['bar'] });

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -403,8 +403,8 @@ describe('ManifestJSONParser', () => {
         addonLinter.collector
       );
       expect(manifestJSONParser.isValid).toEqual(false);
-      const { errors } = addonLinter.collector;
-      expect(errors[0].code).toEqual(
+      const { warnings } = addonLinter.collector;
+      expect(warnings[0].code).toEqual(
         messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX.code
       );
     });

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -394,6 +394,20 @@ describe('ManifestJSONParser', () => {
       expect(errors[0].code).toEqual(messages.MANIFEST_FIELD_INVALID.code);
       expect(errors[0].message).toContain('/name');
     });
+
+    it('should not contain the words "mozilla" or "firefox" on name value', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({ name: 'my-awesome-ext for Firefox' });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      expect(manifestJSONParser.isValid).toEqual(false);
+      const { errors } = addonLinter.collector;
+      expect(errors[0].code).toEqual(
+        messages.PROP_NAME_MUST_NOT_CONTAIN_MOZILLA_OR_FIREFOX.code
+      );
+    });
   });
 
   describe('version', () => {


### PR DESCRIPTION
This PR Fix #2158 where a new rule was added to validate cases where the words `Mozilla` and `Firefox` were used in the extension name.

I need some help on this to check for localized versions of the name. Is there a place that has already use localized versions of Mozilla and Firefox that i can rely on?



