### PR TITLE
Update circle-ci config to test the project against a third node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,9 +145,7 @@ jobs:
       # run integration tests using an addons-linter binary in a
       # production-like environment
       - run: npm run test-integration:production
-      # TODO: re-enable this test suite, see:
-      # https://github.com/mozilla/addons-linter/issues/3788
-      #- run: npm run webext-test-functional
+      - run: npm run webext-test-functional
 
   publish-rules:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,10 +142,12 @@ jobs:
       - *make_production_build
       - *configure_global_npm
       - run: npm run test-ci
-      # run integration tests using an addons-linter binary in a
-      # production-like environment
+        # run integration tests using an addons-linter binary in a
+        # production-like environment
       - run: npm run test-integration:production
-      - run: npm run webext-test-functional
+      # TODO: re-enable this test suite, see:
+      # https://github.com/mozilla/addons-linter/issues/3788
+      #- run: npm run webext-test-functional
 
   publish-rules:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,18 @@ references:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
 
   defaults-next: &defaults-next
-    working_directory: ~/addons-linter
+    <<: *defaults
     docker:
       # This is the next NodeJS version we will support.
       - image: circleci/node:14
+
+  defaults-alternate: &defaults-alternate
+    <<: *defaults
+    docker:
+      # This is an alternate Node version we support or want to support in the
+      # (far) future. It can either be lower or higher than the current Node
+      # version we run in production.
+      - image: circleci/node:16
 
   restore_build_cache: &restore_build_cache
     restore_cache:
@@ -69,6 +77,19 @@ references:
       paths:
         - ./node_modules
 
+  restore_alternate_build_cache: &restore_alternate_build_cache
+    restore_cache:
+      name: restore npm package cache
+      keys:
+        - alternate-npm-packages-{{ checksum "package-lock.json" }}
+
+  save_alternate_build_cache: &save_alternate_build_cache
+    save_cache:
+      name: save npm package cache
+      key: alternate-npm-packages-{{ checksum "package-lock.json" }}
+      paths:
+        - ./node_modules
+
 jobs:
   test:
     <<: *defaults
@@ -111,6 +132,21 @@ jobs:
       - run: npm run test-integration:production
       - run: npm run webext-test-functional
 
+  test-alternate:
+    <<: *defaults-alternate
+    steps:
+      - checkout
+      - *restore_alternate_build_cache
+      - *run_npm_install
+      - *save_alternate_build_cache
+      - *make_production_build
+      - *configure_global_npm
+      - run: npm run test-ci
+      # run integration tests using an addons-linter binary in a
+      # production-like environment
+      - run: npm run test-integration:production
+      - run: npm run webext-test-functional
+
   publish-rules:
     <<: *defaults
     steps:
@@ -140,6 +176,7 @@ workflows:
             tags:
               only: /.*/
       - test-next
+      - test-alternate
       - publish-rules:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,8 @@ jobs:
       - *make_production_build
       - *configure_global_npm
       - run: npm run test-ci
-        # run integration tests using an addons-linter binary in a
-        # production-like environment
+      # run integration tests using an addons-linter binary in a
+      # production-like environment
       - run: npm run test-integration:production
       # TODO: re-enable this test suite, see:
       # https://github.com/mozilla/addons-linter/issues/3788

--- a/scripts/webext-test-functional
+++ b/scripts/webext-test-functional
@@ -4,17 +4,17 @@
 npm install
 npm run build
 
-# Create (global) addons-linter link
-# See: https://docs.npmjs.com/cli/link
-npm link
+LINTER_PATH=`pwd`
 
 # Fetch web-ext
 git clone https://github.com/mozilla/web-ext
 cd web-ext
 
-# Link addons-linter, then install web-ext's dependencies
+# install web-ext's dependencies, then link the addons-linter
+# dependency from the local addons-linter repo clone.
 npm install
-npm link addons-linter
+mv node_modules/addons-linter node_modules/addons-linter.npm
+ln -s $LINTER_PATH node_modules/addons-linter
 
 # Run web-ext functional tests
 MOCHA_TIMEOUT=60000 npm run test-functional


### PR DESCRIPTION
We're going to adopt node 14 as the "new" current node version in #3761 but we probably want to keep node 12 compatibility for a while, at least for web-ext, which is why I am proposing a `test-alternate` job that could be use to test against a 3rd Node version. It's currently set to Node 16 but it could be set to Node 12 once the current node version becomes "14" and the next version becomes "16".