### PR TITLE
Prevent error when strict_min_version is not a string value

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -398,7 +398,8 @@ export function firefoxStrictMinVersion(manifestJson) {
   if (
     manifestJson.applications &&
     manifestJson.applications.gecko &&
-    manifestJson.applications.gecko.strict_min_version
+    manifestJson.applications.gecko.strict_min_version &&
+    typeof manifestJson.applications.gecko.strict_min_version === 'string'
   ) {
     return parseInt(
       manifestJson.applications.gecko.strict_min_version.split('.')[0],

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -512,6 +512,14 @@ describe('firefoxStrictMinVersion', () => {
       })
     ).toEqual(60);
   });
+
+  it('should return null when value is not a string', () => {
+    expect(
+      firefoxStrictMinVersion({
+        applications: { gecko: { strict_min_version: 12.3 } },
+      })
+    ).toEqual(null);
+  });
 });
 
 describe('basicCompatVersionComparison', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3909

---

Thanks to @rpl for the sketch of patch.