### PR TITLE
feat: Imported Firefox 79b5 schema

### DIFF
--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -25,7 +25,7 @@
                 "search_url": {
                   "type": "string",
                   "format": "url",
-                  "pattern": "^https://.*$",
+                  "pattern": "^(https://|http://(localhost|127\\.0\\.0\\.1|\\[::1\\])).*$",
                   "preprocess": "localize"
                 },
                 "favicon_url": {
@@ -35,7 +35,7 @@
                 },
                 "suggest_url": {
                   "type": "string",
-                  "pattern": "^https://.*$|^$",
+                  "pattern": "^(https://|http://(localhost|127\\.0\\.0\\.1|\\[::1\\])).*$",
                   "preprocess": "localize"
                 },
                 "instant_url": {
@@ -83,7 +83,7 @@
                 "search_form": {
                   "type": "string",
                   "format": "url",
-                  "pattern": "^https://.*$",
+                  "pattern": "^(https://|http://(localhost|127\\.0\\.0\\.1|\\[::1\\])).*$",
                   "preprocess": "localize"
                 },
                 "alternate_urls": {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -747,6 +747,21 @@
       ]
     },
     {
+      "name": "warmup",
+      "type": "function",
+      "description": "Warm up a tab",
+      "async": true,
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "tabId",
+          "minimum": 0,
+          "optional": false,
+          "description": "The ID of the tab to warm up."
+        }
+      ]
+    },
+    {
       "name": "remove",
       "type": "function",
       "description": "Closes one or more tabs.",

--- a/src/schema/imported/urlbar.json
+++ b/src/schema/imported/urlbar.json
@@ -190,12 +190,17 @@
     {
       "name": "onResultPicked",
       "type": "function",
-      "description": "Typically, a provider includes a <code>url</code> property in its results' payloads. When the user picks a result with a URL, Firefox automatically loads the URL. URLs don't make sense for every result type, however. When the user picks a result without a URL, this event is fired. The provider should take an appropriate action in response. Currently the only applicable <code>ResultType</code> is <code>tip</code>.",
+      "description": "Typically, a provider includes a <code>url</code> property in its results' payloads. When the user picks a result with a URL, Firefox automatically loads the URL. URLs don't make sense for every result type, however. When the user picks a result without a URL, this event is fired. The provider should take an appropriate action in response. Currently the only applicable <code>ResultTypes</code> are <code>dynamic</code> and <code>tip</code>.",
       "parameters": [
         {
           "name": "payload",
           "type": "object",
           "description": "The payload of the result that was picked."
+        },
+        {
+          "name": "elementName",
+          "type": "string",
+          "description": "If the result is a dynamic type, this is the name of the element in the result view that was picked. If the result is not a dynamic type, this is an empty string."
         }
       ],
       "extraParameters": [
@@ -311,13 +316,14 @@
     "ResultType": {
       "type": "string",
       "enum": [
+        "dynamic",
         "remote_tab",
         "search",
         "tab",
         "tip",
         "url"
       ],
-      "description": "Possible types of results. <code>remote_tab</code>: A synced tab from another device. <code>search</code>: A search suggestion from a search engine. <code>tab</code>: An open tab in the browser. <code>tip</code>: An actionable message to help the user with their query. <code>url</code>: A URL that's not one of the other types."
+      "description": "Possible types of results. <code>dynamic</code>: A result whose view and payload are specified by the extension. <code>remote_tab</code>: A synced tab from another device. <code>search</code>: A search suggestion from a search engine. <code>tab</code>: An open tab in the browser. <code>tip</code>: An actionable message to help the user with their query. <code>url</code>: A URL that's not one of the other types."
     },
     "SearchOptions": {
       "type": "object",


### PR DESCRIPTION
Import updated API schema files from Firefox 79b5:

- allowed localhost hostname/ips in chrome_settings_overrides's search_url
- new tabs.warmup API method
- some additions to the browser.experiments.urlbar API
