### PR TITLE
fix: manifest validator should add a warning instead of an error on non-square svg icons

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -510,8 +510,12 @@ export default class ManifestJSONParser extends JSONParser {
     try {
       const info = await getImageMetadata(this.io, iconPath);
       if (info.width !== info.height) {
-        this.collector.addWarning(messages.iconIsNotSquare(iconPath));
-        this.isValid = false;
+        if (info.mime !== 'image/svg+xml') {
+          this.collector.addError(messages.iconIsNotSquare(iconPath));
+          this.isValid = false;
+        } else {
+          this.collector.addWarning(messages.iconIsNotSquare(iconPath));
+        }
       } else if (
         expectedSize !== null &&
         info.mime !== 'image/svg+xml' &&

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -510,7 +510,7 @@ export default class ManifestJSONParser extends JSONParser {
     try {
       const info = await getImageMetadata(this.io, iconPath);
       if (info.width !== info.height) {
-        this.collector.addError(messages.iconIsNotSquare(iconPath));
+        this.collector.addWarning(messages.iconIsNotSquare(iconPath));
         this.isValid = false;
       } else if (
         expectedSize !== null &&

--- a/tests/fixtures/rectangle.svg
+++ b/tests/fixtures/rectangle.svg
@@ -1,0 +1,1 @@
+<svg width="300" height="349" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="2" width="296" height="345" style="fill:#DEDEDE;stroke:#555555;stroke-width:2"/><text x="50%" y="50%" font-size="18" text-anchor="middle" alignment-baseline="middle" font-family="monospace, sans-serif" fill="#555555">300&#215;349</text></svg>

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1730,7 +1730,7 @@ describe('ManifestJSONParser', () => {
         expect(warnings.length).toEqual(0);
       });
 
-      it('adds an error if the dimensions of the image are not the same', async () => {
+      it('adds a warning if the dimensions of the image are not the same', async () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const icon32 = 'tests/fixtures/rectangle.png';
         const size32 = 32;
@@ -1750,9 +1750,9 @@ describe('ManifestJSONParser', () => {
 
         await manifestJSONParser.validateIcon(icon32, size32);
         expect(manifestJSONParser.isValid).toBeFalsy();
-        const { errors } = addonLinter.collector;
-        expect(errors.length).toEqual(1);
-        expect(errors[0].code).toEqual(messages.ICON_NOT_SQUARE);
+        const { warnings } = addonLinter.collector;
+        expect(warnings.length).toEqual(1);
+        expect(warnings[0].code).toEqual(messages.ICON_NOT_SQUARE);
       });
     });
   });

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1730,7 +1730,7 @@ describe('ManifestJSONParser', () => {
         expect(warnings.length).toEqual(0);
       });
 
-      it('adds a warning if the icon is SVG but the dimensions of the image are not the same', async () => {
+      it('does add a warning if the icon is a non square svg', async () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const icon32 = 'tests/fixtures/rectangle.svg';
         const size32 = 32;

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1730,6 +1730,30 @@ describe('ManifestJSONParser', () => {
         expect(warnings.length).toEqual(0);
       });
 
+      it('adds a warning if the icon is SVG but the dimensions of the image are not the same', async () => {
+        const addonLinter = new Linter({ _: ['bar'] });
+        const icon32 = 'tests/fixtures/rectangle.svg';
+        const size32 = 32;
+        const json = validManifestJSON({
+          icons: {
+            [size32]: icon32,
+          },
+        });
+        const files = {
+          [icon32]: fs.createReadStream(icon32),
+        };
+        const manifestJSONParser = new ManifestJSONParser(
+          json,
+          addonLinter.collector,
+          { io: getStreamableIO(files) }
+        );
+
+        await manifestJSONParser.validateIcon(icon32, size32);
+        expect(manifestJSONParser.isValid).toBeTruthy();
+        const { warnings } = addonLinter.collector;
+        expect(warnings.length).toEqual(1);
+        expect(warnings[0].code).toEqual(messages.ICON_NOT_SQUARE);
+      });
       it('adds an error if the dimensions of the image are not the same', async () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const icon32 = 'tests/fixtures/rectangle.png';

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1754,6 +1754,7 @@ describe('ManifestJSONParser', () => {
         expect(warnings.length).toEqual(1);
         expect(warnings[0].code).toEqual(messages.ICON_NOT_SQUARE);
       });
+
       it('adds an error if the dimensions of the image are not the same', async () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const icon32 = 'tests/fixtures/rectangle.png';

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1730,7 +1730,7 @@ describe('ManifestJSONParser', () => {
         expect(warnings.length).toEqual(0);
       });
 
-      it('adds a warning if the dimensions of the image are not the same', async () => {
+      it('adds an error if the dimensions of the image are not the same', async () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const icon32 = 'tests/fixtures/rectangle.png';
         const size32 = 32;
@@ -1750,9 +1750,9 @@ describe('ManifestJSONParser', () => {
 
         await manifestJSONParser.validateIcon(icon32, size32);
         expect(manifestJSONParser.isValid).toBeFalsy();
-        const { warnings } = addonLinter.collector;
-        expect(warnings.length).toEqual(1);
-        expect(warnings[0].code).toEqual(messages.ICON_NOT_SQUARE);
+        const { errors } = addonLinter.collector;
+        expect(errors.length).toEqual(1);
+        expect(errors[0].code).toEqual(messages.ICON_NOT_SQUARE);
       });
     });
   });


### PR DESCRIPTION
Fixes #3322

it's now a warning instead of an error.