### PR TITLE
feat: Imported Firefox 94.0b8 API schema

### DIFF
--- a/src/schema/imported/cookies.json
+++ b/src/schema/imported/cookies.json
@@ -31,6 +31,16 @@
             "firstPartyDomain": {
               "type": "string",
               "description": "The first-party domain which the cookie to retrieve is associated. This attribute is required if First-Party Isolation is enabled."
+            },
+            "partitionKey": {
+              "allOf": [
+                {
+                  "$ref": "#/types/PartitionKey"
+                },
+                {
+                  "description": "The storage partition, if the cookie is part of partitioned storage. By default, only non-partitioned cookies are returned."
+                }
+              ]
             }
           },
           "required": [
@@ -100,6 +110,16 @@
             "firstPartyDomain": {
               "type": "string",
               "description": "Restricts the retrieved cookies to those whose first-party domains match this one. This attribute is required if First-Party Isolation is enabled. To not filter by a specific first-party domain, use `null` or `undefined`."
+            },
+            "partitionKey": {
+              "allOf": [
+                {
+                  "$ref": "#/types/PartitionKey"
+                },
+                {
+                  "description": "Selects a specific storage partition to look up cookies. Defaults to null, in which case only non-partitioned cookies are retrieved. If an object iis passed, partitioned cookies are also included, and filtered based on the keys present in the given PartitionKey description. An empty object ({}) returns all cookies (partitioned + unpartitioned), a non-empty object (e.g. {topLevelSite: '...'}) only returns cookies whose partition match all given attributes."
+                }
+              ]
             }
           }
         },
@@ -180,6 +200,16 @@
             "firstPartyDomain": {
               "type": "string",
               "description": "The first-party domain of the cookie. This attribute is required if First-Party Isolation is enabled."
+            },
+            "partitionKey": {
+              "allOf": [
+                {
+                  "$ref": "#/types/PartitionKey"
+                },
+                {
+                  "description": "The storage partition, if the cookie is part of partitioned storage. By default, non-partitioned storage is used."
+                }
+              ]
             }
           },
           "required": [
@@ -233,6 +263,16 @@
             "firstPartyDomain": {
               "type": "string",
               "description": "The first-party domain associated with the cookie. This attribute is required if First-Party Isolation is enabled."
+            },
+            "partitionKey": {
+              "allOf": [
+                {
+                  "$ref": "#/types/PartitionKey"
+                },
+                {
+                  "description": "The storage partition, if the cookie is part of partitioned storage. By default, non-partitioned storage is used."
+                }
+              ]
             }
           },
           "required": [
@@ -266,6 +306,16 @@
                 "firstPartyDomain": {
                   "type": "string",
                   "description": "The first-party domain associated with the cookie that's been removed."
+                },
+                "partitionKey": {
+                  "allOf": [
+                    {
+                      "$ref": "#/types/PartitionKey"
+                    },
+                    {
+                      "description": "The storage partition, if the cookie is part of partitioned storage. null if not partitioned."
+                    }
+                  ]
                 }
               },
               "required": [
@@ -374,6 +424,16 @@
       ],
       "description": "A cookie's 'SameSite' state (https://tools.ietf.org/html/draft-west-first-party-cookies). 'no_restriction' corresponds to a cookie set without a 'SameSite' attribute, 'lax' to 'SameSite=Lax', and 'strict' to 'SameSite=Strict'."
     },
+    "PartitionKey": {
+      "type": "object",
+      "description": "The description of the storage partition of a cookie. This object may be omitted (null) if a cookie is not partitioned.",
+      "properties": {
+        "topLevelSite": {
+          "type": "string",
+          "description": "The first-party URL of the cookie, if the cookie is in storage partitioned by the top-level site."
+        }
+      }
+    },
     "Cookie": {
       "type": "object",
       "description": "Represents information about an HTTP cookie.",
@@ -431,6 +491,16 @@
         "firstPartyDomain": {
           "type": "string",
           "description": "The first-party domain of the cookie."
+        },
+        "partitionKey": {
+          "allOf": [
+            {
+              "$ref": "#/types/PartitionKey"
+            },
+            {
+              "description": "The cookie's storage partition, if any. null if not partitioned."
+            }
+          ]
         }
       },
       "required": [

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -341,6 +341,9 @@
             "ntp_background": {
               "$ref": "#/types/ThemeColor"
             },
+            "ntp_card_background": {
+              "$ref": "#/types/ThemeColor"
+            },
             "ntp_text": {
               "$ref": "#/types/ThemeColor"
             },


### PR DESCRIPTION
This PR includes the following new schema updates imported from Firefox 94.0b8:
- [Bug 1669716](https://bugzilla.mozilla.org/show_bug.cgi?id=1669716): new partitionKey property introduced in the cookies WebExtensions API, to allow extensions to correctly manage cookies stored into partitioned storage by the dFPI Firefox feature
- [Bug 1727333](https://bugzilla.mozilla.org/show_bug.cgi?id=1727333): new theme color `ntp_card_background", introduced to allow themes to better customize newtab page look

These changes to the imported JSONSchema data does not require any other additional changes to the addons-linter (the new `partitionKey` property isn't actually going to be used for the addons-linter validation, because we don't validate API calls parameters, and the new theme color is a manifest property and should already be validated as the other theme colors without any further change).

Fixes #3974 