### PR TITLE
Drop `whatwg-url` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7971,7 +7971,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -11243,6 +11244,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
       "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -11830,7 +11832,8 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
     },
     "webpack": {
       "version": "4.44.2",
@@ -12197,6 +12200,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
       "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "source-map-support": "0.5.19",
     "tosource": "1.0.0",
     "upath": "2.0.1",
-    "whatwg-url": "8.4.0",
     "yargs": "16.2.0",
     "yauzl": "2.10.0"
   },

--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -1,5 +1,3 @@
-import { URL } from 'whatwg-url';
-
 const VALIDNUMRX = /^[0-9]{1,5}$/;
 
 // Firefox's version format is laxer than Chrome's, it accepts:

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 import url from 'url';
 
 import upath from 'upath';
-import { URL } from 'whatwg-url';
 import Jed from 'jed';
 import semver from 'semver';
 import { oneLine } from 'common-tags';


### PR DESCRIPTION
`URL` has been part of Node since v6.13 and it's a global since Node 10 (which matches your `engines.node` field)

https://nodejs.org/api/url.html#url_class_url