### PR TITLE
Make install_origins error messages more user friendly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -436,6 +436,11 @@
 <td>Bad host permission</td>
 </tr>
 <tr>
+<td><code>MANIFEST_INSTALL_ORIGINS</code></td>
+<td>error</td>
+<td>Invalid install_origins</td>
+</tr>
+<tr>
 <td><code>JSON_BLOCK_COMMENTS</code></td>
 <td>error</td>
 <td>Block Comments are not allowed in JSON</td>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -107,6 +107,7 @@ Rules are sorted by severity.
 | `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
 | `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                         |
 | `MANIFEST_BAD_HOST_PERMISSION`                          | error    | Bad host permission                                                                             |
+| `MANIFEST_INSTALL_ORIGINS`                              | error    | Invalid install_origins                                                                         |
 | `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
 | `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
 | `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |

--- a/src/const.js
+++ b/src/const.js
@@ -99,7 +99,7 @@ export const FLAGGED_FILE_REGEX = /thumbs\.db$|\.DS_Store$|\.orig$|\.old$|~$/i;
 export const ALREADY_SIGNED_REGEX = /^META-INF\/manifest\.mf/;
 export const PERMS_DATAPATH_REGEX =
   /^\/(permissions|optional_permissions|host_permissions)\/([\d+])/;
-export const INSTALLORIGIN_DATAPATH_REGEX = /^\/(install_origins)\/([\d+])/;
+export const INSTALL_ORIGINS_DATAPATH_REGEX = /^\/(install_origins)\/([\d+])/;
 
 export const RESERVED_FILENAMES = ['mozilla-recommendation.json'];
 

--- a/src/const.js
+++ b/src/const.js
@@ -97,8 +97,8 @@ export const MAX_FILE_SIZE_TO_PARSE_MB = 4;
 export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
 export const FLAGGED_FILE_REGEX = /thumbs\.db$|\.DS_Store$|\.orig$|\.old$|~$/i;
 export const ALREADY_SIGNED_REGEX = /^META-INF\/manifest\.mf/;
-export const PERMS_DATAPATH_REGEX =
-  /^\/(permissions|optional_permissions|host_permissions)\/([\d+])/;
+export const COMPLEX_ARRAYS_DATAPATH_REGEX =
+  /^\/(permissions|optional_permissions|host_permissions|install_origins)\/([\d+])/;
 
 export const RESERVED_FILENAMES = ['mozilla-recommendation.json'];
 

--- a/src/const.js
+++ b/src/const.js
@@ -97,8 +97,9 @@ export const MAX_FILE_SIZE_TO_PARSE_MB = 4;
 export const HIDDEN_FILE_REGEX = /^__MACOSX\//;
 export const FLAGGED_FILE_REGEX = /thumbs\.db$|\.DS_Store$|\.orig$|\.old$|~$/i;
 export const ALREADY_SIGNED_REGEX = /^META-INF\/manifest\.mf/;
-export const COMPLEX_ARRAYS_DATAPATH_REGEX =
-  /^\/(permissions|optional_permissions|host_permissions|install_origins)\/([\d+])/;
+export const PERMS_DATAPATH_REGEX =
+  /^\/(permissions|optional_permissions|host_permissions)\/([\d+])/;
+export const INSTALLORIGIN_DATAPATH_REGEX = /^\/(install_origins)\/([\d+])/;
 
 export const RESERVED_FILENAMES = ['mozilla-recommendation.json'];
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,7 +1,7 @@
 import { oneLine } from 'common-tags';
 
 import { i18n, errorParamsToUnsupportedVersionRange } from 'utils';
-import { MANIFEST_JSON, PERMS_DATAPATH_REGEX } from 'const';
+import { MANIFEST_JSON, COMPLEX_ARRAYS_DATAPATH_REGEX } from 'const';
 
 export const MANIFEST_FIELD_REQUIRED = {
   code: 'MANIFEST_FIELD_REQUIRED',
@@ -49,7 +49,7 @@ export function manifestPermissionUnsupported(permissionName, error) {
   const message = i18n.sprintf(messageTmpl, {
     permissionName,
     versionRange,
-    fieldName: error.dataPath.match(PERMS_DATAPATH_REGEX)[1],
+    fieldName: error.dataPath.match(COMPLEX_ARRAYS_DATAPATH_REGEX)[1],
   });
 
   return {
@@ -109,6 +109,17 @@ export const MANIFEST_HOST_PERMISSIONS = {
   // TODO(https://github.com/mozilla/addons-linter/issues/3893): link host_permissions
   // MDN doc page here once we have created it.
   description: i18n._('Invalid host permission.'),
+  file: MANIFEST_JSON,
+};
+
+export const MANIFEST_INSTALL_ORIGINS = {
+  code: 'MANIFEST_INSTALL_ORIGINS',
+  message: i18n._('Invalid install origin.'),
+  // TODO(https://github.com/mozilla/addons-linter/issues/4084): link install_origins
+  // MDN doc page here once we have created it.
+  description: i18n._(
+    'Invalid install origin (A valid origin has - only - a scheme, hostname and optional port.'
+  ),
   file: MANIFEST_JSON,
 };
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,7 +1,7 @@
 import { oneLine } from 'common-tags';
 
 import { i18n, errorParamsToUnsupportedVersionRange } from 'utils';
-import { MANIFEST_JSON, COMPLEX_ARRAYS_DATAPATH_REGEX } from 'const';
+import { MANIFEST_JSON, PERMS_DATAPATH_REGEX } from 'const';
 
 export const MANIFEST_FIELD_REQUIRED = {
   code: 'MANIFEST_FIELD_REQUIRED',
@@ -49,7 +49,7 @@ export function manifestPermissionUnsupported(permissionName, error) {
   const message = i18n.sprintf(messageTmpl, {
     permissionName,
     versionRange,
-    fieldName: error.dataPath.match(COMPLEX_ARRAYS_DATAPATH_REGEX)[1],
+    fieldName: error.dataPath.match(PERMS_DATAPATH_REGEX)[1],
   });
 
   return {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -25,10 +25,11 @@ import {
   LOCALES_DIRECTORY,
   MESSAGES_JSON,
   FILE_EXTENSIONS_TO_MIME,
+  INSTALLORIGIN_DATAPATH_REGEX,
   STATIC_THEME_IMAGE_MIMES,
   RESTRICTED_HOMEPAGE_URLS,
   RESTRICTED_PERMISSIONS,
-  COMPLEX_ARRAYS_DATAPATH_REGEX,
+  PERMS_DATAPATH_REGEX,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -295,7 +296,7 @@ export default class ManifestJSONParser extends JSONParser {
     ) {
       // Choose a different message for permissions unsupported with the
       // add-on manifest_version.
-      if (COMPLEX_ARRAYS_DATAPATH_REGEX.test(error.dataPath)) {
+      if (PERMS_DATAPATH_REGEX.test(error.dataPath)) {
         baseObject = messages.manifestPermissionUnsupported(error.data, error);
       } else {
         baseObject = messages.manifestFieldUnsupported(error.dataPath, error);
@@ -333,7 +334,11 @@ export default class ManifestJSONParser extends JSONParser {
     // Arrays can be extremely verbose, this tries to make them a little
     // more sane. Using a regex because there will likely be more as we
     // expand the schema.
-    const match = error.dataPath.match(COMPLEX_ARRAYS_DATAPATH_REGEX);
+    // Note that this works because the 2 regexps use similar patterns. We'll
+    // want to adjust this if they start to differ.
+    const match =
+      error.dataPath.match(PERMS_DATAPATH_REGEX) ||
+      error.dataPath.match(INSTALLORIGIN_DATAPATH_REGEX);
 
     if (
       match &&

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -25,7 +25,7 @@ import {
   LOCALES_DIRECTORY,
   MESSAGES_JSON,
   FILE_EXTENSIONS_TO_MIME,
-  INSTALLORIGIN_DATAPATH_REGEX,
+  INSTALL_ORIGINS_DATAPATH_REGEX,
   STATIC_THEME_IMAGE_MIMES,
   RESTRICTED_HOMEPAGE_URLS,
   RESTRICTED_PERMISSIONS,
@@ -338,7 +338,7 @@ export default class ManifestJSONParser extends JSONParser {
     // want to adjust this if they start to differ.
     const match =
       error.dataPath.match(PERMS_DATAPATH_REGEX) ||
-      error.dataPath.match(INSTALLORIGIN_DATAPATH_REGEX);
+      error.dataPath.match(INSTALL_ORIGINS_DATAPATH_REGEX);
 
     if (
       match &&

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -28,7 +28,7 @@ import {
   STATIC_THEME_IMAGE_MIMES,
   RESTRICTED_HOMEPAGE_URLS,
   RESTRICTED_PERMISSIONS,
-  PERMS_DATAPATH_REGEX,
+  COMPLEX_ARRAYS_DATAPATH_REGEX,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -295,7 +295,7 @@ export default class ManifestJSONParser extends JSONParser {
     ) {
       // Choose a different message for permissions unsupported with the
       // add-on manifest_version.
-      if (PERMS_DATAPATH_REGEX.test(error.dataPath)) {
+      if (COMPLEX_ARRAYS_DATAPATH_REGEX.test(error.dataPath)) {
         baseObject = messages.manifestPermissionUnsupported(error.data, error);
       } else {
         baseObject = messages.manifestFieldUnsupported(error.dataPath, error);
@@ -333,7 +333,7 @@ export default class ManifestJSONParser extends JSONParser {
     // Arrays can be extremely verbose, this tries to make them a little
     // more sane. Using a regex because there will likely be more as we
     // expand the schema.
-    const match = error.dataPath.match(PERMS_DATAPATH_REGEX);
+    const match = error.dataPath.match(COMPLEX_ARRAYS_DATAPATH_REGEX);
 
     if (
       match &&
@@ -343,7 +343,7 @@ export default class ManifestJSONParser extends JSONParser {
       baseObject.code !== messages.MANIFEST_PERMISSION_UNSUPPORTED
     ) {
       baseObject = messages[`MANIFEST_${match[1].toUpperCase()}`];
-      overrides.message = oneLine`/${match[1]}: Unknown ${match[1]}
+      overrides.message = oneLine`/${match[1]}: Invalid ${match[1]}
           "${error.data}" at ${match[2]}.`;
     }
 


### PR DESCRIPTION
This also changes the generic error message for arrays from `"Unknown ..."` to `"Invalid ..."` to better accommodate install origins

Fixes #4061