### PR TITLE
Update dependency eslint-config-amo to v5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "babel-loader": "8.2.3",
         "comment-json": "4.1.1",
         "doctoc": "2.1.0",
-        "eslint-config-amo": "5.1.0",
+        "eslint-config-amo": "5.2.0",
         "github-markdown-css": "5.0.0",
         "gunzip-maybe": "1.4.2",
         "hashish": "0.0.4",
@@ -5334,59 +5334,69 @@
       }
     },
     "node_modules/eslint-config-airbnb": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.0.tgz",
+      "integrity": "sha512-f5FzCDw8osQJtifOGazdBtYuDOH38FVQSOwHvSU0iFjAmkdl4zQ1jG+YV6sVNt4gqVubqJwn98zZQzDoaCwDyw==",
       "dev": true,
       "dependencies": {
-        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-react": "^7.21.5",
-        "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0"
       }
     },
     "node_modules/eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^10.12.0 || >=12.0.0"
       },
       "peerDependencies": {
-        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-        "eslint-plugin-import": "^2.22.1"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-config-amo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-amo/-/eslint-config-amo-5.1.0.tgz",
-      "integrity": "sha512-TEA5c/6bAv/KV87f4LZVtYMKnezVPZVdvBSo+gKK8jNvWVqzWmk4CEH8uus+GA22/eePOqLFMDZtGUZB/te73A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-amo/-/eslint-config-amo-5.2.0.tgz",
+      "integrity": "sha512-Vwrj3moRBcUyLuXh7gankvLYVQJKA8cBHOaaXEPqecFCHkG5qBsa8rmruXfPDQBbFC8HjtbQFLLkfNdHJwT/8A==",
       "dev": true,
       "dependencies": {
-        "eslint-config-airbnb": "18.2.1",
-        "eslint-config-airbnb-base": "14.2.1",
+        "eslint-config-airbnb": "19.0.0",
+        "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "8.3.0",
-        "eslint-plugin-import": "2.25.2",
-        "eslint-plugin-jest": "25.2.2",
-        "eslint-plugin-jsx-a11y": "6.4.1",
+        "eslint-plugin-import": "2.25.3",
+        "eslint-plugin-jest": "25.2.4",
+        "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-prettier": "4.0.0",
-        "eslint-plugin-react": "7.26.1",
-        "eslint-plugin-react-hooks": "4.2.0"
+        "eslint-plugin-react": "7.27.0",
+        "eslint-plugin-react-hooks": "4.3.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -5516,9 +5526,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz",
-      "integrity": "sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==",
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
+      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -5526,9 +5536,9 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.0",
+        "eslint-module-utils": "^2.7.1",
         "has": "^1.0.3",
-        "is-core-module": "^2.7.0",
+        "is-core-module": "^2.8.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.0.4",
         "object.values": "^1.1.5",
@@ -5570,9 +5580,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.2.tgz",
-      "integrity": "sha512-frn5yhOF60U4kcqozO3zKTNZQUk+mfx037XOy2iiYL8FhorEkuCuL3/flzKcY1ECDP2WYT9ydmvlO3fRW9o4mg==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz",
+      "integrity": "sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^5.0.0"
@@ -5587,32 +5597,36 @@
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
           "optional": true
+        },
+        "jest": {
+          "optional": true
         }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
-      "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
+      "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": "^7.16.3",
         "aria-query": "^4.2.2",
-        "array-includes": "^3.1.1",
+        "array-includes": "^3.1.4",
         "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.0.2",
+        "axe-core": "^4.3.5",
         "axobject-query": "^2.2.0",
-        "damerau-levenshtein": "^1.0.6",
-        "emoji-regex": "^9.0.0",
+        "damerau-levenshtein": "^1.0.7",
+        "emoji-regex": "^9.2.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^3.1.0",
-        "language-tags": "^1.0.5"
+        "jsx-ast-utils": "^3.2.1",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.0.4"
       },
       "engines": {
         "node": ">=4.0"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -5651,43 +5665,43 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -16739,42 +16753,51 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.0.tgz",
+      "integrity": "sha512-f5FzCDw8osQJtifOGazdBtYuDOH38FVQSOwHvSU0iFjAmkdl4zQ1jG+YV6sVNt4gqVubqJwn98zZQzDoaCwDyw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "eslint-config-amo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-amo/-/eslint-config-amo-5.1.0.tgz",
-      "integrity": "sha512-TEA5c/6bAv/KV87f4LZVtYMKnezVPZVdvBSo+gKK8jNvWVqzWmk4CEH8uus+GA22/eePOqLFMDZtGUZB/te73A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-amo/-/eslint-config-amo-5.2.0.tgz",
+      "integrity": "sha512-Vwrj3moRBcUyLuXh7gankvLYVQJKA8cBHOaaXEPqecFCHkG5qBsa8rmruXfPDQBbFC8HjtbQFLLkfNdHJwT/8A==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb": "18.2.1",
-        "eslint-config-airbnb-base": "14.2.1",
+        "eslint-config-airbnb": "19.0.0",
+        "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "8.3.0",
-        "eslint-plugin-import": "2.25.2",
-        "eslint-plugin-jest": "25.2.2",
-        "eslint-plugin-jsx-a11y": "6.4.1",
+        "eslint-plugin-import": "2.25.3",
+        "eslint-plugin-jest": "25.2.4",
+        "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-prettier": "4.0.0",
-        "eslint-plugin-react": "7.26.1",
-        "eslint-plugin-react-hooks": "4.2.0"
+        "eslint-plugin-react": "7.27.0",
+        "eslint-plugin-react-hooks": "4.3.0"
       }
     },
     "eslint-config-prettier": {
@@ -16877,9 +16900,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz",
-      "integrity": "sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==",
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
+      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -16887,9 +16910,9 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.0",
+        "eslint-module-utils": "^2.7.1",
         "has": "^1.0.3",
-        "is-core-module": "^2.7.0",
+        "is-core-module": "^2.8.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.0.4",
         "object.values": "^1.1.5",
@@ -16924,31 +16947,32 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.2.tgz",
-      "integrity": "sha512-frn5yhOF60U4kcqozO3zKTNZQUk+mfx037XOy2iiYL8FhorEkuCuL3/flzKcY1ECDP2WYT9ydmvlO3fRW9o4mg==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz",
+      "integrity": "sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^5.0.0"
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
-      "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
+      "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": "^7.16.3",
         "aria-query": "^4.2.2",
-        "array-includes": "^3.1.1",
+        "array-includes": "^3.1.4",
         "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.0.2",
+        "axe-core": "^4.3.5",
         "axobject-query": "^2.2.0",
-        "damerau-levenshtein": "^1.0.6",
-        "emoji-regex": "^9.0.0",
+        "damerau-levenshtein": "^1.0.7",
+        "emoji-regex": "^9.2.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^3.1.0",
-        "language-tags": "^1.0.5"
+        "jsx-ast-utils": "^3.2.1",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "emoji-regex": {
@@ -16975,25 +16999,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -17024,9 +17048,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "babel-loader": "8.2.3",
     "comment-json": "4.1.1",
     "doctoc": "2.1.0",
-    "eslint-config-amo": "5.1.0",
+    "eslint-config-amo": "5.2.0",
     "github-markdown-css": "5.0.0",
     "gunzip-maybe": "1.4.2",
     "hashish": "0.0.4",

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -32,7 +32,9 @@ const UNRECOGNIZED_PROPERTY_REFS = [
 ];
 
 const schemaRegexes = [
+  // eslint-disable-next-line prefer-regex-literals
   new RegExp('browser/components/extensions/schemas/.*\\.json'),
+  // eslint-disable-next-line prefer-regex-literals
   new RegExp('toolkit/components/extensions/schemas/.*\\.json'),
 ];
 
@@ -757,7 +759,9 @@ async function fetchSchemasFromDir({ inputPath, outputPath }) {
       const readStream = fs.createReadStream(filePath);
       readStream.pipe(destFileStream);
       // Ensure we're closing all the created write streams before resolving.
-      return new Promise((resolve) => destFileStream.on('close', resolve));
+      return new Promise((resolve) => {
+        destFileStream.on('close', resolve);
+      });
     });
     return Promise.all(writeStreamsPromises);
   });
