### PR TITLE
feat: Imported Firefox 86.0b5 API schema

### DIFF
--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -47,7 +47,7 @@
                 },
                 "suggest_url": {
                   "type": "string",
-                  "pattern": "^(https://|http://(localhost|127\\.0\\.0\\.1|\\[::1\\])(:\\d*)?(/|$)).*$",
+                  "pattern": "^$|^(https://|http://(localhost|127\\.0\\.0\\.1|\\[::1\\])(:\\d*)?(/|$)).*$",
                   "preprocess": "localize"
                 },
                 "instant_url": {

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -180,7 +180,8 @@
         "fileio",
         "fileioall",
         "noiostacks",
-        "audiocallbacktracing"
+        "audiocallbacktracing",
+        "cpu"
       ]
     },
     "supports": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -11,7 +11,8 @@
         "manifest_version": {
           "type": "integer",
           "minimum": 2,
-          "maximum": 2
+          "maximum": 2,
+          "postprocess": "manifestVersionCheck"
         },
         "applications": {
           "type": "object",
@@ -203,16 +204,6 @@
                           "type": "string",
                           "format": "contentSecurityPolicy",
                           "description": "The Content Security Policy used for extension pages."
-                        },
-                        "content_scripts": {
-                          "type": "string",
-                          "format": "contentSecurityPolicy",
-                          "description": "The Content Security Policy used for content scripts."
-                        },
-                        "isolated_world": {
-                          "type": "string",
-                          "format": "contentSecurityPolicy",
-                          "description": "An alias for content_scripts to support Chrome compatibility.  Content Security Policy implementations may differ between Firefox and Chrome.  If both isolated_world and content_scripts exist, the value from content_scripts will be used."
                         }
                       }
                     }

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -735,7 +735,11 @@
     "PlatformArch": {
       "type": "string",
       "enum": [
+        "aarch64",
         "arm",
+        "ppc64",
+        "s390x",
+        "sparc64",
         "x86-32",
         "x86-64"
       ],

--- a/src/schema/imported/windows.json
+++ b/src/schema/imported/windows.json
@@ -217,8 +217,21 @@
               "description": "The height in pixels of the new window, including the frame. If not specified defaults to a natural height."
             },
             "focused": {
-              "unsupported": true,
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "enum": [
+                    true
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ],
+                  "deprecated": "Opening inactive windows is not supported."
+                }
+              ],
               "description": "If true, opens an active window. If false, opens an inactive window."
             },
             "incognito": {

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -82,6 +82,9 @@
           "version": {
             "description": "Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3.",
             "format": "versionString"
+          },
+          "manifest_version": {
+            "maximum": 2
           }
         }
       }

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -886,9 +886,6 @@ describe('ManifestJSONParser', () => {
 
         const contentSecurityPolicy = {
           extension_pages: invalidValue,
-          content_scripts: invalidValue,
-          // Alias for content_scripts.
-          isolated_world: invalidValue,
         };
 
         const jsonV3 = validManifestJSON({
@@ -915,7 +912,7 @@ describe('ManifestJSONParser', () => {
             `content_security_policy.${keys[i]}`
           );
         }
-        expect(warnings.length).toBe(3);
+        expect(warnings.length).toBe(1);
       });
     });
 

--- a/tests/unit/schema/test.manifest_version.js
+++ b/tests/unit/schema/test.manifest_version.js
@@ -13,6 +13,16 @@ describe('/manifest_version', () => {
     expect(validateAddon.errors.length).toEqual(1);
   });
 
+  // NOTE: this is enforced by overriding manifest_version API schema data
+  // with `"maximum": 2` from src/schema/updates/manifest.json.
+  it('should be invalid on manifest_version 3', () => {
+    const manifest = cloneDeep(validManifest);
+    manifest.manifest_version = 3;
+    validateAddon(manifest);
+    expect(validateAddon.errors[0].dataPath).toEqual('/manifest_version');
+    expect(validateAddon.errors.length).toEqual(1);
+  });
+
   it('should be invalid due to missing manifest_version', () => {
     const manifest = cloneDeep(validManifest);
     manifest.manifest_version = undefined;


### PR DESCRIPTION
This PR includes the following changes to the API schemas:

- increased from `2` to `3` the maximum allowed value for the `manifest_version` manifest property ([Bug 1594234](https://bugzilla.mozilla.org/1594234)) 
- removed `content_scripts` and `isolated_world` sub-properties from the `content_security_policy` manifest property definition ([Bug 1594234](https://bugzilla.mozilla.org/1594234)) 
- added a new CPU experimental feature to the geckoProfiles API schema ([Bug 1679930](https://bugzilla.mozilla.org/show_bug.cgi?id=1679930)) 
- changed to the pattern used to validate `chrome_settings_overrides.search_provider.suggest_url` (which seems to have been added to allow it to be set as empty)
- added some more values to the `PlatformArch` enum ([Bug 1554971](https://bugzilla.mozilla.org/1554971))
- changed definition for focused property in the `windows.create` API schema (to just print a warning when set to `false`, to explicitly state that it isn't actually supported and it is just ignored)

TODO - I think that before merging this PR we should:
- [x] make sure we don't yet accept `manifest_version: 3` on submissions to AMO (we should make it an error for now, until we are ready to start accepting manifest v3 addons)
- [x] double-check if the changes to the `content_security_policy` do require changes to the CSP validation that the addons-linter does internally independently from the API schema imported (which should be in `src/parsers/manifestjson.js`).

Based on what I recall about the changes we did more recently in the code that is validating the csp string there shouldn't be any changes needed, but I don't recall all the details about it and so it would be better to double-check that explicitly. 