### PR TITLE
feat: Imported Firefox 90.0b7 api schemas

### DIFF
--- a/src/schema/imported/browser_settings.json
+++ b/src/schema/imported/browser_settings.json
@@ -51,7 +51,8 @@
           "$ref": "types#/types/Setting"
         },
         {
-          "description": "Returns whether the FTP protocol is enabled. Read-only."
+          "description": "Returns whether the FTP protocol is enabled. Read-only.",
+          "deprecated": "FTP support was removed from Firefox in bug 1574475"
         }
       ]
     },

--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -41,8 +41,17 @@
                   "preprocess": "localize"
                 },
                 "favicon_url": {
-                  "type": "string",
-                  "format": "relativeUrl",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "relativeUrl",
+                      "max_manifest_version": 2
+                    },
+                    {
+                      "type": "string",
+                      "format": "strictRelativeUrl"
+                    }
+                  ],
                   "preprocess": "localize"
                 },
                 "suggest_url": {

--- a/src/schema/imported/extension.json
+++ b/src/schema/imported/extension.json
@@ -9,6 +9,8 @@
     "lastError": {
       "type": "object",
       "optional": true,
+      "max_manifest_version": 2,
+      "deprecated": "Please use $(ref:runtime.lastError).",
       "allowedContexts": [
         "content",
         "devtools"
@@ -39,6 +41,8 @@
     {
       "name": "getURL",
       "type": "function",
+      "deprecated": "Please use $(ref:runtime.getURL).",
+      "max_manifest_version": 2,
       "allowedContexts": [
         "content",
         "devtools"
@@ -100,6 +104,7 @@
     {
       "name": "getBackgroundPage",
       "type": "function",
+      "max_manifest_version": 2,
       "description": "Returns the JavaScript 'window' object for the background page running inside the current extension. Returns null if the extension has no background page.",
       "parameters": [],
       "returns": {

--- a/src/schema/imported/extension_protocol_handlers.json
+++ b/src/schema/imported/extension_protocol_handlers.json
@@ -47,6 +47,7 @@
                 "ircs",
                 "magnet",
                 "mailto",
+                "matrix",
                 "mms",
                 "news",
                 "nntp",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -197,10 +197,12 @@
                   "onError": "warn",
                   "anyOf": [
                     {
+                      "max_manifest_version": 2,
                       "type": "string",
                       "format": "contentSecurityPolicy"
                     },
                     {
+                      "min_manifest_version": 3,
                       "type": "object",
                       "properties": {
                         "extension_pages": {
@@ -255,10 +257,40 @@
                   "uniqueItems": true
                 },
                 "web_accessible_resources": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "anyOf": [
+                    {
+                      "max_manifest_version": 2,
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "min_manifest_version": 3,
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "resources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "matches": {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/types/MatchPatternRestricted"
+                            }
+                          }
+                        },
+                        "required": [
+                          "resources",
+                          "matches"
+                        ]
+                      }
+                    }
+                  ]
                 },
                 "developer": {
                   "type": "object",

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -34,6 +34,7 @@
   "functions": [
     {
       "name": "getBackgroundPage",
+      "max_manifest_version": 2,
       "type": "function",
       "description": "Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set.",
       "async": "callback",

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -25,53 +25,122 @@ import schemas from './imported';
 
 const jsonSchemaDraft06 = require('ajv/lib/refs/json-schema-draft-06');
 
-function filterErrors(errors, manifestData = undefined) {
-  if (errors) {
-    let filteredErrors = errors.filter((error) => {
-      return error.keyword !== '$merge';
+function isRelevantError({
+  error,
+  manifest_version,
+  allowedManifestVersionsRange,
+}) {
+  // The errors related to the manifest_version are always relevant,
+  // if an error has been collected for it then it is because the
+  // addon manifest_version is outside or the allowed range.
+  if (error.dataPath === '/manifest_version') {
+    return true;
+  }
+
+  const { minimum, maximum } = allowedManifestVersionsRange;
+
+  const errorMinManifestVersion =
+    error.params?.min_manifest_version ??
+    error.parentSchema?.min_manifest_version ??
+    minimum;
+
+  const errorMaxManifestVersion =
+    error.params?.max_manifest_version ??
+    error.parentSchema?.max_manifest_version ??
+    maximum;
+
+  // Omit errors related to a schema fragment that is not relevant
+  // for the given manifest version (and also if its parent schema
+  // is not relevant for the given manifest version).
+  if (
+    manifest_version < errorMinManifestVersion ||
+    manifest_version > errorMaxManifestVersion
+  ) {
+    return false;
+  }
+
+  // An error collected by an `anyOf` schema entry is relevant only if its the schema
+  // entries are relevant for the given addon manifest_version.
+  if (error.keyword === 'anyOf') {
+    const anyOfSchemaEntries = error.schema.filter((schema) => {
+      const min = schema.min_manifest_version ?? minimum;
+      const max = schema.mix_manifest_version ?? maximum;
+
+      return manifest_version >= min && manifest_version <= max;
     });
 
-    // Filter out errors related to future manifest versions.
-    if (
-      filteredErrors.length > 0 &&
-      manifestData?.manifest_version === MANIFEST_VERSION_DEFAULT
-    ) {
-      filteredErrors = filteredErrors.filter((error) => {
-        // Omit errors related to a schema fragment that is only allowed
-        // in a future manifest version (and also if its parent schema
-        // is only allowed in future manifest versions).
-        if (
-          error.params?.min_manifest_version > MANIFEST_VERSION_DEFAULT ||
-          error.parentSchema?.min_manifest_version > MANIFEST_VERSION_DEFAULT
-        ) {
-          return false;
-        }
-
-        // Skip anyOf errors if only one entry is actually allowed in the
-        // currently supported manifest versions.
-        if (error.keyword === 'anyOf') {
-          const anyOfSchemaEntries = error.schema.filter((schema) => {
-            return !(
-              'min_manifest_version' in schema &&
-              schema.min_manifest_version > MANIFEST_VERSION_DEFAULT
-            );
-          });
-
-          // Skip if there is only one or no entries (if there is one entry
-          // we can still omit the anyOf, the linting message related to that
-          // entry would already been separately part of the validation errror
-          // if it should have been).
-          if (anyOfSchemaEntries.length <= 1) {
-            return false;
-          }
-        }
-        return true;
-      });
+    // The error is irrelevant if:
+    // - there is no anyOf entry that is relevant for the given addon manifest_version
+    // - there is only one relevant entry (in that case an error for that entry would
+    //   have been already collected and there is no need to report it again as part
+    //   of the error collected by anyOf.
+    if (anyOfSchemaEntries.length <= 1) {
+      return false;
     }
-
-    return filteredErrors;
   }
-  return errors;
+
+  return true;
+}
+
+function filterErrors(
+  errors,
+  { manifest_version, allowedManifestVersionsRange } = {}
+) {
+  if (!errors) {
+    return errors;
+  }
+
+  let filteredErrors = errors.filter((error) => {
+    return error.keyword !== '$merge';
+  });
+
+  // Filter out errors that are not relevant for the addon manifest_version,
+  // this means that:
+  //
+  // - for mv2 addons, the errors related to schema only supported in mv3 will not be reported
+  // - similarly for mv3 addons, errors related to schema only supported in mv2 will not be reported
+  //
+  // This should help to avoid to report too many validation errors and to ensure that the
+  // validation errors reported are all relevant for the manifest_version actually set on
+  // the extension.
+  if (
+    filteredErrors.length > 0 &&
+    typeof manifest_version === 'number' &&
+    allowedManifestVersionsRange
+  ) {
+    filteredErrors = filteredErrors.filter((error) =>
+      isRelevantError({ error, manifest_version, allowedManifestVersionsRange })
+    );
+  }
+
+  return filteredErrors;
+}
+
+function getManifestVersionsRange(validatorOptions) {
+  const { minManifestVersion, maxManifestVersion } = validatorOptions;
+
+  const minimum =
+    minManifestVersion == null
+      ? getDefaultConfigValue('min-manifest-version')
+      : minManifestVersion;
+
+  const maximum =
+    maxManifestVersion == null
+      ? getDefaultConfigValue('max-manifest-version')
+      : maxManifestVersion;
+
+  // Make sure the version range is valid, if it is not:
+  // raise an explicit error.
+  if (minimum > maximum) {
+    throw new Error(
+      `Invalid manifest version range requested: ${JSON.stringify({
+        maximum,
+        minimum,
+      })}`
+    );
+  }
+
+  return { minimum, maximum };
 }
 
 export class SchemaValidator {
@@ -109,6 +178,8 @@ export class SchemaValidator {
    */
   constructor(validatorOptions) {
     this._options = validatorOptions;
+    this.allowedManifestVersionsRange =
+      getManifestVersionsRange(validatorOptions);
 
     const validator = ajv({
       allErrors: true,
@@ -147,8 +218,8 @@ export class SchemaValidator {
     // Lazily compile the addon validator, its base manifest definitions
     // are also needed for the static theme, dictionary and langpack validators.
     if (!this._addonValidator) {
-      const { _validator, _options } = this;
-      this._addonValidator = this._compileAddonValidator(_validator, _options);
+      const { _validator } = this;
+      this._addonValidator = this._compileAddonValidator(_validator);
     }
 
     return this._addonValidator;
@@ -281,42 +352,21 @@ export class SchemaValidator {
     return this._localeValidator;
   }
 
-  _compileAddonValidator(validator, validatorOptions) {
-    const { minManifestVersion, maxManifestVersion } = validatorOptions;
+  _compileAddonValidator(validator) {
+    const { minimum, maximum } = this.allowedManifestVersionsRange;
 
-    let schemaData = this.schemaObject;
-
-    if (minManifestVersion != null || maxManifestVersion != null) {
-      const minimum =
-        minManifestVersion == null
-          ? getDefaultConfigValue('min-manifest-version')
-          : minManifestVersion;
-      const maximum =
-        maxManifestVersion == null
-          ? getDefaultConfigValue('max-manifest-version')
-          : maxManifestVersion;
-
-      // Make sure the version range is valid, if it is not:
-      // raise an explicit error.
-      if (maxManifestVersion < minManifestVersion) {
-        throw new Error(
-          `Invalid manifest version range requested: ${JSON.stringify({
-            maxManifestVersion,
-            minManifestVersion,
-          })}`
-        );
-      }
-
-      schemaData = deepPatch(this.schemaObject, {
-        types: {
-          ManifestBase: {
-            properties: {
-              manifest_version: { minimum, maximum },
+    const schemaData = deepPatch(this.schemaObject, {
+      types: {
+        ManifestBase: {
+          properties: {
+            manifest_version: {
+              minimum,
+              maximum,
             },
           },
         },
-      });
-    }
+      },
+    });
 
     return validator.compile({
       ...schemaData,
@@ -406,9 +456,7 @@ export class SchemaValidator {
         //   (which happens based on the current or parent schema in the `filterErrors`
         //   helper method).
         if (schema.type === 'array') {
-          // NOTE: the alternative would be to do this for the entire set of schema
-          // entries (either while importing them, or when we load the data into the
-          // SchemaValidator class instance).
+          // TODO(#3774): move this at "import JSONSchema data" time, and remove it from here.
           // eslint-disable-next-line no-param-reassign
           schema.items[keyword] = schema[keyword];
         }
@@ -475,10 +523,10 @@ export function getValidator(validatorOptions) {
 export const validateAddon = (manifestData, validatorOptions = {}) => {
   const validator = getValidator(validatorOptions);
   const isValid = validator.validateAddon(manifestData);
-  validateAddon.errors = filterErrors(
-    validator.validateAddon.errors,
-    manifestData
-  );
+  validateAddon.errors = filterErrors(validator.validateAddon.errors, {
+    manifest_version: manifestData.manifest_version,
+    allowedManifestVersionsRange: validator.allowedManifestVersionsRange,
+  });
   return isValid;
 };
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1955,10 +1955,10 @@ describe('ManifestJSONParser', () => {
       expect(linter.collector.errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            dataPath: '/background',
-            code: 'MANIFEST_FIELD_UNSUPPORTED',
+            dataPath: '/background/service_worker',
+            code: 'JSON_INVALID',
             message: expect.stringMatching(
-              /"\/background" is in a format not supported in manifest versions < 3/
+              /"\/background\/service_worker" is an invalid additional property/
             ),
           }),
         ])

--- a/tests/unit/schema/test.schema.js
+++ b/tests/unit/schema/test.schema.js
@@ -48,7 +48,7 @@ describe('getValidator', () => {
   });
 
   it('can be forced to not cache an instance', () => {
-    const options = { minManifestVersion: 3 };
+    const options = { minManifestVersion: 3, maxManifestVersion: 3 };
     const validator = getValidator(options);
     const validator2 = getValidator(options);
 

--- a/tests/unit/schema/test.web_accessible_resources.js
+++ b/tests/unit/schema/test.web_accessible_resources.js
@@ -5,32 +5,92 @@ import { validateAddon } from 'schema/validator';
 import { validManifest } from './helpers';
 
 describe('/web_accessible_resources', () => {
-  it('should be an array', () => {
-    const manifest = cloneDeep(validManifest);
-    manifest.web_accessible_resources = 'foo.png';
-    validateAddon(manifest);
-    expect(validateAddon.errors.length).toEqual(1);
-    expect(validateAddon.errors[0].dataPath).toEqual(
-      '/web_accessible_resources'
-    );
-    expect(validateAddon.errors[0].message).toEqual('should be array');
+  describe('manifest_version 2', () => {
+    it('should be an array', () => {
+      const manifest = cloneDeep(validManifest);
+      manifest.web_accessible_resources = 'foo.png';
+      validateAddon(manifest);
+      expect(validateAddon.errors.length).toEqual(1);
+      expect(validateAddon.errors[0].dataPath).toEqual(
+        '/web_accessible_resources'
+      );
+      expect(validateAddon.errors[0].message).toEqual('should be array');
+    });
+
+    it('should fail if not an array of strings', () => {
+      const manifest = cloneDeep(validManifest);
+      manifest.web_accessible_resources = ['foo.png', 1];
+      validateAddon(manifest);
+      expect(validateAddon.errors.length).toEqual(1);
+      expect(validateAddon.errors[0].dataPath).toEqual(
+        '/web_accessible_resources/1'
+      );
+      expect(validateAddon.errors[0].message).toEqual('should be string');
+    });
+
+    it('should be array of strings', () => {
+      const manifest = cloneDeep(validManifest);
+      manifest.web_accessible_resources = ['foo.png', 'bar.css'];
+      validateAddon(manifest);
+      expect(validateAddon.errors).toBeNull();
+    });
   });
 
-  it('should fail if not an array of strings', () => {
-    const manifest = cloneDeep(validManifest);
-    manifest.web_accessible_resources = ['foo.png', 1];
-    validateAddon(manifest);
-    expect(validateAddon.errors.length).toEqual(1);
-    expect(validateAddon.errors[0].dataPath).toEqual(
-      '/web_accessible_resources/1'
-    );
-    expect(validateAddon.errors[0].message).toEqual('should be string');
-  });
+  describe('manifest_version 3', () => {
+    it('should be array of objects with the expected format', () => {
+      const manifest = {
+        ...cloneDeep(validManifest),
+        manifest_version: 3,
+        web_accessible_resources: [
+          {
+            resources: ['foo.png', 'bar.css'],
+            matches: ['*://*/*'],
+          },
+        ],
+      };
+      validateAddon(manifest, { maxManifestVersion: 3 });
+      expect(validateAddon.errors).toBeNull();
+    });
 
-  it('should be array of strings', () => {
-    const manifest = cloneDeep(validManifest);
-    manifest.web_accessible_resources = ['foo.png', 'bar.css'];
-    validateAddon(manifest);
-    expect(validateAddon.errors).toBeNull();
+    it('should have validation error if not an array of objects', () => {
+      const manifest = {
+        ...cloneDeep(validManifest),
+        manifest_version: 3,
+        web_accessible_resources: ['foo.png'],
+      };
+      validateAddon(manifest, { maxManifestVersion: 3 });
+      expect(validateAddon.errors.length).toBeGreaterThan(0);
+      expect(validateAddon.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            dataPath: '/web_accessible_resources/0',
+            message: expect.stringMatching('should be object'),
+          }),
+        ])
+      );
+    });
+
+    it('should have validation error if "resources" is not an array', () => {
+      const manifest = {
+        ...cloneDeep(validManifest),
+        manifest_version: 3,
+        web_accessible_resources: [
+          {
+            resources: 'foo.png',
+            matches: ['*://*/*'],
+          },
+        ],
+      };
+      validateAddon(manifest, { maxManifestVersion: 3 });
+      expect(validateAddon.errors.length).toBeGreaterThan(0);
+      expect(validateAddon.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            dataPath: '/web_accessible_resources/0/resources',
+            message: expect.stringMatching('should be array'),
+          }),
+        ])
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR imports the WebExtensions API JSONSchema from Firefox 90.0b7, which includes the following changes:

- Added deprecation message on the `browserSettings`'s `ftpProtocolEnabled`
- changes to `chrome_settings_override`'s `favicon_url`, which will enforce the favicon url to be part of the extension xpi file in manifest_version 3 extensions ([Bug 1697059](https://bugzilla.mozilla.org/1697059))
- `extension.lastError`, `extension.getURL`, `extension.getBackgroundPage`/`runtime.getBackgroundPage` as marked as unsupported for manifest_version 3 extensions ([Bug 1687762](https://bugzilla.mozilla.org/1687762))
- added `"matrix"` to the list of protocols that can be handled by extensions ([Bug 1688030](https://bugzilla.mozilla.org/1688030)
- marked with min/max_manifest_version the schema entries related to the manifest `content_security_policy` ([Bug 1696043](https://bugzilla.mozilla.org/1696043))
- added manifest_version 3 format for the `web_accessible_resources manifest` property ([Bug 1696580](https://bugzilla.mozilla.org/1696580)

The changes to the `web_accessible_resources` format was triggering a test failure (due to the same issue tracked by #3738), and so in addition to the changes to the imported schema, this PR also includes a separate patch with a proposed approach to fix #3738.

The change to the test case related to `background.service_worker` being used in a `manifest_version: 2` extension is related to this set of changes, the resulting messages for a `manifest_version 2` extension does not mention anymore the formats supported in `manifest_version: 3`. 