### PR TITLE
fix: Add a warning when both applications and browser_specific_settings are being used in the same manifest.json

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -126,7 +126,7 @@ Rules are sorted by severity.
 | `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
 | `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
 | `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
-| `DUPLICATE_GECKO_PROPERTY`                              | warning  | Use of both `applications.gecko` and `browser_specific_settings.gecko`                          |
+| `IGNORED_APPLICATIONS_PROPERTY`                         | warning  | Usage of both `applications` and `browser_specific_settings` properties                         |
 
 ### Static Theme / manifest.json
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -126,6 +126,7 @@ Rules are sorted by severity.
 | `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
 | `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
 | `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
+| `DUPLICATE_GECKO_PROPERTY`                              | warning  | Use of both `applications.gecko` and `browser_specific_settings.gecko`                          |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -455,11 +455,13 @@ export const WRONG_ICON_EXTENSION = {
   file: MANIFEST_JSON,
 };
 
-export const DUPLICATE_GECKO_PROPERTY = {
-  code: 'DUPLICATE_GECKO_PROPERTY',
-  message: i18n._('Multiple use of "Gecko" property'),
+export const IGNORED_APPLICATIONS_PROPERTY = {
+  code: 'IGNORED_APPLICATIONS_PROPERTY',
+  message: i18n._(
+    'Usage of both "browser_specific_settings" and "applications"'
+  ),
   description: i18n._(
-    oneLine`the property Gecko is being used in "applications" and "browser_specific_settings" keys at the same time`
+    oneLine`The applications property is being ignored because it is superseded by the browser_specific_settings property which is also defined in your manifest. Consider removing applications.`
   ),
   file: MANIFEST_JSON,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -458,10 +458,10 @@ export const WRONG_ICON_EXTENSION = {
 export const IGNORED_APPLICATIONS_PROPERTY = {
   code: 'IGNORED_APPLICATIONS_PROPERTY',
   message: i18n._(
-    'Usage of both "browser_specific_settings" and "applications"'
+    '"applications" property overridden by "browser_specific_settings" property"'
   ),
   description: i18n._(
-    oneLine`The applications property is being ignored because it is superseded by the browser_specific_settings property which is also defined in your manifest. Consider removing applications.`
+    oneLine`The "applications" property is being ignored because it is superseded by the "browser_specific_settings" property which is also defined in your manifest. Consider removing applications.`
   ),
   file: MANIFEST_JSON,
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -455,6 +455,15 @@ export const WRONG_ICON_EXTENSION = {
   file: MANIFEST_JSON,
 };
 
+export const DUPLICATE_GECKO_PROPERTY = {
+  code: 'DUPLICATE_GECKO_PROPERTY',
+  message: i18n._('Multiple use of "Gecko" property'),
+  description: i18n._(
+    oneLine`the property Gecko is being used in "applications" and "browser_specific_settings" keys at the same time`
+  ),
+  file: MANIFEST_JSON,
+};
+
 export const NO_MESSAGES_FILE_IN_LOCALES = 'NO_MESSAGES_FILE_IN_LOCALES';
 export function noMessagesFileInLocales(path) {
   return {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -305,6 +305,15 @@ export default class ManifestJSONParser extends JSONParser {
 
     if (
       this.parsedJSON.browser_specific_settings &&
+      this.parsedJSON.applications &&
+      this.parsedJSON.browser_specific_settings.gecko &&
+      this.parsedJSON.applications.gecko
+    ) {
+      this.collector.addWarning(messages.DUPLICATE_GECKO_PROPERTY);
+    }
+
+    if (
+      this.parsedJSON.browser_specific_settings &&
       this.parsedJSON.browser_specific_settings.gecko
     ) {
       this.parsedJSON.applications = this.parsedJSON.browser_specific_settings;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -309,7 +309,7 @@ export default class ManifestJSONParser extends JSONParser {
       this.parsedJSON.browser_specific_settings.gecko &&
       this.parsedJSON.applications.gecko
     ) {
-      this.collector.addWarning(messages.DUPLICATE_GECKO_PROPERTY);
+      this.collector.addWarning(messages.IGNORED_APPLICATIONS_PROPERTY);
     }
 
     if (

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -305,9 +305,7 @@ export default class ManifestJSONParser extends JSONParser {
 
     if (
       this.parsedJSON.browser_specific_settings &&
-      this.parsedJSON.applications &&
-      this.parsedJSON.browser_specific_settings.gecko &&
-      this.parsedJSON.applications.gecko
+      this.parsedJSON.applications
     ) {
       this.collector.addWarning(messages.IGNORED_APPLICATIONS_PROPERTY);
     }

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -72,7 +72,7 @@ describe('ManifestJSONParser', () => {
     });
   });
 
-  it('warn if both "applications" and "browser_specific_settings" have gecko property', () => {
+  it('warn if both "applications" and "browser_specific_settings" properties are being used', () => {
     const addonLinter = new Linter({ _: ['bar'] });
     const json = validManifestJSON({
       applications: {
@@ -93,7 +93,7 @@ describe('ManifestJSONParser', () => {
     expect(manifestJSONParser.isValid).toEqual(true);
     const { warnings } = addonLinter.collector;
     expect(warnings.length).toEqual(1);
-    expect(warnings[0].code).toEqual('DUPLICATE_GECKO_PROPERTY');
+    expect(warnings[0].code).toEqual('IGNORED_APPLICATIONS_PROPERTY');
   });
 
   describe('id', () => {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -72,7 +72,7 @@ describe('ManifestJSONParser', () => {
     });
   });
 
-  it('warn if both "applications" and "browser_specific_settings" properties are being used', () => {
+  it('should warn if both "applications" and "browser_specific_settings" properties are being used', () => {
     const addonLinter = new Linter({ _: ['bar'] });
     const json = validManifestJSON({
       applications: {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -72,6 +72,30 @@ describe('ManifestJSONParser', () => {
     });
   });
 
+  it('warn if both "applications" and "browser_specific_settings" have gecko property', () => {
+    const addonLinter = new Linter({ _: ['bar'] });
+    const json = validManifestJSON({
+      applications: {
+        gecko: {
+          strict_max_version: '58.0',
+        },
+      },
+      browser_specific_settings: {
+        gecko: {
+          strict_max_version: '58.0',
+        },
+      },
+    });
+    const manifestJSONParser = new ManifestJSONParser(
+      json,
+      addonLinter.collector
+    );
+    expect(manifestJSONParser.isValid).toEqual(true);
+    const { warnings } = addonLinter.collector;
+    expect(warnings.length).toEqual(1);
+    expect(warnings[0].code).toEqual('DUPLICATE_GECKO_PROPERTY');
+  });
+
   describe('id', () => {
     it('should return the correct id', () => {
       const addonLinter = new Linter({ _: ['bar'] });


### PR DESCRIPTION
Fixes #2294 
**This PR will be changed with more commits based on the final decision in #2294**
Currently it gives a warning if both `"browser_specific_settings"` and `applications` have a gecko property

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.
- [x] Add tests to cover the changes added in this PR.

