### PR TITLE
fix: add JSON filename in results

### DIFF
--- a/src/scanners/json.js
+++ b/src/scanners/json.js
@@ -27,9 +27,12 @@ export default class JSONScanner extends BaseScanner {
       );
       localeMessagesJSONParser.parse();
     } else {
-      const jsonParser = new JSONParser(json, this.options.collector, {
-        filename: this.filename,
-      });
+      const jsonParser = new JSONParser(
+        json,
+        this.options.collector,
+        this.options.addonMetadata,
+        { filename: this.filename }
+      );
       jsonParser.parse();
     }
 

--- a/tests/unit/scanners/test.json.js
+++ b/tests/unit/scanners/test.json.js
@@ -20,6 +20,21 @@ describe('JSONScanner', () => {
     await expect(jsonScanner.scan()).rejects.toThrow('Explode!');
   });
 
+  it('should report invalid JSON', async () => {
+    const addonsLinter = new Linter({ _: ['foo'] });
+    const jsonScanner = new JSONScanner('{ bar: undefined }', 'baz.json', {
+      collector: addonsLinter.collector,
+    });
+
+    await jsonScanner.scan();
+
+    const { errors } = addonsLinter.collector;
+    expect(errors.length).toEqual(1);
+    expect(errors[0].code).toEqual(messages.JSON_INVALID.code);
+    expect(errors[0].file).toEqual('baz.json');
+    expect(errors[0].message).toEqual(messages.JSON_INVALID.message);
+  });
+
   it('should use special parser for messages.json', async () => {
     const addonsLinter = new Linter({ _: ['foo'] });
     const jsonScanner = new JSONScanner(
@@ -35,6 +50,7 @@ describe('JSONScanner', () => {
     const { errors } = addonsLinter.collector;
     expect(errors.length).toEqual(1);
     expect(errors[0].code).toEqual(messages.NO_MESSAGE.code);
+    expect(errors[0].file).toEqual('_locales/en/messages.json');
     expect(errors[0].message).toEqual(messages.NO_MESSAGE.message);
   });
 });


### PR DESCRIPTION
Fixes #3282

The commit https://github.com/mozilla/addons-linter/commit/087cac8e5979f17eb55979d2aa5ea6c046fce261 added the `addonMetadata` parameter to the `JSONParser` and `LocaleMessagesJSONParser` constructors. But it was not added to the [`JSONParser` constructor](https://github.com/mozilla/addons-linter/blob/master/src/scanners/json.js#L30) call.
The `addonMetadata` property is no longer in use, so I removed it from both constructors and the call to the `LocaleMessagesJSONParser` constructor.