### PR TITLE
fix: Add an INVALID_ZIPFILE lint error on zip file with invalid chars in filenames

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -225,11 +225,6 @@
 <td>Flagged file extensions found</td>
 </tr>
 <tr>
-<td><code>DUPLICATE_XPI_ENTRY</code></td>
-<td>warning</td>
-<td>Package contains duplicate entries</td>
-</tr>
-<tr>
 <td><code>ALREADY_SIGNED</code></td>
 <td>warning</td>
 <td>Already signed</td>
@@ -240,9 +235,19 @@
 <td>Firefox add-ons are not allowed to run coin miners.</td>
 </tr>
 <tr>
+<td><code>DUPLICATE_XPI_ENTRY</code></td>
+<td>error</td>
+<td>Package contains duplicate entries.</td>
+</tr>
+<tr>
+<td><code>INVALID_XPI_ENTRY</code></td>
+<td>error</td>
+<td>Package contains invalid entries (e.g. invalid characters in entries path name).</td>
+</tr>
+<tr>
 <td><code>BAD_ZIPFILE</code></td>
 <td>error</td>
-<td>Bad zip file</td>
+<td>Bad zip file.</td>
 </tr>
 <tr>
 <td><code>FILE_TOO_LARGE</code></td>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -52,17 +52,18 @@ Rules are sorted by severity.
 
 ## Package layout
 
-| Message code               | Severity | Description                                         |
-| -------------------------- | -------- | --------------------------------------------------- |
-| `MOZILLA_COND_OF_USE`      | notice   | Mozilla conditions of use violation.                |
-| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                   |
-| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                       |
-| `DUPLICATE_XPI_ENTRY`      | warning  | Package contains duplicate entries                  |
-| `ALREADY_SIGNED`           | warning  | Already signed                                      |
-| `COINMINER_USAGE_DETECTED` | warning  | Firefox add-ons are not allowed to run coin miners. |
-| `BAD_ZIPFILE`              | error    | Bad zip file                                        |
-| `FILE_TOO_LARGE`           | error    | File is too large to parse                          |
-| `RESERVED_FILENAME`        | error    | Reserved filename detected.                         |
+| Message code               | Severity | Description                                                                      |
+| -------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `MOZILLA_COND_OF_USE`      | notice   | Mozilla conditions of use violation.                                             |
+| `FLAGGED_FILE_TYPE`        | notice   | (Binary) Flagged file type found.                                                |
+| `FLAGGED_FILE_EXTENSION`   | warning  | Flagged file extensions found                                                    |
+| `ALREADY_SIGNED`           | warning  | Already signed                                                                   |
+| `COINMINER_USAGE_DETECTED` | warning  | Firefox add-ons are not allowed to run coin miners.                              |
+| `DUPLICATE_XPI_ENTRY`      | error    | Package contains duplicate entries.                                              |
+| `INVALID_XPI_ENTRY`        | error    | Package contains invalid entries (e.g. invalid characters in entries path name). |
+| `BAD_ZIPFILE`              | error    | Bad zip file.                                                                    |
+| `FILE_TOO_LARGE`           | error    | File is too large to parse                                                       |
+| `RESERVED_FILENAME`        | error    | Reserved filename detected.                                                      |
 
 ## Type detection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mdn/browser-compat-data": "4.0.5",
         "addons-moz-compare": "1.2.0",
-        "addons-scanner-utils": "4.11.0",
+        "addons-scanner-utils": "5.0.0",
         "ajv": "6.12.6",
         "ajv-merge-patch": "4.1.0",
         "chalk": "4.1.2",
@@ -3104,9 +3104,9 @@
       "integrity": "sha512-COG8qk2/dubPqabfcoJW4E7pm2EQDI43iMrHnhlobvq/uRMEzx/PYJ1KaUZ97Vgg44R3QdRG5CvDsTRbMUHcDw=="
     },
     "node_modules/addons-scanner-utils": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-4.11.0.tgz",
