### PR TITLE
feat: Imported Firefox 98.0b10 API schema

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -184,6 +184,7 @@
         "samplingallthreads",
         "markersallthreads",
         "unregisteredthreads",
+        "processcpu",
         "responsiveness"
       ]
     },

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -137,7 +137,9 @@
                           "$ref": "manifest#/types/ExtensionURL"
                         },
                         "persistent": {
-                          "$ref": "#/types/PersistentBackgroundProperty"
+                          "type": "boolean",
+                          "max_manifest_version": 2,
+                          "default": true
                         }
                       },
                       "required": [
@@ -156,7 +158,9 @@
                           }
                         },
                         "persistent": {
-                          "$ref": "#/types/PersistentBackgroundProperty"
+                          "type": "boolean",
+                          "max_manifest_version": 2,
+                          "default": true
                         }
                       },
                       "required": [
@@ -1002,23 +1006,6 @@
     },
     "UnrecognizedProperty": {
       "deprecated": "An unexpected property was found in the WebExtension manifest."
-    },
-    "PersistentBackgroundProperty": {
-      "anyOf": [
-        {
-          "type": "boolean",
-          "enum": [
-            true
-          ]
-        },
-        {
-          "type": "boolean",
-          "enum": [
-            false
-          ],
-          "deprecated": "Event pages are not currently supported. This will run as a persistent background page."
-        }
-      ]
     }
   }
 }

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -38,6 +38,56 @@
           ]
         }
       ]
+    },
+    {
+      "name": "insertCSS",
+      "type": "function",
+      "description": "Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/CSSInjection"
+            },
+            {
+              "name": "injection",
+              "description": "The details of the styles to insert."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the injection.",
+          "parameters": []
+        }
+      ]
+    },
+    {
+      "name": "removeCSS",
+      "type": "function",
+      "description": "Removes a CSS stylesheet that was previously inserted by this extension from a target context.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/CSSInjection"
+            },
+            {
+              "name": "injection",
+              "description": "The details of the styles to remove. Note that the <code>css</code>, <code>files</code>, and <code>origin</code> properties must exactly match the stylesheet inserted through <code>insertCSS</code>. Attempting to remove a non-existent stylesheet is a no-op."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the injection.",
+          "parameters": []
+        }
+      ]
     }
   ],
   "definitions": {
@@ -71,7 +121,7 @@
         },
         "files": {
           "type": "array",
-          "description": "The path of the JS or CSS files to inject, relative to the extension's root directory. Exactly one of <code>files</code> and <code>func</code> must be specified.",
+          "description": "The path of the JS files to inject, relative to the extension's root directory. Exactly one of <code>files</code> and <code>func</code> must be specified.",
           "minItems": 1,
           "items": {
             "type": "string"
@@ -101,11 +151,24 @@
       "description": "Result of a script injection.",
       "properties": {
         "frameId": {
-          "type": "number",
+          "type": "integer",
           "description": "The frame ID associated with the injection."
         },
         "result": {
           "description": "The result of the script execution."
+        },
+        "error": {
+          "type": "object",
+          "description": "When the injection has failed, the error is exposed to the caller with this property.",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A message explaining why the injection has failed."
+            }
+          },
+          "required": [
+            "message"
+          ]
         }
       },
       "required": [
@@ -122,6 +185,10 @@
             "type": "number"
           }
         },
+        "allFrames": {
+          "type": "boolean",
+          "description": "Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if <code>frameIds</code> is specified."
+        },
         "tabId": {
           "type": "number",
           "description": "The ID of the tab into which to inject."
@@ -129,6 +196,45 @@
       },
       "required": [
         "tabId"
+      ]
+    },
+    "CSSInjection": {
+      "type": "object",
+      "properties": {
+        "css": {
+          "type": "string",
+          "description": "A string containing the CSS to inject. Exactly one of <code>files</code> and <code>css</code> must be specified."
+        },
+        "files": {
+          "type": "array",
+          "description": "The path of the CSS files to inject, relative to the extension's root directory. Exactly one of <code>files</code> and <code>css</code> must be specified.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "origin": {
+          "type": "string",
+          "enum": [
+            "USER",
+            "AUTHOR"
+          ],
+          "default": "AUTHOR",
+          "description": "The style origin for the injection. Defaults to <code>'AUTHOR'</code>."
+        },
+        "target": {
+          "allOf": [
+            {
+              "$ref": "#/types/InjectionTarget"
+            },
+            {
+              "description": "Details specifying the target into which to inject the CSS."
+            }
+          ]
+        }
+      },
+      "required": [
+        "target"
       ]
     }
   }

--- a/src/schema/imported/userScripts.json
+++ b/src/schema/imported/userScripts.json
@@ -112,6 +112,21 @@
               "description": "The soonest that the JavaScript will be injected into the tab. Defaults to \"document_idle\"."
             }
           ]
+        },
+        "cookieStoreId": {
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "limit the set of matched tabs to those that belong to the given cookie store id"
         }
       },
       "required": [


### PR DESCRIPTION
Fixes  #4209

The updated schema data includes the following changes:

- Removed PersistentBackgroundProperty schema definition, [Bug 1748524](https://bugzilla.mozilla.org/show_bug.cgi?id=1748524)
   - NOTE: no actual change in behavior expected for the addons-linter perspective: the removed deprecated property is only used on [a small subset of deprecated manifest properties](https://github.com/mozilla/addons-linter/blob/fdc4da955f11740b873a8f77cd422c0e8bb8326c/src/const.js#L146-L150), and so the new schema is not expected to be changing any of the previous behaviors on the validation of MV2 manifests (where the persistent property was still allowed)
- added "processcpu" to the list of `geckoProfiler` API features, [Bug 1744670](https://bugzilla.mozilla.org/show_bug.cgi?id=1744670)

- updated schema for the MV3 `scripting` API, [Bug 1736574](https://bugzilla.mozilla.org/show_bug.cgi?id=1736574) / [Bug 1736579](https://bugzilla.mozilla.org/show_bug.cgi?id=1736579) / [Bug 1736580](https://bugzilla.mozilla.org/show_bug.cgi?id=1736580)

- added `cookieStoreId` to the `userScripts.UserScriptOptions` type,  [Bug 1738567](https://bugzilla.mozilla.org/show_bug.cgi?id=1738567)