### PR TITLE
Prevent TypeError in opendialog-remote-uri rule

### DIFF
--- a/src/rules/javascript/opendialog-remote-uri.js
+++ b/src/rules/javascript/opendialog-remote-uri.js
@@ -13,7 +13,12 @@ const rule = {
         ) {
           if (node.arguments.length) {
             const uri = node.arguments[0];
-            if (uri.type === 'Literal' && isLocalUrl(uri.value) === false) {
+            if (
+              uri.type === 'Literal' &&
+              // The first argument should be of type `string` but, if it is
+              // not for some reasons, report a warning to be extra-safe.
+              (typeof uri.value !== 'string' || isLocalUrl(uri.value) === false)
+            ) {
               return context.report(node, OPENDIALOG_REMOTE_URI.code);
             }
           }

--- a/tests/unit/rules/javascript/test.opendialog_remote_uri.js
+++ b/tests/unit/rules/javascript/test.opendialog_remote_uri.js
@@ -4,7 +4,7 @@ import * as messages from 'messages';
 
 import { runJsScanner } from '../../helpers';
 
-describe('opendialog_remote_uri', () => {
+describe(__filename, () => {
   it('should warn on remote uris passed to openDialog', async () => {
     const code = `foo.openDialog("https://foo.com/bar/");
                 foo.openDialog("http://foo.com/bar/");
@@ -31,5 +31,15 @@ describe('opendialog_remote_uri', () => {
 
     const { linterMessages } = await runJsScanner(jsScanner);
     expect(linterMessages.length).toEqual(0);
+  });
+
+  it('should not throw an error when the first argument is null', async () => {
+    const code = 'foo.openDialog(null)';
+    const jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+    const { linterMessages } = await runJsScanner(jsScanner);
+    expect(linterMessages.length).toEqual(1);
+    expect(linterMessages[0].code).toEqual(messages.OPENDIALOG_REMOTE_URI.code);
+    expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
   });
 });


### PR DESCRIPTION
Fixes #4188

---

We don't check which object calls `openDialog()` so we may find a
completely unrelated method called `openDialog()` and that one could
take `null` as first argument (which isn't allowed in `window.openDialog()`).

In this case, we currently throw a `TypeError` but we shouldn't, which
is what this patch solves. I am not too sure whether we should report
a warning here, though.

The current patch does report a warning because it is _just_ a warning
but maybe we shouldn't?