### PR TITLE
feat: Imported Firefox 77b7 schema

### DIFF
--- a/src/schema/imported/activity_log.json
+++ b/src/schema/imported/activity_log.json
@@ -90,7 +90,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -102,9 +102,9 @@
     }
   },
   "refs": {
-    "activityLog#/definitions/Permission": {
+    "activityLog#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {}

--- a/src/schema/imported/browsing_data.json
+++ b/src/schema/imported/browsing_data.json
@@ -395,7 +395,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -407,9 +407,9 @@
     }
   },
   "refs": {
-    "browsingData#/definitions/Permission": {
+    "browsingData#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/captive_portal.json
+++ b/src/schema/imported/captive_portal.json
@@ -76,7 +76,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -88,9 +88,9 @@
     }
   },
   "refs": {
-    "captivePortal#/definitions/Permission": {
+    "captivePortal#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {}

--- a/src/schema/imported/context_menus.json
+++ b/src/schema/imported/context_menus.json
@@ -506,7 +506,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -517,7 +517,7 @@
         }
       ]
     },
-    "OptionalPermission": {
+    "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -529,13 +529,13 @@
     }
   },
   "refs": {
-    "menus#/definitions/Permission": {
+    "menus#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     },
-    "menus#/definitions/OptionalPermission": {
+    "menus#/definitions/OptionalPermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "OptionalPermission"
+      "type": "OptionalPermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/contextual_identities.json
+++ b/src/schema/imported/contextual_identities.json
@@ -196,7 +196,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -208,9 +208,9 @@
     }
   },
   "refs": {
-    "contextualIdentities#/definitions/Permission": {
+    "contextualIdentities#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/cookies.json
+++ b/src/schema/imported/cookies.json
@@ -347,7 +347,7 @@
     }
   ],
   "definitions": {
-    "OptionalPermission": {
+    "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -359,9 +359,9 @@
     }
   },
   "refs": {
-    "cookies#/definitions/OptionalPermission": {
+    "cookies#/definitions/OptionalPermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "OptionalPermission"
+      "type": "OptionalPermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/devtools.json
+++ b/src/schema/imported/devtools.json
@@ -19,7 +19,7 @@
         }
       }
     },
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -35,9 +35,9 @@
       "namespace": "manifest",
       "type": "WebExtensionManifest"
     },
-    "devtools#/definitions/Permission": {
+    "devtools#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/dns.json
+++ b/src/schema/imported/dns.json
@@ -31,7 +31,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -43,9 +43,9 @@
     }
   },
   "refs": {
-    "dns#/definitions/Permission": {
+    "dns#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -140,7 +140,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -152,9 +152,9 @@
     }
   },
   "refs": {
-    "geckoProfiler#/definitions/Permission": {
+    "geckoProfiler#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/identity.json
+++ b/src/schema/imported/identity.json
@@ -221,7 +221,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -233,9 +233,9 @@
     }
   },
   "refs": {
-    "identity#/definitions/Permission": {
+    "identity#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/management.json
+++ b/src/schema/imported/management.json
@@ -286,7 +286,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -298,9 +298,9 @@
     }
   },
   "refs": {
-    "management#/definitions/Permission": {
+    "management#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -460,15 +460,42 @@
         "size"
       ]
     },
+    "OptionalPermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "idle"
+          ]
+        },
+        {
+          "$ref": "cookies#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
+          "$ref": "menus#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
+          "$ref": "search#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
+          "$ref": "tabs#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
+          "$ref": "webRequest#/definitions/OptionalPermissionNoPrompt"
+        }
+      ]
+    },
     "OptionalPermission": {
       "anyOf": [
+        {
+          "$ref": "#/types/OptionalPermissionNoPrompt"
+        },
         {
           "type": "string",
           "enum": [
             "clipboardRead",
             "clipboardWrite",
             "geolocation",
-            "idle",
             "notifications"
           ]
         },
@@ -479,7 +506,10 @@
           "$ref": "browserSettings#/definitions/OptionalPermission"
         },
         {
-          "$ref": "cookies#/definitions/OptionalPermission"
+          "$ref": "browsingData#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "devtools#/definitions/OptionalPermission"
         },
         {
           "$ref": "downloads#/definitions/OptionalPermission"
@@ -491,13 +521,19 @@
           "$ref": "history#/definitions/OptionalPermission"
         },
         {
-          "$ref": "menus#/definitions/OptionalPermission"
+          "$ref": "management#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "pkcs11#/definitions/OptionalPermission"
         },
         {
           "$ref": "privacy#/definitions/OptionalPermission"
         },
         {
-          "$ref": "search#/definitions/OptionalPermission"
+          "$ref": "proxy#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "sessions#/definitions/OptionalPermission"
         },
         {
           "$ref": "tabs#/definitions/OptionalPermission"
@@ -507,9 +543,6 @@
         },
         {
           "$ref": "webNavigation#/definitions/OptionalPermission"
-        },
-        {
-          "$ref": "webRequest#/definitions/OptionalPermission"
         }
       ]
     },
