### PR TITLE
Do not run publish-rules when it's not needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,11 @@ workflows:
       - publish-rules:
           requires:
             - test
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
       - release-tag:
           requires:
             - test


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3506