### PR TITLE
feat: Imported Firefox 95.0b8 API schema

### DIFF
--- a/src/schema/imported/browser_settings.json
+++ b/src/schema/imported/browser_settings.json
@@ -146,6 +146,16 @@
         }
       ]
     },
+    "overrideContentColorScheme": {
+      "allOf": [
+        {
+          "$ref": "types#/types/Setting"
+        },
+        {
+          "description": "This setting controls whether a light or dark color scheme overrides the page's preferred color scheme."
+        }
+      ]
+    },
     "useDocumentFonts": {
       "allOf": [
         {

--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -59,6 +59,16 @@
               "description": "Allow users to query the mode for 'HTTPS-Only Mode'. This setting's value is of type HTTPSOnlyModeOption, defaulting to <code>never</code>."
             }
           ]
+        },
+        "globalPrivacyControl": {
+          "allOf": [
+            {
+              "$ref": "types#/types/Setting"
+            },
+            {
+              "description": "Allow users to query the status of 'Global Privacy Control'. This setting's value is of type boolean, defaulting to <code>false</code>."
+            }
+          ]
         }
       },
       "required": [
@@ -66,7 +76,8 @@
         "peerConnectionEnabled",
         "webRTCIPHandlingPolicy",
         "tlsVersionRestriction",
-        "httpsOnlyMode"
+        "httpsOnlyMode",
+        "globalPrivacyControl"
       ]
     },
     "services": {

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1386,7 +1386,8 @@
           "type": "string",
           "enum": [
             "webRequest",
-            "webRequestBlocking"
+            "webRequestBlocking",
+            "webRequestFilterResponse.serviceWorkerScript"
           ]
         }
       ]


### PR DESCRIPTION
This PR includes the following new schema updates imported from Firefox 95.0b8:

- [Bug 1733461](https://bugzilla.mozilla.org/show_bug.cgi?id=1733461): Introduced a new `browserSettings.overrideContentColorScheme` setting (to allow extensions to query and/or control the preferred-color-scheme behavior)
- [Bug 1735372](https://bugzilla.mozilla.org/show_bug.cgi?id=1735372): Introduced a new read-only `privacy.network.globalPrivacyControl`

These changes to the imported JSONSchema data does not require any other additional changes to the addons-linter.

Fixes #4047