### PR TITLE
chore: Support importing Firefox API schema from a local mozilla-central directory

### DIFF
--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -599,19 +599,9 @@ async function fetchSchemasFromDir({ inputPath, outputPath }) {
   );
 
   const promiseLoadSchemaFrom = (baseDir) =>
-    new Promise((resolve, reject) => {
-      fs.readdir(baseDir, { encoding: 'utf-8' }, (err, files) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(
-            files
-              .filter((fp) => fp.endsWith('.json'))
-              .map((fp) => path.join(baseDir, fp))
-          );
-        }
-      });
-    });
+    fs.promises.readdir(baseDir, { encoding: 'utf-8' }).then((files) => 
+      files.filter((fp) => fp.endsWith('.json'))
+           .map((fp) => path.join(baseDir, fp)));
 
   return Promise.all([
     promiseLoadSchemaFrom(toolkitSchemasBaseDir),

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -599,9 +599,13 @@ async function fetchSchemasFromDir({ inputPath, outputPath }) {
   );
 
   const promiseLoadSchemaFrom = (baseDir) =>
-    fs.promises.readdir(baseDir, { encoding: 'utf-8' }).then((files) => 
-      files.filter((fp) => fp.endsWith('.json'))
-           .map((fp) => path.join(baseDir, fp)));
+    fs.promises
+      .readdir(baseDir, { encoding: 'utf-8' })
+      .then((files) =>
+        files
+          .filter((fp) => fp.endsWith('.json'))
+          .map((fp) => path.join(baseDir, fp))
+      );
 
   return Promise.all([
     promiseLoadSchemaFrom(toolkitSchemasBaseDir),

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -578,7 +578,50 @@ inner.isBrowserSchema = (_path) => {
   return schemaRegexes.some((re) => re.test(_path));
 };
 
+// This method is used automatically when we import the schema files from
+// a local mozilla-central working tree instead of from a zipped archive
+// (e.g. to evaluate impacts of changes to the schema format while they are still
+// in work and not landed yet). 
+async function fetchSchemasFromDir({ inputPath, outputPath }) {
+  const toolkitSchemasBaseDir = 
+    path.join(inputPath, 'toolkit', 'components', 'extensions', 'schemas');
+  const browserSchemasBaseDir = 
+    path.join(inputPath, 'browser', 'components', 'extensions', 'schemas');
+
+  const promiseLoadSchemaFrom = (baseDir) => new Promise((resolve, reject) => {
+    fs.readdir(baseDir, { encoding: 'utf-8' }, (err, files) => {
+      if (err) { 
+        reject(err);
+      } else {
+        resolve(files.filter(fp => fp.endsWith('.json'))
+          .map(fp => path.join(baseDir, fp)));
+      }
+    });
+  });
+
+  return Promise.all([
+    promiseLoadSchemaFrom(toolkitSchemasBaseDir),
+    promiseLoadSchemaFrom(browserSchemasBaseDir),
+  ]).then(results => {
+    const allFiles = results.flat();
+    const writeStreamsPromises = allFiles.map(filePath => {
+      const outFilePath = path.join(outputPath, path.basename(filePath));
+      const destFileStream = fs.createWriteStream(outFilePath);
+      const readStream = fs.createReadStream(filePath);
+      readStream.pipe(destFileStream);
+      // Ensure we're closing all the creted write streams before resolving.
+      return new Promise((resolve) => destFileStream.on('close', resolve))
+    });
+    return Promise.all(writeStreamsPromises);
+  });
+}
+
 export async function fetchSchemas({ inputPath, outputPath }) {
+  const inputFileStat = fs.statSync(inputPath);
+  if (inputFileStat.isDirectory()) {
+    return fetchSchemasFromDir({ inputPath, outputPath });
+  }
+
   const openZip = util.promisify(yauzl.open);
   const zipfile = await openZip(inputPath);
   const openReadStream = util.promisify(zipfile.openReadStream.bind(zipfile));

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -581,36 +581,50 @@ inner.isBrowserSchema = (_path) => {
 // This method is used automatically when we import the schema files from
 // a local mozilla-central working tree instead of from a zipped archive
 // (e.g. to evaluate impacts of changes to the schema format while they are still
-// in work and not landed yet). 
+// in work and not landed yet).
 async function fetchSchemasFromDir({ inputPath, outputPath }) {
-  const toolkitSchemasBaseDir = 
-    path.join(inputPath, 'toolkit', 'components', 'extensions', 'schemas');
-  const browserSchemasBaseDir = 
-    path.join(inputPath, 'browser', 'components', 'extensions', 'schemas');
+  const toolkitSchemasBaseDir = path.join(
+    inputPath,
+    'toolkit',
+    'components',
+    'extensions',
+    'schemas'
+  );
+  const browserSchemasBaseDir = path.join(
+    inputPath,
+    'browser',
+    'components',
+    'extensions',
+    'schemas'
+  );
 
-  const promiseLoadSchemaFrom = (baseDir) => new Promise((resolve, reject) => {
-    fs.readdir(baseDir, { encoding: 'utf-8' }, (err, files) => {
-      if (err) { 
-        reject(err);
-      } else {
-        resolve(files.filter(fp => fp.endsWith('.json'))
-          .map(fp => path.join(baseDir, fp)));
-      }
+  const promiseLoadSchemaFrom = (baseDir) =>
+    new Promise((resolve, reject) => {
+      fs.readdir(baseDir, { encoding: 'utf-8' }, (err, files) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(
+            files
+              .filter((fp) => fp.endsWith('.json'))
+              .map((fp) => path.join(baseDir, fp))
+          );
+        }
+      });
     });
-  });
 
   return Promise.all([
     promiseLoadSchemaFrom(toolkitSchemasBaseDir),
     promiseLoadSchemaFrom(browserSchemasBaseDir),
-  ]).then(results => {
+  ]).then((results) => {
     const allFiles = results.flat();
-    const writeStreamsPromises = allFiles.map(filePath => {
+    const writeStreamsPromises = allFiles.map((filePath) => {
       const outFilePath = path.join(outputPath, path.basename(filePath));
       const destFileStream = fs.createWriteStream(outFilePath);
       const readStream = fs.createReadStream(filePath);
       readStream.pipe(destFileStream);
       // Ensure we're closing all the creted write streams before resolving.
-      return new Promise((resolve) => destFileStream.on('close', resolve))
+      return new Promise((resolve) => destFileStream.on('close', resolve));
     });
     return Promise.all(writeStreamsPromises);
   });

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -617,7 +617,7 @@ async function fetchSchemasFromDir({ inputPath, outputPath }) {
       const destFileStream = fs.createWriteStream(outFilePath);
       const readStream = fs.createReadStream(filePath);
       readStream.pipe(destFileStream);
-      // Ensure we're closing all the creted write streams before resolving.
+      // Ensure we're closing all the created write streams before resolving.
       return new Promise((resolve) => destFileStream.on('close', resolve));
     });
     return Promise.all(writeStreamsPromises);


### PR DESCRIPTION
A small addition to firefox-schemas-import, meant to be used to make it easier for us to evaluate the impacts of changes to the schema format while they are still in work and not landed yet in Firefox.

I tested it locally by running the script on a local mozilla-central clone with some phabricator revisions still in review applied on it:
```
./scripts/firefox-schema-import ~/mozlab/projects/mc-reviews
```

I haven't added any additional test coverage for the addition, mainly because we are the only consumer of it and if we use it often enough we may just notice and fix it right away if something breaks from time to time, and we may avoid to increase the time needed to the CI jobs to complete.