@@ -523,7 +556,7 @@
         }
       ]
     },
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "$ref": "#/types/OptionalPermission"
@@ -538,64 +571,56 @@
           ]
         },
         {
-          "$ref": "activityLog#/definitions/Permission"
+          "$ref": "activityLog#/definitions/PermissionNoPrompt"
         },
         {
-          "$ref": "browsingData#/definitions/Permission"
+          "$ref": "captivePortal#/definitions/PermissionNoPrompt"
         },
         {
-          "$ref": "captivePortal#/definitions/Permission"
+          "$ref": "contextualIdentities#/definitions/PermissionNoPrompt"
         },
         {
-          "$ref": "contextualIdentities#/definitions/Permission"
+          "$ref": "dns#/definitions/PermissionNoPrompt"
         },
         {
-          "$ref": "devtools#/definitions/Permission"
+          "$ref": "geckoProfiler#/definitions/PermissionNoPrompt"
         },
         {
-          "$ref": "dns#/definitions/Permission"
+          "$ref": "identity#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "menus#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "networkStatus#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "normandyAddonStudy#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "telemetry#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "theme#/definitions/PermissionNoPrompt"
+        },
+        {
+          "$ref": "urlbar#/definitions/PermissionNoPrompt"
+        }
+      ]
+    },
+    "Permission": {
+      "anyOf": [
+        {
+          "$ref": "#/types/PermissionNoPrompt"
+        },
+        {
+          "$ref": "#/types/OptionalPermission"
         },
         {
           "$ref": "experiments#/definitions/Permission"
         },
         {
-          "$ref": "geckoProfiler#/definitions/Permission"
-        },
-        {
-          "$ref": "identity#/definitions/Permission"
-        },
-        {
-          "$ref": "management#/definitions/Permission"
-        },
-        {
-          "$ref": "menus#/definitions/Permission"
-        },
-        {
-          "$ref": "networkStatus#/definitions/Permission"
-        },
-        {
-          "$ref": "normandyAddonStudy#/definitions/Permission"
-        },
-        {
-          "$ref": "pkcs11#/definitions/Permission"
-        },
-        {
-          "$ref": "proxy#/definitions/Permission"
-        },
-        {
           "$ref": "runtime#/definitions/Permission"
-        },
-        {
-          "$ref": "sessions#/definitions/Permission"
-        },
-        {
-          "$ref": "telemetry#/definitions/Permission"
-        },
-        {
-          "$ref": "theme#/definitions/Permission"
-        },
-        {
-          "$ref": "urlbar#/definitions/Permission"
         }
       ]
     },

--- a/src/schema/imported/menus.json
+++ b/src/schema/imported/menus.json
@@ -505,7 +505,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -516,7 +516,7 @@
         }
       ]
     },
