### PR TITLE
feat: Imported Firefox 84.0b6 schema

### DIFF
--- a/src/schema/imported/browsing_data.json
+++ b/src/schema/imported/browsing_data.json
@@ -435,6 +435,10 @@
           },
           "description": "Only remove data associated with these hostnames (only applies to cookies and localStorage)."
         },
+        "cookieStoreId": {
+          "type": "string",
+          "description": "Only remove data associated with this specific cookieStoreId."
+        },
         "originTypes": {
           "type": "object",
           "description": "An object whose properties specify which origin types ought to be cleared. If this object isn't specified, it defaults to clearing only \"unprotected\" origins. Please ensure that you <em>really</em> want to remove application data before adding 'protectedWeb' or 'extensions'.",


### PR DESCRIPTION
This PR includes the following changes to the API schemas:

- `cookieStoreId` property added to the browsingData API ([Bug 1670811](https://bugzilla.mozilla.org/show_bug.cgi?id=1670811)) 