### PR TITLE
feat: Imported Firefox 81b7 schema

### DIFF
--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -19,8 +19,20 @@
                   "preprocess": "localize"
                 },
                 "keyword": {
-                  "type": "string",
-                  "preprocess": "localize"
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "preprocess": "localize"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "preprocess": "localize"
+                      },
+                      "minItems": 1
+                    }
+                  ]
                 },
                 "search_url": {
                   "type": "string",


### PR DESCRIPTION
This schema import contains a small change to the chrome_settings_overrides schema file, which allows a webextension to support more than one search keyword alias (introduced by [Bug 1650881](https://bugzilla.mozilla.org/show_bug.cgi?id=1650881)) 