### PR TITLE
fix: accept versions with buildid

### DIFF
--- a/src/schema/formats.js
+++ b/src/schema/formats.js
@@ -6,15 +6,30 @@ const VALIDNUMRX = /^[0-9]{1,5}$/;
 // permissive than Chrome) to allow Beta addons, per:
 // https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Maintenance
 const TOOLKIT_VERSION_REGEX = /^(\d+\.?){1,3}\.(\d+([A-z]+(-?\d+)?))$/;
+// 1.2.3buildid5.6 is used in practice but not matched by TOOLKIT_VERSION_REGEX.
+// Use this pattern to accept the used format without being too permissive.
+// See https://github.com/mozilla/addons-linter/issues/3998
+const TOOLKIT_WITH_BUILDID_REGEX = /^\d+(?:\.\d+){0,2}buildid\d{8}\.\d{6}$/;
 
-export function isValidVersionString(version) {
+export function isToolkitVersionString(version) {
   // We should be starting with a string. Limit length, see bug 1393644
   if (typeof version !== 'string' || version.length > 100) {
     return false;
   }
+  return (
+    TOOLKIT_VERSION_REGEX.test(version) ||
+    TOOLKIT_WITH_BUILDID_REGEX.test(version)
+  );
+}
+
+export function isValidVersionString(version) {
   // If valid toolkit version string, return true early
-  if (TOOLKIT_VERSION_REGEX.test(version)) {
+  if (isToolkitVersionString(version)) {
     return true;
+  }
+  // We should be starting with a string. Limit length, see bug 1393644
+  if (typeof version !== 'string' || version.length > 100) {
+    return false;
   }
   const parts = version.split('.');
   if (parts.length > 4) {
@@ -37,14 +52,6 @@ export function isValidVersionString(version) {
     }
   }
   return true;
-}
-
-export function isToolkitVersionString(version) {
-  // We should be starting with a string. Limit length, see bug 1393644
-  if (typeof version !== 'string' || version.length > 100) {
-    return false;
-  }
-  return TOOLKIT_VERSION_REGEX.test(version) && isValidVersionString(version);
 }
 
 export function isAbsoluteUrl(value) {

--- a/tests/unit/schema/test.formats.js
+++ b/tests/unit/schema/test.formats.js
@@ -14,6 +14,7 @@ describe('formats', () => {
       '1.0',
       '1.01a',
       '1.0.0beta2',
+      '1.0.0beta-2',
       '1.000000a1',
       '2.10.2',
       '3.1.2.4567',
@@ -21,6 +22,15 @@ describe('formats', () => {
       '4.1pre1',
       '4.1.1pre2',
       '4.1.1.2pre3',
+      '4.1.1.2pre-3',
+      // The following two versions are equivalent in Firefox due to
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1733396
+      // See also https://bugzilla.mozilla.org/show_bug.cgi?id=1732676
+      '57.0.1buildid20210928100000',
+      '57.0.1buildid0',
+      // Regression test for https://github.com/mozilla/addons-linter/issues/3998
+      '57.0.1buildid20210928.100000',
+      '57.0.1buildid99999999.999999',
     ];
 
     const invalidVersionStrings = [
@@ -42,6 +52,8 @@ describe('formats', () => {
       '0.1.12dev-cb31c51',
       '4.1.1dev-abcdef1',
       `1.${'9'.repeat(100)}`,
+      '57.0.1buildid100000000.999999',
+      '57.0.1buildid99999999.1000000',
     ];
 
     validVersionStrings.forEach((validVersionString) => {


### PR DESCRIPTION
Fixes #3998.

The TOOLKIT_VERSION_REGEX is both too permissive and too strict. To fix #3998 while minimizing the chance of issues, accept the format introduced in https://hg.mozilla.org/mozilla-central/rev/b19f06b6337a