### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.02%
+    patch: off


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3720

---

This PR adds a codecov configuration file to:

1. disable "patch" checks, i.e. diff coverage in a PR, which should be 100% but we don't need a CI check for that. Codecov comments in the PR and the comment contains the diff coverage. It's best to disable the check in case we want to merge a PR with a diff coverage < 100%
2. configure the "project" check to allow very small variations, i.e. allow a 0.02% coverage decrease in a PR

This is the configuration used in addons-frontend.