### PR TITLE
Make sure __dirname is false in webpack config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 scripts/download-import-tag
 scripts/list-firefox-tags
+scripts/webext-test-functional
 dist
 coverage
 tests/fixtures/**

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules
 
 dist/*
 coverage/*
+web-ext/
 
 docs/html/*
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 # exclude these files
 scripts/download-import-tag
 scripts/list-firefox-tags
+scripts/webext-test-functional
 package-lock.json
 LICENSE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   # run integration tests using an addons-linter binary in a production-like environment
   - npm run test-integration:production
   - npm run prettier-ci
+  - npm run webext-test-functional
 
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prettier-ci": "prettier --list-different '**' || (echo '\n\nThis failure means you did not run `npm run prettier-dev` before committing\n\n' && exit 1)",
     "prettier-dev": "pretty-quick --branch master",
     "publish-rules": "scripts/build-rules && cp node_modules/gfm.css/gfm.css docs/html/gfm.css && scripts/publish-rules",
-    "gen-contributing-toc": "doctoc CONTRIBUTING.md"
+    "gen-contributing-toc": "doctoc CONTRIBUTING.md",
+    "webext-test-functional": "scripts/webext-test-functional"
   },
   "repository": {
     "type": "git",

--- a/scripts/webext-test-functional
+++ b/scripts/webext-test-functional
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Build addons-linter
+npm install
+npm run build
+
+# Create (global) addons-linter link
+# See: https://docs.npmjs.com/cli/link
+npm link
+
+# Fetch web-ext
+git clone https://github.com/mozilla/web-ext
+cd web-ext
+
+# Link addons-linter, then install web-ext's dependencies
+npm install
+npm link addons-linter
+
+# Run web-ext functional tests
+npm run test-functional
+status_code=$?
+
+# Cleanup
+cd ..
+rm -rf web-ext
+
+exit $status_code

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,4 +57,10 @@ module.exports = {
     modules: ['src', 'node_modules'],
   },
   devtool: 'sourcemap',
+  node: {
+    // This is required because the default value does not seem to be `false`.
+    // If this isn't set to `false`, `__dirname` is likely invalid and it
+    // prevents JS rules to be loaded correctly.
+    __dirname: false,
+  },
 };


### PR DESCRIPTION
@rpl should we have a travis job that checkouts `web-ext`, then `npm link addons-linter` and finally run web-ext's functional tests?