### PR TITLE
Fix message when the file is too large to parse

### DIFF
--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -30,8 +30,8 @@ export const FILE_TOO_LARGE = {
   message: i18n._('File is too large to parse.'),
   description: i18n._(oneLine`This file is not binary and is too large to
     parse. Files larger than ${MAX_FILE_SIZE_TO_PARSE_MB}MB will not be
-    parsed. If your JavaScript file has a large list, consider removing the
-    list and loading it as a separate JSON file instead.`),
+    parsed. Consider moving large lists of data out of JavaScript files and
+    into JSON files, or splitting very large files into smaller ones.`),
 };
 
 export const HIDDEN_FILE = {


### PR DESCRIPTION
Fixes #1700 

The linter should suggest "Consider moving large lists of data out of JavaScript files and into JSON files, or splitting very large files into smaller ones" instead of "including large JSON file as separate JSON file" when the JSON file is too large. The wording is changed in this commit. The [test](https://github.com/mozilla/addons-linter/blob/cc92e134df63d66389ac4d4a0c6d5d534bb28abb/tests/unit/test.linter.js#L1283-L1320) for the corresponding message worked correctly.
Reproduced this issue locally as `addonLinter.collector.errors[0].description` in the test gave the updated rule description message when the JSON file was large.