### PR TITLE
fix: Prefer parsing as a module on js scripts with .mjs extension

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -271,7 +271,9 @@ export default class JavaScriptScanner {
 
     try {
       const ast = espree.parse(this.code, parserOptions);
-      detected.sourceType = this._getSourceType(ast);
+      detected.sourceType = filename.endsWith('.mjs')
+        ? 'module'
+        : this._getSourceType(ast);
     } catch (exc) {
       const line = exc.lineNumber || '(unknown)';
       const column = exc.column || '(unknown)';

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -170,6 +170,15 @@ describe('JavaScript Scanner', () => {
     expect(addonLinter.collector.warnings.length).toEqual(0);
   });
 
+  it('should parse as module .mjs files', async () => {
+    const code = 'const url = import.meta.url;';
+
+    const jsScanner = new JavaScriptScanner(code, 'code.mjs');
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages).toEqual([]);
+  });
+
   it('should support optional catch binding', async () => {
     const code = oneLine`
       try {} catch {}


### PR DESCRIPTION
This PR contains the set of (small) proposed changes for the "more conservative" of the two approaches described in https://github.com/mozilla/addons-linter/issues/3639#issuecomment-806524060 (which defaults to sourceType: 'module' if the filename extension is `.mjs`, even if no import/export statement were being found in the parsed AST).

Fixes #3639 