### PR TITLE
feat: Imported Firefox 78b6 schema

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -165,20 +165,21 @@
         "js",
         "leaf",
         "mainthreadio",
-        "privacy",
         "responsiveness",
         "screenshots",
         "seqstyle",
         "stackwalk",
         "tasktracer",
         "threads",
-        "trackopts",
         "jstracer",
         "jsallocations",
         "nostacksampling",
         "nativeallocations",
         "preferencereads",
-        "ipcmessages"
+        "ipcmessages",
+        "fileio",
+        "fileioall",
+        "noiostacks"
       ]
     },
     "supports": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -299,6 +299,9 @@
           "$ref": "sidebarAction#/definitions/WebExtensionManifest"
         },
         {
+          "$ref": "telemetry#/definitions/WebExtensionManifest"
+        },
+        {
           "$ref": "theme#/definitions/WebExtensionManifest"
         },
         {

--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -258,7 +258,8 @@
             "reject_all",
             "reject_third_party",
             "allow_visited",
-            "reject_trackers"
+            "reject_trackers",
+            "reject_trackers_and_partition_foreign"
           ],
           "description": "The type of cookies to allow."
         },

--- a/src/schema/imported/storage.json
+++ b/src/schema/imported/storage.json
@@ -38,7 +38,7 @@
     "sync": {
       "allOf": [
         {
-          "$ref": "#/types/StorageArea"
+          "$ref": "#/types/StorageAreaSync"
         },
         {
           "description": "Items in the <code>sync</code> storage area are synced by the browser.",
@@ -181,6 +181,155 @@
         {
           "name": "getBytesInUse",
           "unsupported": true,
+          "type": "function",
+          "description": "Gets the amount of space (in bytes) being used by one or more items.",
+          "async": "callback",
+          "parameters": [
+            {
+              "name": "keys",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "description": "A single key or list of keys to get the total usage for. An empty list will return 0. Pass in <code>null</code> to get the total usage of all of storage.",
+              "optional": true
+            },
+            {
+              "name": "callback",
+              "type": "function",
+              "description": "Callback with the amount of space being used by storage, or on failure (in which case $(ref:runtime.lastError) will be set).",
+              "parameters": [
+                {
+                  "name": "bytesInUse",
+                  "type": "integer",
+                  "description": "Amount of space being used in storage, in bytes."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "type": "function",
+          "description": "Sets multiple items.",
+          "async": "callback",
+          "parameters": [
+            {
+              "name": "items",
+              "type": "object",
+              "additionalProperties": {},
+              "description": "<p>An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.</p><p>Primitive values such as numbers will serialize as expected. Values with a <code>typeof</code> <code>\"object\"</code> and <code>\"function\"</code> will typically serialize to <code>{}</code>, with the exception of <code>Array</code> (serializes as expected), <code>Date</code>, and <code>Regex</code> (serialize using their <code>String</code> representation).</p>"
+            },
+            {
+              "name": "callback",
+              "type": "function",
+              "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+              "parameters": [],
+              "optional": true
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "type": "function",
+          "description": "Removes one or more items from storage.",
+          "async": "callback",
+          "parameters": [
+            {
+              "name": "keys",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "description": "A single key or a list of keys for items to remove."
+            },
+            {
+              "name": "callback",
+              "type": "function",
+              "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+              "parameters": [],
+              "optional": true
+            }
+          ]
+        },
+        {
+          "name": "clear",
+          "type": "function",
+          "description": "Removes all items from storage.",
+          "async": "callback",
+          "parameters": [
+            {
+              "name": "callback",
+              "type": "function",
+              "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+              "parameters": [],
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    "StorageAreaSync": {
+      "type": "object",
+      "functions": [
+        {
+          "name": "get",
+          "type": "function",
+          "description": "Gets one or more items from storage.",
+          "async": "callback",
+          "parameters": [
+            {
+              "name": "keys",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object",
+                  "description": "Storage items to return in the callback, where the values are replaced with those from storage if they exist.",
+                  "additionalProperties": {}
+                }
+              ],
+              "description": "A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object).  An empty list or object will return an empty result object.  Pass in <code>null</code> to get the entire contents of storage.",
+              "optional": true
+            },
+            {
+              "name": "callback",
+              "type": "function",
+              "description": "Callback with storage items, or on failure (in which case $(ref:runtime.lastError) will be set).",
+              "parameters": [
+                {
+                  "name": "items",
+                  "type": "object",
+                  "additionalProperties": {},
+                  "description": "Object with items in their key-value mappings."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "getBytesInUse",
           "type": "function",
           "description": "Gets the amount of space (in bytes) being used by one or more items.",
           "async": "callback",

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -54,6 +54,39 @@
       ]
     },
     {
+      "name": "submitEncryptedPing",
+      "type": "function",
+      "description": "Submits a custom ping to the Telemetry back-end, with an encrypted payload. Requires a telemetry entry in the manifest to be used.",
+      "parameters": [
+        {
+          "name": "message",
+          "type": "object",
+          "additionalProperties": {},
+          "description": "The data payload for the ping, which will be encrypted."
+        },
+        {
+          "description": "Options object.",
+          "name": "options",
+          "type": "object",
+          "properties": {
+            "schemaName": {
+              "type": "string",
+              "description": "Schema name used for payload."
+            },
+            "schemaVersion": {
+              "type": "integer",
+              "description": "Schema version used for payload."
+            }
+          },
+          "required": [
+            "schemaName",
+            "schemaVersion"
+          ]
+        }
+      ],
+      "async": true
+    },
+    {
       "name": "canUpload",
       "type": "function",
       "description": "Checks if Telemetry upload is enabled.",
@@ -315,6 +348,62 @@
     }
   ],
   "definitions": {
+    "WebExtensionManifest": {
+      "properties": {
+        "telemetry": {
+          "type": "object",
+          "properties": {
+            "ping_type": {
+              "type": "string"
+            },
+            "schemaNamespace": {
+              "type": "string"
+            },
+            "public_key": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "object",
+                  "properties": {
+                    "crv": {
+                      "type": "string"
+                    },
+                    "kty": {
+                      "type": "string"
+                    },
+                    "x": {
+                      "type": "string"
+                    },
+                    "y": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "key"
+              ]
+            },
+            "study_name": {
+              "type": "string"
+            },
+            "pioneer_id": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "ping_type",
+            "schemaNamespace",
+            "public_key"
+          ]
+        }
+      }
+    },
     "PermissionNoPrompt": {
       "anyOf": [
         {
@@ -327,6 +416,10 @@
     }
   },
   "refs": {
+    "telemetry#/definitions/WebExtensionManifest": {
+      "namespace": "manifest",
+      "type": "WebExtensionManifest"
+    },
     "telemetry#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
       "type": "PermissionNoPrompt"

--- a/src/schema/imported/top_sites.json
+++ b/src/schema/imported/top_sites.json
@@ -58,7 +58,7 @@
             "newtab": {
               "type": "boolean",
               "default": false,
-              "description": "Return the sites that exactly appear on the user's new-tab page. When true, all other options are ignored except limit and includeFavicon."
+              "description": "Return the sites that exactly appear on the user's new-tab page. When true, all other options are ignored except limit and includeFavicon. If the user disabled newtab Top Sites, the newtab parameter will be ignored."
             }
           },
           "default": {},

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1410,7 +1410,6 @@
         "object",
         "object_subrequest",
         "xmlhttprequest",
-        "xbl",
         "xslt",
         "ping",
         "beacon",
@@ -1498,7 +1497,14 @@
           "type": "array",
           "description": "A list of request types. Requests that cannot match any of the types will be filtered out.",
           "items": {
-            "$ref": "#/types/ResourceType"
+            "allOf": [
+              {
+                "$ref": "#/types/ResourceType"
+              },
+              {
+                "onError": "warn"
+              }
+            ]
           },
           "minItems": 1
         },


### PR DESCRIPTION
Import updated API schema files from Firefox 78b6.

Notable changes:
- new "reject_trackers_and_partition_foreign" value added in `privacy.cookieConfig` enum
- `getBytesInUse` marked as supported in `storage.sync` API namespace (which is now referring to the `StorageAreaSync` type where `getBytesInUse` is marked as supported, all other storage areas are still referring to `StorageArea` where `getBytesInUse` is still marked as unsupported) 
- in webRequest API the "xbl" `ResourceType` has been removed, errors on ResourceType validation are logged as warnings

Other changes to API not available to third party extensions:
- changes to `geckoProfiler`'s `ProfilerFeature` enum
- added a new `submitEncryptedPing` API method to the `telemetry` API (and some new manifest properties to support this new API method)