@@ -784,7 +788,9 @@ export async function fetchSchemas({ inputPath, outputPath }) {
           // for them to ensure we're closing their streams
           const destFileStream = fs.createWriteStream(filePath);
           writeStreamsPromises.push(
-            new Promise((res) => destFileStream.on('close', res))
+            new Promise((res) => {
+              destFileStream.on('close', res);
+            })
           );
           const readStream = await openReadStream(entry);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
 
 /* global nodeRequire, localesRoot */
 
-const SOURCE_MAP_RE = new RegExp(/\/\/[#@]\s(source(?:Mapping)?URL)=\s*(\S+)/);
+const SOURCE_MAP_RE = /\/\/[#@]\s(source(?:Mapping)?URL)=\s*(\S+)/;
 
 // Represents an error condition related to a user error (e.g. an invalid
 // configuration option passed to the linter class, usually through the

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -73,7 +73,7 @@ module.exports = {
   plugins: [
     // Don't generate modules for locale files.
     new webpack.IgnorePlugin({
-      resourceRegExp: new RegExp(`locale\\/.*\\/messages\\.js$`),
+      resourceRegExp: /locale\/.*\/messages\.js$/,
     }),
     ...webpackConfig.plugins,
   ],


### PR DESCRIPTION
Closes #4041

---

I disabled a new rule in two cases because rewritting the regexp without
`RegExp` when it's dealing with a path isn't very readable.