### PR TITLE
feat: Imported Firefox 96.0b7 API schema

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -165,7 +165,9 @@
         "js",
         "leaf",
         "mainthreadio",
-        "responsiveness",
+        "fileio",
+        "fileioall",
+        "noiostacks",
         "screenshots",
         "seqstyle",
         "stackwalk",
@@ -173,15 +175,17 @@
         "jstracer",
         "jsallocations",
         "nostacksampling",
-        "nativeallocations",
         "preferencereads",
+        "nativeallocations",
         "ipcmessages",
-        "fileio",
-        "fileioall",
-        "noiostacks",
         "audiocallbacktracing",
         "cpu",
-        "notimerresolutionchange"
+        "notimerresolutionchange",
+        "cpuallthreads",
+        "samplingallthreads",
+        "markersallthreads",
+        "unregisteredthreads",
+        "responsiveness"
       ]
     },
     "supports": {

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -42,6 +42,7 @@ import pkcs11 from './pkcs11.json';
 import privacy from './privacy.json';
 import proxy from './proxy.json';
 import runtime from './runtime.json';
+import scripting from './scripting.json';
 import search from './search.json';
 import sessions from './sessions.json';
 import sidebarAction from './sidebar_action.json';
@@ -101,6 +102,7 @@ export default [
   privacy,
   proxy,
   runtime,
+  scripting,
   search,
   sessions,
   sidebarAction,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -15,24 +15,17 @@
           "postprocess": "manifestVersionCheck"
         },
         "applications": {
-          "type": "object",
-          "properties": {
-            "gecko": {
-              "$ref": "#/types/FirefoxSpecificProperties"
+          "allOf": [
+            {
+              "$ref": "#/types/BrowserSpecificSettings"
+            },
+            {
+              "description": "The applications property is deprecated, please use 'browser_specific_settings'"
             }
-          }
+          ]
         },
         "browser_specific_settings": {
-          "type": "object",
-          "properties": {
-            "gecko": {
-              "$ref": "#/types/FirefoxSpecificProperties"
-            },
-            "edge": {
-              "type": "object",
-              "additionalProperties": {}
-            }
-          }
+          "$ref": "#/types/BrowserSpecificSettings"
         },
         "name": {
           "type": "string",
@@ -73,10 +66,25 @@
         },
         "install_origins": {
           "type": "array",
-          "maxItems": 5,
           "items": {
             "type": "string",
             "format": "origin"
+          },
+          "maxItems": 5
+        },
+        "developer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "preprocess": "localize"
+            },
+            "url": {
+              "type": "string",
+              "format": "url",
+              "preprocess": "localize",
+              "onError": "warn"
+            }
           }
         }
       },
@@ -336,16 +344,13 @@
                     }
                   ]
                 },
+                "hidden": {
+                  "type": "boolean",
+                  "default": false
+                },
                 "developer": {
-                  "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "preprocess": "localize"
-                    },
                     "url": {
-                      "type": "string",
-                      "preprocess": "localize",
                       "format": "ignore",
                       "oneOf": [
                         {
@@ -357,10 +362,6 @@
                       ]
                     }
                   }
-                },
-                "hidden": {
-                  "type": "boolean",
-                  "default": false
                 }
               }
             }
@@ -582,6 +583,9 @@
           "$ref": "menus#/definitions/OptionalPermissionNoPrompt"
         },
         {
+          "$ref": "scripting#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
           "$ref": "search#/definitions/OptionalPermissionNoPrompt"
         },
         {
@@ -799,6 +803,15 @@
           "pattern": "^[0-9]{1,3}(\\.[a-z0-9*]+)+$"
         }
       }