-      "integrity": "sha512-4bb7TqufOeUBowAyoclBpgpXnAjY5R31vwp95v63MSIhArKBioXukB4BFyEN6lCiaBdouKW6etG4IytYbUHyJw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-5.0.0.tgz",
+      "integrity": "sha512-uENKmGryUeR07I1c8RonDZY/bkAG+zKfZ3T61JFusgY5wiARQJ5+8hI33m8sctXxPopjfxiIjHsG/g7cQzn4Yw==",
       "dependencies": {
         "@types/yauzl": "2.9.2",
         "common-tags": "1.8.0",
@@ -15836,9 +15836,9 @@
       "integrity": "sha512-COG8qk2/dubPqabfcoJW4E7pm2EQDI43iMrHnhlobvq/uRMEzx/PYJ1KaUZ97Vgg44R3QdRG5CvDsTRbMUHcDw=="
     },
     "addons-scanner-utils": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-4.11.0.tgz",
-      "integrity": "sha512-4bb7TqufOeUBowAyoclBpgpXnAjY5R31vwp95v63MSIhArKBioXukB4BFyEN6lCiaBdouKW6etG4IytYbUHyJw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-5.0.0.tgz",
+      "integrity": "sha512-uENKmGryUeR07I1c8RonDZY/bkAG+zKfZ3T61JFusgY5wiARQJ5+8hI33m8sctXxPopjfxiIjHsG/g7cQzn4Yw==",
       "requires": {
         "@types/yauzl": "2.9.2",
         "common-tags": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@mdn/browser-compat-data": "4.0.5",
     "addons-moz-compare": "1.2.0",
-    "addons-scanner-utils": "4.11.0",
+    "addons-scanner-utils": "5.0.0",
     "ajv": "6.12.6",
     "ajv-merge-patch": "4.1.0",
     "chalk": "4.1.2",

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -11,6 +11,23 @@ export const DUPLICATE_XPI_ENTRY = {
     and re-zipping your add-on package and try again.`),
 };
 
+export const INVALID_XPI_ENTRY = {
+  code: 'INVALID_XPI_ENTRY',
+  // `message` will be replaced with the `InvalidZipFileError` message
+  // got from the addons-scanner-utils dependency when we were reading
+  // the zip file entries (in particular this would be triggered by
+  // a zipfile entry using invalid characters, like '\' as a path
+  // separator, and the underlying yauzl error message follows the
+  // format:
+  //   `invalid characters in fileName: nameOfTheInvalidZipFileEntry`
+  message: 'Invalid ZIP file entry',
+  description: i18n._(oneLine`The package is invalid. It may contain
+    entries using invalid characters, as an example using '\\' as a
+    path separator is not allowed in Firefox. Try to recreate your
+    add-on package (ZIP) and make sure all entries are using '/' as the
+    path separator.`),
+};
+
 export const BAD_ZIPFILE = {
   code: 'BAD_ZIPFILE',
   message: 'Corrupt ZIP file',


### PR DESCRIPTION
This is the addons-linter counterpart of the proposed changes to detect and collect a linting error on zip files with invalid characters in zip entries filenames.

NOTE: this can't and shouldn't be merged until mozilla/addons-scanner-utils#190 has been reviewed, merged and released on npm in a new addons-scanner-utils release. 

With this and the related changes to addons-scanner-utils, the linter should report the issue as follows:
```
$ ./bin/addons-linter ../addons-scanner-utils/src/tests/fixtures/io/archive-with-invalid-chars-in-filenames.zip
Validation Summary:

errors          1
notices         0
warnings        0

ERRORS:

Code              Message                 Description                                    File   Line   Column
INVALID_ZIPFILE   invalid characters in   The package is invalid. It may contain
                  fileName:               entries using invalid characters, as an
                  path\to\file.txt        example using '\' as a path separator is not
                                          allowed in Firefox. Try to re-zipping your
                                          add-on package and make sure all entries are
                                          using '/' as the path separator.
```