### PR TITLE
Replace heavy dependency (espree)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "eslint": "7.21.0",
         "eslint-plugin-no-unsanitized": "3.1.4",
         "eslint-visitor-keys": "2.0.0",
-        "espree": "7.3.1",
         "esprima": "4.0.1",
         "fluent-syntax": "0.13.0",
         "glob": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint": "7.21.0",
     "eslint-plugin-no-unsanitized": "3.1.4",
     "eslint-visitor-keys": "2.0.0",
-    "espree": "7.3.1",
     "esprima": "4.0.1",
     "fluent-syntax": "0.13.0",
     "glob": "7.1.6",

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -220,8 +220,9 @@ export default class JavaScriptScanner {
 
     This returns `script` or `module`.
   */
-  detectSourceType(filename) {
+  detectSourceType() {
     try {
+      // eslint-disable-next-line no-new
       new vm.Script(this.code);
     } catch (error) {
       if (

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -229,8 +229,8 @@ export default class JavaScriptScanner {
           "Unexpected token 'export'",
           'Cannot use import statement outside a module',
         ].includes(error.message)
-        ) {
-          return 'module';
+      ) {
+        return 'module';
       }
     }
 

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -427,7 +427,7 @@ describe('JavaScript Scanner', () => {
 
     it('should default to script in case of SyntaxError', async () => {
       const code = oneLine`
-        import foo
+        an import foo
       `;
 
       const jsScanner = new JavaScriptScanner(code, 'code.js');


### PR DESCRIPTION
`espree` takes [1.7MB](https://packagephobia.com/result?p=espree) of disk space ([3 dependencies](https://npm.broofa.com/?q=espree)) and is actually currently duplicated as can be seen in the [lockfile](https://github.com/mozilla/addons-linter/blob/f756b4dec94705020170fbfd7149d39ee36940c5/package-lock.json)

It seemed excessive to load a whole JS parser module just to detect the script type, but I understand if this solution isn't considered on par.

It uses Node’s own parser to detect the module type, with 0 dependencies 🎈 