### PR TITLE
feat: Imported Firefox 97.0b8 API schema

### DIFF
--- a/src/schema/imported/content_scripts.json
+++ b/src/schema/imported/content_scripts.json
@@ -84,6 +84,21 @@
               "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]
+        },
+        "cookieStoreId": {
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "limit the set of matched tabs to those that belong to the given cookie store id"
         }
       },
       "required": [

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -171,7 +171,6 @@
         "screenshots",
         "seqstyle",
         "stackwalk",
-        "threads",
         "jstracer",
         "jsallocations",
         "nostacksampling",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -531,6 +531,39 @@
         }
       }
     },
+    "WebExtensionSitePermissionsManifest": {
+      "$merge": {
+        "source": {
+          "$ref": "manifest#/types/ManifestBase"
+        },
+        "with": {
+          "type": "object",
+          "description": "Represents a WebExtension site permissions manifest.json file",
+          "properties": {
+            "site_permissions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/types/SitePermission"
+              }
+            },
+            "install_origins": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 1,
+              "items": {
+                "type": "string",
+                "format": "origin"
+              }
+            }
+          },
+          "required": [
+            "site_permissions",
+            "install_origins"
+          ]
+        }
+      }
+    },
     "ThemeIcons": {
       "type": "object",
       "properties": {
@@ -745,6 +778,17 @@
         },
         {
           "$ref": "#/types/MatchPattern"
+        }
+      ]
+    },
+    "SitePermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "midi",
+            "midi-sysex"
+          ]
         }
       ]
     },

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -459,7 +459,17 @@
               "description": "The position of the tabs within their windows."
             },
             "cookieStoreId": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "The CookieStoreId used for the tab."
             },
             "openerTabId": {

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -376,6 +376,34 @@ export class SchemaValidator {
     return this._localeValidator;
   }
 
+  get validateSitePermission() {
+    this._lazyInit();
+
+    if (!this._sitepermissionValidator) {
+      // Like with langpacks, we don't want additional properties in dictionaries,
+      // and there is no separate schema file.
+      // Uses ``deepPatch`` (instead of deepmerge) because we're patching a
+      // complicated schema instead of simply merging them together.
+      this._sitepermissionValidator = this._validator.compile({
+        ...deepPatch(this.schemaObject, {
+          types: {
+            WebExtensionSitePermissionsManifest: {
+              $merge: {
+                with: {
+                  additionalProperties: false,
+                },
+              },
+            },
+          },
+        }),
+        id: 'sitepermission-manifest',
+        $ref: '#/types/WebExtensionSitePermissionsManifest',
+      });
+    }
+
+    return this._sitepermissionValidator;
+  }
+
   _compileAddonValidator(validator) {
     const { minimum, maximum } = this.allowedManifestVersionsRange;
 
@@ -575,6 +603,15 @@ export const validateDictionary = (manifestData, validatorOptions = {}) => {
   const validator = getValidator(validatorOptions);
   const isValid = validator.validateDictionary(manifestData);
   validateDictionary.errors = filterErrors(validator.validateDictionary.errors);
+  return isValid;
+};
+
+export const validateSitePermission = (manifestData, validatorOptions = {}) => {
+  const validator = getValidator(validatorOptions);
+  const isValid = validator.validateSitePermission(manifestData);
+  validateSitePermission.errors = filterErrors(
+    validator.validateSitePermission.errors
+  );
   return isValid;
 };
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -209,6 +209,22 @@ export function validLocaleMessagesJSON() {
   });
 }
 
+export function validSitePermissionManifestJSON(extra) {
+  return JSON.stringify({
+    manifest_version: 2,
+    name: 'My SitePermission Addon',
+    version: '1.0a1',
+    site_permissions: ['midi'],
+    install_origins: ['http://mozilla.org'],
+    applications: {
+      gecko: {
+        id: '@my-exaple-sitepermission',
+      },
+    },
+    ...extra,
+  });
+}
+
 function isMatch(target, expected) {
   return isMatchWith(target, expected, (tVal, eVal) => {
     if (eVal instanceof RegExp) {


### PR DESCRIPTION
Fixes #4149

The updated schema data includes the following changes:
-  removed "threads" from the list `geckoProfiler` API features, [Bug 1729815](https://bugzilla.mozilla.org/1729815)
-  added "cookieStoreId" to `tabs.query` API options, [Bug 1730931](https://bugzilla.mozilla.org/1730931)
-  added "cookieStoreId" to `contentScripts.register` API options, [Bug 1470651](https://bugzilla.mozilla.org/1470651)
- new manifest format "WebExtensionSitePermissionsManifest"

The "WebExtensionSitePermissionsManifest" JSONSchema also required some additional changes to the schema validator and to the manifest parser, and additional tests to cover the sitepermission manifest validation.