### PR TITLE
feat: Imported Firefox 82b7 schema

### DIFF
--- a/src/schema/imported/extension_types.json
+++ b/src/schema/imported/extension_types.json
@@ -14,7 +14,7 @@
     },
     "ImageDetails": {
       "type": "object",
-      "description": "Details about the format and quality of an image.",
+      "description": "Details about the format, quality, area and scale of the capture.",
       "properties": {
         "format": {
           "allOf": [
@@ -31,6 +31,34 @@
           "minimum": 0,
           "maximum": 100,
           "description": "When format is <code>\"jpeg\"</code>, controls the quality of the resulting image.  This value is ignored for PNG images.  As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease."
+        },
+        "rect": {
+          "type": "object",
+          "description": "The area of the document to capture, in CSS pixels, relative to the page.  If omitted, capture the visible viewport.",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "width",
+            "height"
+          ]
+        },
+        "scale": {
+          "type": "number",
+          "description": "The scale of the resulting image.  Defaults to <code>devicePixelRatio</code>."
         }
       }
     },

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -861,7 +861,7 @@
     {
       "name": "captureTab",
       "type": "function",
-      "description": "Captures the visible area of a specified tab. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
+      "description": "Captures an area of a specified tab. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
       "permissions": [
         "<all_urls>"
       ],
@@ -890,7 +890,7 @@
     {
       "name": "captureVisibleTab",
       "type": "function",
-      "description": "Captures the visible area of the currently active tab in the specified window. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
+      "description": "Captures an area of the currently active tab in the specified window. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
       "permissions": [
         "<all_urls>"
       ],


### PR DESCRIPTION
In this import of the Firefox WebExtensions API schemas related to Firefox 82:
- small changes to the tabs.captureTab and tabs.captureVisibleTab
- additional properties supported by the ImageDetails type