### PR TITLE
Use node 14 as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     working_directory: ~/addons-linter
     docker:
       # This is the NodeJS version we run in production.
-      - image: circleci/node:12
+      - image: circleci/node:14
     environment:
       # This environment variable is needed for `scripts/publish-rules`.
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
@@ -20,7 +20,7 @@ references:
     <<: *defaults
     docker:
       # This is the next NodeJS version we will support.
-      - image: circleci/node:14
+      - image: circleci/node:16
 
   defaults-alternate: &defaults-alternate
     <<: *defaults
@@ -28,7 +28,7 @@ references:
       # This is an alternate Node version we support or want to support in the
       # (far) future. It can either be lower or higher than the current Node
       # version we run in production.
-      - image: circleci/node:16
+      - image: circleci/node:12
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3761

---

This PR changes the default node version from `12` to `14` because AMO is going
to use Node 14 as the default production version. The next node version is set
to `16` and we set the alternate Node version to `12` because we want to
support Node 12 for web-ext.

This change also means that the `addons-linter` package (published on npmjs)
will be built with Node `14` and not Node `12` anymore.