### PR TITLE
feat: Imported Firefox 89.0b8 API schema

### DIFF
--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -284,7 +284,14 @@
               "$ref": "#/types/ThemeColor"
             },
             "toolbar_field_separator": {
-              "$ref": "#/types/ThemeColor"
+              "allOf": [
+                {
+                  "$ref": "#/types/ThemeColor"
+                },
+                {
+                  "deprecated": "This color property is ignored in Firefox >= 89."
+                }
+              ]
             },
             "toolbar_top_separator": {
               "$ref": "#/types/ThemeColor"


### PR DESCRIPTION
This PR contains only a small change related to the schema definition for the toolbar color `toolbar_field_separator`, which has been deprecated because isn't used anywhere in the Proton UI.