### PR TITLE
feat: Import API schema data for Firefox 92

### DIFF
--- a/src/schema/imported/downloads.json
+++ b/src/schema/imported/downloads.json
@@ -29,6 +29,10 @@
               "default": false,
               "type": "boolean"
             },
+            "cookieStoreId": {
+              "type": "string",
+              "description": "The cookie store ID of the contextual identity; requires \"cookies\" permission."
+            },
             "conflictAction": {
               "$ref": "#/types/FilenameConflictAction"
             },
@@ -627,6 +631,10 @@
           "description": "False if this download is recorded in the history, true if it is not recorded.",
           "type": "boolean"
         },
+        "cookieStoreId": {
+          "type": "string",
+          "description": "The cookie store ID of the contextual identity."
+        },
         "danger": {
           "allOf": [
             {
@@ -850,6 +858,10 @@
         "filename": {
           "description": "Absolute local path.",
           "type": "string"
+        },
+        "cookieStoreId": {
+          "type": "string",
+          "description": "The cookie store ID of the contextual identity."
         },
         "danger": {
           "allOf": [

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -215,17 +215,38 @@
                   ]
                 },
                 "permissions": {
-                  "type": "array",
                   "default": [],
-                  "items": {
-                    "allOf": [
-                      {
-                        "$ref": "#/types/PermissionOrOrigin"
-                      },
-                      {
-                        "onError": "warn"
+                  "anyOf": [
+                    {
+                      "max_manifest_version": 2,
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/types/PermissionOrOrigin"
+                          },
+                          {
+                            "onError": "warn"
+                          }
+                        ]
                       }
-                    ],
+                    },
+                    {
+                      "min_manifest_version": 3,
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/types/Permission"
+                          },
+                          {
+                            "onError": "warn"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "items": {
                     "anyOf": [
                       {},
                       {
@@ -234,6 +255,21 @@
                     ]
                   },
                   "uniqueItems": true
+                },
+                "host_permissions": {
+                  "min_manifest_version": 3,
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/types/MatchPattern"
+                      },
+                      {
+                        "onError": "warn"
+                      }
+                    ]
+                  },
+                  "default": []
                 },
                 "optional_permissions": {
                   "type": "array",


### PR DESCRIPTION
Fixes #3872

-----

This PR includes the following changes to the schema:
- downloads API (added cookieStoreId to the parameters for some of the API methods) - [Bug 1669566](https://bugzilla.mozilla.org/1669566)
- host_permissions support in manifest_version 3 extensions - [Bug 1693385](https://bugzilla.mozilla.org/1693385)

Along with some new tests related to the behavior expected on the `host_permissions` manifest property in manifest_version 2 and manifest_version 3 extensions (the change to the downloads API isn't actually used by the eslint rule that validates the API calls and so it didn't need additional coverage).