### PR TITLE
feat: Imported Firefox 85.0b5 schema

### DIFF
--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -49,13 +49,24 @@
               "description": "This property controls the minimum and maximum TLS versions. This setting's value is an object of $(ref:tlsVersionRestrictionConfig)."
             }
           ]
+        },
+        "httpsOnlyMode": {
+          "allOf": [
+            {
+              "$ref": "types#/types/Setting"
+            },
+            {
+              "description": "Allow users to query the mode for 'HTTPS-Only Mode'. This setting's value is of type HTTPSOnlyModeOption, defaulting to <code>never</code>."
+            }
+          ]
         }
       },
       "required": [
         "networkPredictionEnabled",
         "peerConnectionEnabled",
         "webRTCIPHandlingPolicy",
-        "tlsVersionRestriction"
+        "tlsVersionRestriction",
+        "httpsOnlyMode"
       ]
     },
     "services": {
@@ -237,6 +248,15 @@
           "description": "The maximum TLS version supported."
         }
       }
+    },
+    "HTTPSOnlyModeOption": {
+      "type": "string",
+      "enum": [
+        "always",
+        "private_browsing",
+        "never"
+      ],
+      "description": "The mode for https-only mode."
     },
     "TrackingProtectionModeOption": {
       "type": "string",


### PR DESCRIPTION
This PR includes the following changes to the API schemas:

- new `browser.privacy.network.httpsOnlyMode` privacy browser setting ([Bug 1678306](https://bugzilla.mozilla.org/show_bug.cgi?id=1678306))