### PR TITLE
feat: Imported Firefox 88.0b5 API schema

### DIFF
--- a/src/schema/imported/browser_settings.json
+++ b/src/schema/imported/browser_settings.json
@@ -51,7 +51,7 @@
           "$ref": "types#/types/Setting"
         },
         {
-          "description": "This boolean setting controls whether the FTP protocol is enabled."
+          "description": "Returns whether the FTP protocol is enabled. Read-only."
         }
       ]
     },

--- a/src/schema/imported/extension_protocol_handlers.json
+++ b/src/schema/imported/extension_protocol_handlers.json
@@ -37,6 +37,7 @@
                 "bitcoin",
                 "dat",
                 "dweb",
+                "ftp",
                 "geo",
                 "gopher",
                 "im",

--- a/src/schema/imported/network_status.json
+++ b/src/schema/imported/network_status.json
@@ -71,9 +71,7 @@
             "usb",
             "wifi",
             "wimax",
-            "2g",
-            "3g",
-            "4g"
+            "mobile"
           ],
           "description": "If known, the type of network connection that is avialable."
         },

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -205,7 +205,8 @@
         },
         "ftp": {
           "type": "string",
-          "description": "The address of the ftp proxy, can include a port."
+          "deprecated": true,
+          "description": "The address of the ftp proxy, can include a port.  Deprecated since Firefox 88."
         },
         "ssl": {
           "type": "string",

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -2251,7 +2251,8 @@
         "pinned",
         "sharingState",
         "status",
-        "title"
+        "title",
+        "url"
       ],
       "description": "Event names supported in onUpdated."
     },

--- a/src/schema/imported/test.json
+++ b/src/schema/imported/test.json
@@ -222,8 +222,7 @@
               "$ref": "#/types/ExpectedError"
             },
             {
-              "name": "expectedError",
-              "optional": true
+              "name": "expectedError"
             }
           ]
         },
@@ -248,8 +247,7 @@
               "$ref": "#/types/ExpectedError"
             },
             {
-              "name": "expectedError",
-              "optional": true
+              "name": "expectedError"
             }
           ]
         },


### PR DESCRIPTION
- some small changes related to Bug 1626365 (extension-related changes for the FTP protocol removal part of Firefox 88)
- changes to the NetworkLinkInfo's type enum (Bug 1695056)
- added url to the supported filter properties for tabs.onUpdated (Bug 1680279)