### PR TITLE
fix: Invalid host_permissions should be reported as warning in MV3 and filtered out in MV2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -336,6 +336,11 @@
 <td>Unknown optional permission</td>
 </tr>
 <tr>
+<td><code>MANIFEST_HOST_PERMISSIONS</code></td>
+<td>warning</td>
+<td>Unknown host permission</td>
+</tr>
+<tr>
 <td><code>NO_MESSAGES_FILE</code></td>
 <td>warning</td>
 <td>When default_locale is specified a matching messages.json must exist</td>
@@ -419,6 +424,11 @@
 <td><code>MANIFEST_BAD_OPTIONAL_PERMISSION</code></td>
 <td>error</td>
 <td>Bad optional permission</td>
+</tr>
+<tr>
+<td><code>MANIFEST_BAD_HOST_PERMISSION</code></td>
+<td>error</td>
+<td>Bad host permission</td>
 </tr>
 <tr>
 <td><code>JSON_BLOCK_COMMENTS</code></td>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -87,6 +87,7 @@ Rules are sorted by severity.
 | `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
 | `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
 | `MANIFEST_OPTIONAL_PERMISSIONS`                         | warning  | Unknown optional permission                                                                     |
+| `MANIFEST_HOST_PERMISSIONS`                             | warning  | Unknown host permission                                                                         |
 | `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
 | `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
 | `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |
@@ -104,6 +105,7 @@ Rules are sorted by severity.
 | `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
 | `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
 | `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                         |
+| `MANIFEST_BAD_HOST_PERMISSION`                          | error    | Bad host permission                                                                             |
 | `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
 | `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
 | `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |

--- a/src/const.js
+++ b/src/const.js
@@ -97,7 +97,7 @@ export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
 export const FLAGGED_FILE_REGEX = /thumbs\.db$|\.DS_Store$|\.orig$|\.old$|~$/i;
 export const ALREADY_SIGNED_REGEX = /^META-INF\/manifest\.mf/;
 export const PERMS_DATAPATH_REGEX =
-  /^\/(permissions|optional_permissions)\/([\d+])/;
+  /^\/(permissions|optional_permissions|host_permissions)\/([\d+])/;
 
 export const RESERVED_FILENAMES = ['mozilla-recommendation.json'];
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -76,6 +76,15 @@ export const MANIFEST_BAD_OPTIONAL_PERMISSION = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_BAD_HOST_PERMISSION = {
+  code: 'MANIFEST_BAD_HOST_PERMISSION',
+  message: i18n._('The permission type is unsupported.'),
+  // TODO(https://github.com/mozilla/addons-linter/issues/3893): link host_permissions
+  // MDN doc page here once we have created it.
+  description: i18n._('The permission type is unsupported.'),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_PERMISSIONS = {
   code: 'MANIFEST_PERMISSIONS',
   message: i18n._('Unknown permission.'),
@@ -91,6 +100,15 @@ export const MANIFEST_OPTIONAL_PERMISSIONS = {
   description: i18n._(
     'See https://mzl.la/2Qn0fWC (MDN Docs) for more information.'
   ),
+  file: MANIFEST_JSON,
+};
+
+export const MANIFEST_HOST_PERMISSIONS = {
+  code: 'MANIFEST_HOST_PERMISSIONS',
+  message: i18n._('Invalid host permission.'),
+  // TODO(https://github.com/mozilla/addons-linter/issues/3893): link host_permissions
+  // MDN doc page here once we have created it.
+  description: i18n._('Invalid host permission.'),
   file: MANIFEST_JSON,
 };
 


### PR DESCRIPTION
Followup to #3873, Fixes #3888

This PR includes the following changes:
- two new rules code:  `MANIFEST_HOST_PERMISSIONS` (used to report invalid permission as a warning) and `MANIFEST_BAD_HOST_PERMISSION` (reported as error, only used when a permission doesn't have the expected type string), as the ones we already have for the `permissions` and `optional_permissions` manifest keys 
- ensure that invalid host_permissions (the ones that are still in the expected string form) are reported as warnings (as we do already for `permissions` and `optional_permissions`)
- filter out the additional linting error that the top level anyOf schema entry (recently introduced because of the difference in the schema definition for the "permissions" manifest key in manifest_version 2 and manifest_version 3), because that is redundant (the schema entries nested into it have already reported their validation errors) and it would trigger a JSON_INVALID that is reported as an error even when the nested schema entries reported only warnings
- changes to the tests to properly cover the expected behaviors

As a side note, the `ManifestJSONParser`'s `errorLookup` method could use a refactoring, it has never been that much readable, but it is also increasing in complexity and it would be good to reorganize it to make it easier to read and maintain over the time, but it may be reasonable to defer that to a separate follow up (e.g. to keep this incremental change to fix the permissions validations smaller).