### PR TITLE
chore: Increased jest timeout when running test.linter.js on nodejs 10

### DIFF
--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import fs from 'fs';
+import process from 'process';
 
 import { oneLine } from 'common-tags';
 
@@ -20,6 +21,13 @@ import {
   validStaticThemeManifestJSON,
   assertHasMatchingError,
 } from './helpers';
+
+// Increasing jest timeout when running on nodejs 10,
+// due to some intermittency when running this tests
+// on Travis.
+if (process.release.lts === 'Dubnium') {
+  jest.setTimeout(10000);
+}
 
 const fakeCheckFileExists = async () => {
   return {


### PR DESCRIPTION
Travis nodejs 10 jobs is failing intermittently, but consistently on this test file.

The small changes in this PR are making that test file to detect when it is running on nodejs 10 ([using process.release property, see docs here](https://nodejs.org/api/process.html#process_process_release)) and increase the jest timeout.