### PR TITLE
fix: Manifest keys unsupported in the current manifest version should be reported as warnings

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -95,13 +95,13 @@ Rules are sorted by severity.
 | `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
 | `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
 | `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
+| `MANIFEST_FIELD_UNSUPPORTED`                            | warning  | A manifest field is not supported (or not supported for the extension manifest_version)         |
+| `MANIFEST_PERMISSION_UNSUPPORTED`                       | warning  | A manifest permission is not supported for the extension manifest_version                       |
 | `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |
 | `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                         |
 | `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
 | `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
 | `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
-| `MANIFEST_FIELD_UNSUPPORTED`                            | error    | A manifest field is not supported (or not supported for the extension manifest_version)         |
-| `MANIFEST_PERMISSION_UNSUPPORTED`                       | error    | A manifest permission is not supported for the extension manifest_version                       |
 | `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
 | `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                         |
 | `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -323,6 +323,7 @@ export default class ManifestJSONParser extends JSONParser {
       messages.MANIFEST_PERMISSIONS.code,
       messages.MANIFEST_OPTIONAL_PERMISSIONS.code,
       messages.MANIFEST_PERMISSION_UNSUPPORTED,
+      messages.MANIFEST_FIELD_UNSUPPORTED,
     ];
     let validate = validateAddon;
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -445,6 +445,32 @@ describe('ManifestJSONParser', () => {
           });
         });
       }
+
+      it('warns on unsupported manifest key', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const json = validManifestJSON({
+          action: { default_popup: 'popup.html' },
+          browser_action: { default_popup: 'popup.html' },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          json,
+          linter.collector,
+          { io: { files: { 'popup.html': '' } } }
+        );
+
+        expect(manifestJSONParser.collector.warnings).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: 'MANIFEST_FIELD_UNSUPPORTED',
+              // This would need to be changed to /browser_action
+              // if the manifest_version we test by default becomes
+              // manifest_version 3.
+              dataPath: '/action',
+            }),
+          ])
+        );
+        expect(linter.collector.errors).toEqual([]);
+      });
     });
   });
 


### PR DESCRIPTION
This PR includes:
- one line change needed to ensure that on unsupported manifest keys we report a warning (which aligns the behavior of the linter to the one on Firefox, [re-]introduced for manifest_version 2 extensions by [Bug 1722966](https://bugzilla.mozilla.org/show_bug.cgi?id=1722966))
- update the table in rules.md accordingly (also fix the severity value for `MANIFEST_PERMISSION_UNSUPPORTED`)
- an additional test case to ensure that MANIFEST_FIELD_UNSUPPORTED is reported as a warning 
