### PR TITLE
fix: Align optional_permissions validation to the validation rules already applied to the manifest permissions 

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,7 @@ Rules are sorted by severity.
 | `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
 | `MANIFEST_FIELD_UNSUPPORTED`                            | error    | A manifest field is not supported                                                               |
 | `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
+| `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                         |
 | `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
 | `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
 | `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -86,7 +86,7 @@ Rules are sorted by severity.
 | `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
 | `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
 | `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
-| `MANIFEST_OPTIONAL_PERMISSIONS`                                  | warning  | Unknown optional permission                                                                              |
+| `MANIFEST_OPTIONAL_PERMISSIONS`                         | warning  | Unknown optional permission                                                                     |
 | `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
 | `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
 | `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -86,6 +86,7 @@ Rules are sorted by severity.
 | `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
 | `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
 | `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
+| `MANIFEST_OPTIONAL_PERMISSIONS`                                  | warning  | Unknown optional permission                                                                              |
 | `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
 | `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
 | `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -41,6 +41,14 @@ export const MANIFEST_BAD_PERMISSION = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_BAD_OPTIONAL_PERMISSION = {
+  code: 'MANIFEST_BAD_OPTIONAL_PERMISSION',
+  message: i18n._('The permission type is unsupported.'),
+  description: i18n._(oneLine`See https://mzl.la/2Qn0fWC
+    (MDN Docs) for more information.`),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_PERMISSIONS = {
   code: 'MANIFEST_PERMISSIONS',
   message: i18n._('Unknown permission.'),

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -50,6 +50,15 @@ export const MANIFEST_PERMISSIONS = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_OPTIONAL_PERMISSIONS = {
+  code: 'MANIFEST_OPTIONAL_PERMISSIONS',
+  message: i18n._('Unknown permission.'),
+  description: i18n._(
+    'See https://mzl.la/1R1n1t0 (MDN Docs) for more information.'
+  ),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_VERSION_INVALID = {
   code: 'MANIFEST_VERSION_INVALID',
   message: i18n._(

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -54,7 +54,7 @@ export const MANIFEST_OPTIONAL_PERMISSIONS = {
   code: 'MANIFEST_OPTIONAL_PERMISSIONS',
   message: i18n._('Unknown permission.'),
   description: i18n._(
-    'See https://mzl.la/1R1n1t0 (MDN Docs) for more information.'
+    'See https://mzl.la/2Qn0fWC (MDN Docs) for more information.'
   ),
   file: MANIFEST_JSON,
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -232,6 +232,13 @@ export default class ManifestJSONParser extends JSONParser {
     ) {
       baseObject = messages.MANIFEST_BAD_PERMISSION;
       overrides.message = `Permissions ${error.message}.`;
+    } else if (
+      error.dataPath.startsWith('/optional_permissions') &&
+      typeof error.data !== 'undefined' &&
+      typeof error.data !== 'string'
+    ) {
+      baseObject = messages.MANIFEST_BAD_OPTIONAL_PERMISSION;
+      overrides.message = `Permissions ${error.message}.`;
     } else if (error.keyword === 'type') {
       baseObject = messages.MANIFEST_FIELD_INVALID;
     }
@@ -242,7 +249,11 @@ export default class ManifestJSONParser extends JSONParser {
     const match = error.dataPath.match(
       /^\/(permissions|optional_permissions)\/([\d+])/
     );
-    if (match && baseObject.code !== messages.MANIFEST_BAD_PERMISSION.code) {
+    if (
+      match &&
+      baseObject.code !== messages.MANIFEST_BAD_PERMISSION.code &&
+      baseObject.code !== messages.MANIFEST_BAD_OPTIONAL_PERMISSION.code
+    ) {
       baseObject = messages[`MANIFEST_${match[1].toUpperCase()}`];
       overrides.message = oneLine`/${match[1]}: Unknown ${match[1]}
           "${error.data}" at ${match[2]}.`;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -239,9 +239,9 @@ export default class ManifestJSONParser extends JSONParser {
     // Arrays can be extremely verbose, this tries to make them a little
     // more sane. Using a regex because there will likely be more as we
     // expand the schema.
-    const match =
-      error.dataPath.match(/^\/(optional_permissions)\/([\d+])/) ||
-      error.dataPath.match(/^\/(permissions)\/([\d+])/);
+    const match = error.dataPath.match(
+      /^\/(permissions|optional_permissions)\/([\d+])/
+    );
     if (match && baseObject.code !== messages.MANIFEST_BAD_PERMISSION.code) {
       baseObject = messages[`MANIFEST_${match[1].toUpperCase()}`];
       overrides.message = oneLine`/${match[1]}: Unknown ${match[1]}

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -239,7 +239,9 @@ export default class ManifestJSONParser extends JSONParser {
     // Arrays can be extremely verbose, this tries to make them a little
     // more sane. Using a regex because there will likely be more as we
     // expand the schema.
-    const match = error.dataPath.match(/^\/(permissions)\/([\d+])/);
+    const match =
+      error.dataPath.match(/^\/(optional_permissions)\/([\d+])/) ||
+      error.dataPath.match(/^\/(permissions)\/([\d+])/);
     if (match && baseObject.code !== messages.MANIFEST_BAD_PERMISSION.code) {
       baseObject = messages[`MANIFEST_${match[1].toUpperCase()}`];
       overrides.message = oneLine`/${match[1]}: Unknown ${match[1]}
@@ -252,7 +254,10 @@ export default class ManifestJSONParser extends JSONParser {
   _validate() {
     // Not all messages returned by the schema are fatal to Firefox, messages
     // that are just warnings should be added to this array.
-    const warnings = [messages.MANIFEST_PERMISSIONS.code];
+    const warnings = [
+      messages.MANIFEST_PERMISSIONS.code,
+      messages.MANIFEST_OPTIONAL_PERMISSIONS.code,
+    ];
     let validate = validateAddon;
 
     if (this.isStaticTheme) {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -241,7 +241,6 @@
                 },
                 "optional_permissions": {
                   "type": "array",
-                  "default": [],
                   "items": {
                     "allOf": [
                       {
@@ -249,7 +248,8 @@
                       },
                       {
                         "onError": "warn"
-                      }],
+                      }
+                    ],
                     "anyOf": [
                       {},
                       {
@@ -257,6 +257,7 @@
                       }
                     ]
                   },
+                  "default": [],
                   "uniqueItems": true
                 },
                 "web_accessible_resources": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -241,6 +241,7 @@
                 },
                 "optional_permissions": {
                   "type": "array",
+                  "default": [],
                   "items": {
                     "allOf": [
                       {
@@ -251,7 +252,7 @@
                       }
                     ]
                   },
-                  "default": []
+                  "uniqueItems": true
                 },
                 "web_accessible_resources": {
                   "type": "array",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -249,6 +249,11 @@
                       },
                       {
                         "onError": "warn"
+                      }],
+                    "anyOf": [
+                      {},
+                      {
+                        "format": "deprecated"
                       }
                     ]
                   },

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -46,7 +46,7 @@
                     },
                     "uniqueItems": true
                   } ,
-                  "optioanl_permissions": {
+                  "optional_permissions": {
                     "items": {
                       "anyOf": [
                         {},

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -45,6 +45,15 @@
                       ]
                     },
                     "uniqueItems": true
+                  } ,
+                  "optioanl_permissions": {
+                    "items": {
+                      "anyOf": [
+                        {},
+                        { "format": "deprecated" }
+                      ]
+                    },
+                    "uniqueItems": true
                   }
                 }
               }

--- a/tests/unit/test.messages.js
+++ b/tests/unit/test.messages.js
@@ -11,12 +11,6 @@ describe('Messages', () => {
       it('should have a code set', () => {
         expect(code).not.toEqual(null);
       });
-
-      it(`should have code length <= 25 for ${code}`, () => {
-        // Otherwise the ansi color sequences will be borked
-        // as columnify doesn't handle them when wrapping text.
-        expect(code.length).toBeLessThan(26);
-      });
     }
 
     if (description) {


### PR DESCRIPTION
Fixes #3060 