-    "OptionalPermission": {
+    "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -528,13 +528,13 @@
     }
   },
   "refs": {
-    "menus#/definitions/Permission": {
+    "menus#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     },
-    "menus#/definitions/OptionalPermission": {
+    "menus#/definitions/OptionalPermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "OptionalPermission"
+      "type": "OptionalPermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/network_status.json
+++ b/src/schema/imported/network_status.json
@@ -33,7 +33,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -45,9 +45,9 @@
     }
   },
   "refs": {
-    "networkStatus#/definitions/Permission": {
+    "networkStatus#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/normandyAddonStudy.json
+++ b/src/schema/imported/normandyAddonStudy.json
@@ -56,7 +56,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -68,9 +68,9 @@
     }
   },
   "refs": {
-    "normandyAddonStudy#/definitions/Permission": {
+    "normandyAddonStudy#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/permissions.json
+++ b/src/schema/imported/permissions.json
@@ -116,7 +116,6 @@
     {
       "name": "onAdded",
       "type": "function",
-      "unsupported": true,
       "description": "Fired when the extension acquires new permissions.",
       "parameters": [
         {
@@ -134,7 +133,6 @@
     {
       "name": "onRemoved",
       "type": "function",
-      "unsupported": true,
       "description": "Fired when permissions are removed from the extension.",
       "parameters": [
         {

--- a/src/schema/imported/pkcs11.json
+++ b/src/schema/imported/pkcs11.json
@@ -60,7 +60,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -72,9 +72,9 @@
     }
   },
   "refs": {
-    "pkcs11#/definitions/Permission": {
+    "pkcs11#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {}

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -162,7 +162,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -174,9 +174,9 @@
     }
   },
   "refs": {
-    "proxy#/definitions/Permission": {
+    "proxy#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/search.json
+++ b/src/schema/imported/search.json
@@ -43,7 +43,7 @@
     }
   ],
   "definitions": {
-    "OptionalPermission": {
+    "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -55,9 +55,9 @@
     }
   },
   "refs": {
-    "search#/definitions/OptionalPermission": {
+    "search#/definitions/OptionalPermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "OptionalPermission"
+      "type": "OptionalPermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/sessions.json
+++ b/src/schema/imported/sessions.json
@@ -273,7 +273,7 @@
     }
   },
   "definitions": {
-    "Permission": {
+    "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
@@ -285,9 +285,9 @@
     }
   },
   "refs": {
-    "sessions#/definitions/Permission": {
+    "sessions#/definitions/OptionalPermission": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "OptionalPermission"
     }
   },
   "types": {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -325,6 +325,21 @@
           "description": "The ID of the tab which is to be duplicated."
         },
         {
+          "type": "object",
+          "name": "duplicateProperties",
+          "optional": true,
+          "properties": {
+            "index": {
+              "type": "integer",
+              "description": "The position the new tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window."
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see $(ref:windows.update)). Defaults to <var>true</var>."
+            }
+          }
+        },
+        {
           "type": "function",
           "name": "callback",
           "optional": true,
@@ -1275,6 +1290,48 @@
           }
         }
       ]
+    },
+    {
+      "name": "goForward",
+      "type": "function",
+      "description": "Navigate to next page in tab's history, if available",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "tabId",
+          "minimum": 0,
+          "optional": true,
+          "description": "The ID of the tab to navigate forward."
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "optional": true,
+          "parameters": []
+        }
+      ]
+    },
+    {
+      "name": "goBack",
+      "type": "function",
+      "description": "Navigate to previous page in tab's history, if available.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "tabId",
+          "minimum": 0,
+          "optional": true,
+          "description": "The ID of the tab to navigate backward."
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "optional": true,
+          "parameters": []
+        }
+      ]
     }
   ],
   "events": [
@@ -1738,12 +1795,21 @@
     }
   ],
   "definitions": {
+    "OptionalPermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "activeTab"
+          ]
+        }
+      ]
+    },
     "OptionalPermission": {
       "anyOf": [
         {
           "type": "string",
           "enum": [
-            "activeTab",
             "tabs",
             "tabHide"
           ]
@@ -1752,6 +1818,10 @@
     }
   },
   "refs": {
+    "tabs#/definitions/OptionalPermissionNoPrompt": {
+      "namespace": "manifest",
+      "type": "OptionalPermissionNoPrompt"
+    },
     "tabs#/definitions/OptionalPermission": {
       "namespace": "manifest",
       "type": "OptionalPermission"

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -315,7 +315,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -327,9 +327,9 @@
     }
   },
   "refs": {
-    "telemetry#/definitions/Permission": {
+    "telemetry#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -83,7 +83,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -102,9 +102,9 @@
     }
   },
   "refs": {
-    "theme#/definitions/Permission": {
+    "theme#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     },
     "theme#/definitions/WebExtensionManifest": {
       "namespace": "manifest",

--- a/src/schema/imported/urlbar.json
+++ b/src/schema/imported/urlbar.json
@@ -209,7 +209,7 @@
     }
   ],
   "definitions": {
-    "Permission": {
+    "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -221,9 +221,9 @@
     }
   },
   "refs": {
-    "urlbar#/definitions/Permission": {
+    "urlbar#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "Permission"
+      "type": "PermissionNoPrompt"
     }
   },
   "types": {

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1380,7 +1380,7 @@
     }
   ],
   "definitions": {
-    "OptionalPermission": {
+    "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
@@ -1393,9 +1393,9 @@
     }
   },
   "refs": {
-    "webRequest#/definitions/OptionalPermission": {
+    "webRequest#/definitions/OptionalPermissionNoPrompt": {
       "namespace": "manifest",
-      "type": "OptionalPermission"
+      "type": "OptionalPermissionNoPrompt"
     }
   },
   "types": {


### PR DESCRIPTION
Import updated API schema files from Firefox 77b7.

Notable changes:
- recognize newly supported `optional_permissions` (Fixes #3138)
- newly supported `permissions.onAdded/onRemoved` API events
- new `tabs.goForward/goBack` API methods
- newly added `index` and `active` properties in `tabs.duplicate` options