### PR TITLE
Respect disable-linter-rules CLI argument

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -386,7 +386,7 @@ export default class Linter {
         // https://github.com/mozilla/addons-linter/issues/895
         collector: this.collector,
         // list of disabled rules for js scanner
-        disabledLinterRules: this.config.disableLinterRules,
+        disabledRules: this.config.disableLinterRules,
         existingFiles: this.io.files,
       });
 

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -20,7 +20,7 @@
       "devDependencies": true
     }],
     "jest/expect-expect": ["warn", {
-      // Allow Jest, Sinon, or helper lib assertions
+      // Allow Jest or Sinon assertions
       "assertFunctionNames": ["expect", "sinon.assert.*"]
     }],
     "promise/always-return": "off",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -19,6 +19,10 @@
       // Allow dev-dependencies in this directory.
       "devDependencies": true
     }],
+    "jest/expect-expect": ["warn", {
+      // Allow Jest, Sinon, or helper lib assertions
+      "assertFunctionNames": ["expect", "sinon.assert.*"]
+    }],
     "promise/always-return": "off",
     "promise/avoid-new": "off",
     "promise/no-nesting": "off",

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -1549,6 +1549,27 @@ describe('Linter.run()', () => {
     expect(result).toEqual(addonLinter.output);
   });
 
+  it('should pass disabled linting rules to Scanner', async () => {
+    const addonLinter = new Linter({ _: ['tests/fixtures/good.zip'] });
+
+    const fakeScanner = sinon.stub().returns({
+      scan: () => Promise.resolve({ linterMessages: [], scannedFiles: [] }),
+    });
+    addonLinter.getScanner = sinon.stub().returns(fakeScanner);
+
+    addonLinter.config.disableLinterRules = 'foo,bar, baz';
+
+    await addonLinter.run({ _console: fakeConsole });
+
+    sinon.assert.calledWithNew(fakeScanner);
+    sinon.assert.calledWithExactly(
+      fakeScanner,
+      sinon.match.string, // fileData
+      sinon.match.string, // filename
+      sinon.match({ disabledRules: 'foo,bar, baz' })
+    );
+  });
+
   describe('auto-close', () => {
     class FakeXpi extends FakeIOBase {
       static closeWasCalled = false;


### PR DESCRIPTION
Fixes #3524.

Upon debugging the issue, I noticed that the JavaScript Scanner expects a property named `disabledRules` https://github.com/mozilla/addons-linter/blob/1b8cb482464da5b2d8a8844adb5084fc2aa60d74/src/scanners/javascript.js#L27-L29

but is passed a property named `disabledLinterRules` https://github.com/mozilla/addons-linter/blob/1b8cb482464da5b2d8a8844adb5084fc2aa60d74/src/linter.js#L389

and so the list of disabled rules was always empty.

The JavaScript Scanner is the only Scanner that accepts a list of disabled rules, and I only found one caller that tries to set that option (`linter.js`, fixed in this PR).

-----

I also adjusted the `jest/expect-expect` ESLint rule to recognize `sinon.assert` assertions.  This eliminated ~15 false-positives for that rule (though some false-positives remain for other reasons).