### PR TITLE
Only deploy once on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
     tags: true
     repo: mozilla/addons-linter
     branch: master
-    node_js: 'v10.21.0'
+    node_js: 'v11.21.0'
 
 after_success: npm run publish-rules > /dev/null 2>&1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
     tags: true
     repo: mozilla/addons-linter
     branch: master
-    node_js: 'v11.21.0'
+    node_js: 'v10.21.0'
 
 after_success: npm run publish-rules > /dev/null 2>&1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  # When updating the value below, make sure to update the `node_js` version in
+  # the `deploy` section at the bottom of this file too.
   - 'v10.21.0'
   - 'v12.18.1'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 'v10.21.0'
   - 'v12.18.1'
+
 script:
   - node scripts/build-locales
   - npm run build
@@ -10,15 +11,18 @@ script:
   # run integration tests using an addons-linter binary in a production-like environment
   - npm run test-integration:production
   - npm run prettier-ci
+
 notifications:
   slack:
     if: branch = master
     on_success: change
     on_failure: always
     secure: Y8YmPUEEFzyH6GzX+zz8wSkknwJie/lkTtTXURPtwKEtb4P9QYaiXOZqooRJAFlJbQUKIC+t1Lp5wcdULfgmKf3MxdlXMwlkbS/gTyWJZ9W/T3Xr0FToiLezcM6xX40d7CZu5ZImOPuptPGhPUCEOvT27Z+0LTu5JKdGe9RPxAmJ4lzaUMvT9BQwmPd6eN43OaeKXroi4KjtJhX2cGa0dTfT5/wMjNGKdyO+UpUJUXiNo2U3taui595TLEI9V3+qtu1HInnkzjtm5fdjF8+TqEFAz8Ge0ASbTtDy0jyd22WIJct1kiHjGHRrHfuD9xTIgRaQL1/1lLh/XuCSUqqm1fwP/agMNwZBy5nIsKKkiwVfa0kyMi++ChooJm+hCctwZIsMgAJOPI/vnmsfkyslS8qhdoL+cJJKXRdqov/+yPW6fZq44kthadtqC8Ee3D1YcvBN/FlgeZpShKRrk+a3ro/0gabtGWpArgoD3FYm3mbqa+/QxYd5XsYFtKiNJ7g5hNBPpoMi+y8w7TMdv5tXWpHZ7UjDpklslmREDyxoXfbCURwDy4+cAsKeWMcrpzvQuwFt6TmWTEDL3tplvwwRuYKjaRGngl9JIMRt1caAmPckf8MsGvds7FvY3rhGGIJoVwaa+kKbkbRCI5Z9OJNXBPl1lgE1DobDE9AjGYsAK6g=
+
 cache:
   directories:
   - node_modules
+
 deploy:
   provider: npm
   email: addons-dev-automation+npm@mozilla.com
@@ -31,6 +35,8 @@ deploy:
     tags: true
     repo: mozilla/addons-linter
     branch: master
+    node_js: 'v10.21.0'
+
 after_success: npm run publish-rules > /dev/null 2>&1
 env:
   global:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3228

---

I chose the lower node version because this is the one we support. It's sad that we can reference the first entry of the top-level `node_js` key but it is not so bad. We don't change those versions very often.

I also added some blank lines because the content of this file is hard to read..