### PR TITLE
Disable variable tracing because of a bug in the eslint plugin

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -1,10 +1,11 @@
 export const ESLINT_ERROR = 2;
 export const ESLINT_WARNING = 1;
 
-// Disable escapers (Sanitizer.escapeHTML, escapeHTML)
-// and unwrappers (Sanitizer.unwrapSafeHTML, unwrapSafeHTML)
-// which are allowed by default by this plugin.
-const DISABLE_ALLOWED_ESCAPERS = {
+const NO_UNSANITIZED_OPTIONS = {
+  variableTracing: false,
+  // Disable escapers (Sanitizer.escapeHTML, escapeHTML) and unwrappers
+  // (Sanitizer.unwrapSafeHTML, unwrapSafeHTML) which are allowed by default by
+  // this plugin.
   escape: { taggedTemplates: [], methods: [] },
 };
 
@@ -13,8 +14,8 @@ export const EXTERNAL_RULE_MAPPING = {
   'no-eval': [ESLINT_WARNING, { allowIndirect: false }],
   'no-implied-eval': ESLINT_WARNING,
   'no-new-func': ESLINT_WARNING,
-  'no-unsanitized/method': [ESLINT_WARNING, DISABLE_ALLOWED_ESCAPERS],
-  'no-unsanitized/property': [ESLINT_WARNING, DISABLE_ALLOWED_ESCAPERS],
+  'no-unsanitized/method': [ESLINT_WARNING, NO_UNSANITIZED_OPTIONS],
+  'no-unsanitized/property': [ESLINT_WARNING, NO_UNSANITIZED_OPTIONS],
 };
 
 export const ESLINT_RULE_MAPPING = {

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -419,6 +419,23 @@ describe('JavaScript Scanner', () => {
     ]);
   });
 
+  // See: https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/188
+  it('has variable tracing disabled to avoid a bug', async () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    const code = 'let c; a.innerHTML = `${c}`;';
+
+    const jsScanner = new JavaScriptScanner(code, 'code.js');
+
+    // We are not so much interested in the actual result. This would throw an
+    // error because of the bug in the upstream library.
+    return expect(jsScanner.scan()).resolves.toEqual({
+      linterMessages: [
+        expect.objectContaining({ code: 'UNSAFE_VAR_ASSIGNMENT' }),
+      ],
+      scannedFiles: ['code.js'],
+    });
+  });
+
   describe('detectSourceType', () => {
     it('should detect module', async () => {
       const code = oneLine`


### PR DESCRIPTION
The issue is described in jhttps://github.com/mozilla/eslint-plugin-no-unsanitized/issues/188 and we think it is the underlying problem behind https://github.com/mozilla/addons/issues/1368. The test case is temporary but it shows that the config change fixes the issue.