### PR TITLE
Improve error message when there is a JS syntax error

### DIFF
--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -6,7 +6,9 @@ export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
   message: i18n._('JavaScript syntax error'),
   description: i18n._(oneLine`There is a JavaScript syntax error in your
-    code; validation cannot continue on this file.`),
+    code, which might be related to some experimental JavaScript features that
+    aren't an official part of the language specification and therefore not
+    supported yet. The validation cannot continue on this file.`),
 };
 
 export const EVENT_LISTENER_FOURTH = {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3482

---

It'll be awesome once it's ready.

## Output

```
❯ ./bin/addons-linter test-addon
Validation Summary:

errors          1
notices         0
warnings        0

ERRORS:

Code              Message                                               Description                                                                                        File    Line   Column
JS_SYNTAX_ERROR   JavaScript syntax error (Parsing as module error:     There is a JavaScript syntax error in your code, which might be related to some experimental       cs.js   1      1
                  Unexpected token = at line: 4 and column: 5)          JavaScript features that aren't an official part of the language specification and therefore not
                  (Parsing as script error: 'import' and 'export' may   supported yet. The validation cannot continue on this file.
                  appear only with 'sourceType: module' at line: 1
                  and column: 1)
```