### PR TITLE
feat: Imported Firefox 93.0b7 API schema

### DIFF
--- a/src/schema/imported/extension_types.json
+++ b/src/schema/imported/extension_types.json
@@ -59,6 +59,10 @@
         "scale": {
           "type": "number",
           "description": "The scale of the resulting image.  Defaults to <code>devicePixelRatio</code>."
+        },
+        "resetScrollPosition": {
+          "type": "boolean",
+          "description": "If true, temporarily resets the scroll position of the document to 0. Only takes effect if rect is also specified."
         }
       }
     },


### PR DESCRIPTION
This PR includes the following new schema updates imported from Firefox 93.0b7:

- [Bug 1708403](https://bugzilla.mozilla.org/show_bug.cgi?id=1708403): new `resetScrollPosition` boolean option added to the `ImageDetails` options from the `browser.tabs.captureTab/captureVisibileTab` API methods
  - NOTE: this option is just ignored for non privileged addons (in practice it is [only used when the caller is a privileged signed addons that also require the "mozillaAddons" permissions](https://searchfox.org/mozilla-central/rev/45e308665eb9fc52fd21e2d4b3b959f3cec13ef1/toolkit/components/extensions/parent/ext-tabs-base.js#135-140))

These changes to the imported JSONSchema data does not require any other additional changes to the addons-linter, especially given that the addons-linter eslint rules are not really using this data (none of the API methods parameters are validated using the schema data).