### PR TITLE
feat: Imported Firefox 80b6 schema

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -99,6 +99,7 @@ Rules are sorted by severity.
 | `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
 | `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
 | `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
+| `MANIFEST_FIELD_UNSUPPORTED`                            | error    | A manifest field is not supported                                                               |
 | `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
 | `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
 | `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -21,6 +21,18 @@ export const MANIFEST_FIELD_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_FIELD_UNSUPPORTED = 'MANIFEST_FIELD_UNSUPPORTED';
+export function manifestFieldUnsupported(fieldName) {
+  return {
+    code: 'MANIFEST_FIELD_UNSUPPORTED',
+    message: i18n._('Manifest field not supported.'),
+    description: i18n.sprintf(i18n._('"%(fieldName)s" is not supported.'), {
+      fieldName,
+    }),
+    file: MANIFEST_JSON,
+  };
+}
+
 export const MANIFEST_BAD_PERMISSION = {
   code: 'MANIFEST_BAD_PERMISSION',
   message: i18n._('The permission type is unsupported.'),

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -314,6 +314,16 @@ export default class ManifestJSONParser extends JSONParser {
           'page'
         );
       }
+      if (this.parsedJSON.background.service_worker) {
+        // TODO: replace this with a call to this.validateFileExistsInPackage
+        // once background.service_worker is supported on the Firefox side and
+        // we can accept it on AMO submissions
+        // (https://github.com/mozilla/addons-linter/issues/3290).
+        this.collector.addError(
+          messages.manifestFieldUnsupported('background.service_worker')
+        );
+        this.isValid = false;
+      }
     }
 
     if (

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -179,7 +179,8 @@
         "ipcmessages",
         "fileio",
         "fileioall",
-        "noiostacks"
+        "noiostacks",
+        "audiocallbacktracing"
       ]
     },
     "supports": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -144,6 +144,18 @@
                       "required": [
                         "scripts"
                       ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "service_worker": {
+                          "$ref": "manifest#/types/ExtensionURL"
+                        }
+                      },
+                      "postprocess": "requireBackgroundServiceWorkerEnabled",
+                      "required": [
+                        "service_worker"
+                      ]
                     }
                   ]
                 },

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1788,6 +1788,25 @@ describe('ManifestJSONParser', () => {
         description: 'Background page could not be found at "foo.html".',
       });
     });
+
+    it('does error if background.service_worker is being used', () => {
+      const linter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        background: { service_worker: 'background_worker.js' },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        linter.collector,
+        { io: { files: {} } }
+      );
+
+      expect(manifestJSONParser.isValid).toBeFalsy();
+      assertHasMatchingError(linter.collector.errors, {
+        code: messages.MANIFEST_FIELD_UNSUPPORTED,
+        message: 'Manifest field not supported.',
+        description: '"background.service_worker" is not supported.',
+      });
+    });
   });
 
   describe('content_scripts', () => {


### PR DESCRIPTION
This schema import contains:

- a small addition to the geckoProfiler ProfilerFeature enum
- the addition manifest entry for the background service worker

On the Firefox side the background.service_worker property is guarded by the `requireBackgroundServiceWorkerEnabled` postprocess function and locked behind a pref disabled by default on all channels.

It may be worth to special case the background.service_worker property as part of the manifest linting and raise an error if it is being used (and file a follow up to remove that once we are going to enable it by default on the Firefox side).