+    },
+    "BrowserSpecificSettings": {
+      "type": "object",
+      "properties": {
+        "gecko": {
+          "$ref": "#/types/FirefoxSpecificProperties"
+        }
+      },
+      "additionalProperties": {}
     },
     "MatchPattern": {
       "anyOf": [

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -106,6 +106,26 @@
       }
     },
     {
+      "name": "getFrameId",
+      "type": "function",
+      "allowedContexts": [
+        "content",
+        "devtools"
+      ],
+      "description": "Get the frameId of any window global or frame element.",
+      "parameters": [
+        {
+          "name": "target",
+          "description": "A WindowProxy or a Browsing Context container element (IFrame, Frame, Embed, Object) for the target frame."
+        }
+      ],
+      "allowCrossOriginArguments": true,
+      "returns": {
+        "type": "number",
+        "description": "The frameId of the target frame, or -1 if it doesn't exist."
+      }
+    },
+    {
       "name": "setUninstallURL",
       "type": "function",
       "description": "Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.",

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -1,0 +1,135 @@
+{
+  "id": "scripting",
+  "description": "Use the scripting API to execute script in different contexts.",
+  "permissions": [
+    "scripting"
+  ],
+  "min_manifest_version": 3,
+  "functions": [
+    {
+      "name": "executeScript",
+      "type": "function",
+      "description": "Injects a script into a target context. The script will be run at <code>document_idle</code>.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ScriptInjection"
+            },
+            {
+              "name": "injection",
+              "description": "The details of the script which to inject."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the injection. The resulting array contains the result of execution for each frame where the injection succeeded.",
+          "parameters": [
+            {
+              "name": "results",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/InjectionResult"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "OptionalPermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "scripting"
+          ],
+          "min_manifest_version": 3
+        }
+      ]
+    }
+  },
+  "refs": {
+    "scripting#/definitions/OptionalPermissionNoPrompt": {
+      "namespace": "manifest",
+      "type": "OptionalPermissionNoPrompt"
+    }
+  },
+  "types": {
+    "ScriptInjection": {
+      "type": "object",
+      "description": "Details of a script injection",
+      "properties": {
+        "args": {
+          "type": "array",
+          "description": "The arguments to curry into a provided function. This is only valid if the <code>func</code> parameter is specified. These arguments must be JSON-serializable.",
+          "items": {}
+        },
+        "files": {
+          "type": "array",
+          "description": "The path of the JS or CSS files to inject, relative to the extension's root directory. Exactly one of <code>files</code> and <code>func</code> must be specified.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "func": {
+          "type": "function",
+          "description": "A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of <code>files</code> and <code>func</code> must be specified."
+        },
+        "target": {
+          "allOf": [
+            {
+              "$ref": "#/types/InjectionTarget"
+            },
+            {
+              "description": "Details specifying the target into which to inject the script."
+            }
+          ]
+        }
+      },
+      "required": [
+        "target"
+      ]
+    },
+    "InjectionResult": {
+      "type": "object",
+      "description": "Result of a script injection.",
+      "properties": {
+        "frameId": {
+          "type": "number",
+          "description": "The frame ID associated with the injection."
+        },
+        "result": {
+          "description": "The result of the script execution."
+        }
+      },
+      "required": [
+        "frameId"
+      ]
+    },
+    "InjectionTarget": {
+      "type": "object",
+      "properties": {
+        "frameIds": {
+          "type": "array",
+          "description": "The IDs of specific frames to inject into.",
+          "items": {
+            "type": "number"
+          }
+        },
+        "tabId": {
+          "type": "number",
+          "description": "The ID of the tab into which to inject."
+        }
+      },
+      "required": [
+        "tabId"
+      ]
+    }
+  }
+}

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -108,12 +108,7 @@
             "maximum": 2
           },
           "install_origins": {
-            "type": "array",
-            "maxItems": 5,
-            "items": {
-              "type": "string",
-              "format": "origin"
-            }
+            "maxItems": 5
           }
         }
       }


### PR DESCRIPTION
This PR includes the following new schema updates imported from Firefox 96.0b7:

-  [Bug 1742522](https://bugzilla.mozilla.org/show_bug.cgi?id=1742522): some changes to the geckoProfiles API options (New profiler feature to discover unregistered threads and capture some data)
- [Bug 1740601](https://bugzilla.mozilla.org/show_bug.cgi?id=1740601): new imported schema data for the initial part of the MV3 scripting API implementation
- [Bug 1737162](https://bugzilla.mozilla.org/show_bug.cgi?id=1737162): refactored schema data to use the same `BrowserSpecificSettings` type for both `applications` and `browser_specific_settings` manifest properties
- [Bug 1736902](https://bugzilla.mozilla.org/show_bug.cgi?id=1736902): introduced the `install_origins` manifest property in the Firefox schema
- [Bug 1739618](https://bugzilla.mozilla.org/show_bug.cgi?id=1739618): Move `developer` manifest property definition to `ManifestBase`
- [Bug 1739602](https://bugzilla.mozilla.org/show_bug.cgi?id=1739602): Add `"format": "url"` to the `developer.url` manifest property definitions
- [Bug 1733104](https://bugzilla.mozilla.org/show_bug.cgi?id=1733104): Added JSONSchema for the new `runtime.getFrameId` API method

Fixes #4101