### PR TITLE
feat: Imported Firefox 99.0b8 schema

### DIFF
--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -762,7 +762,8 @@
         "s390x",
         "sparc64",
         "x86-32",
-        "x86-64"
+        "x86-64",
+        "noarch"
       ],
       "allowedContexts": [
         "content",

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -88,6 +88,88 @@
           "parameters": []
         }
       ]
+    },
+    {
+      "name": "registerContentScripts",
+      "type": "function",
+      "description": "Registers one or more content scripts for this extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "scripts",
+          "type": "array",
+          "description": "Contains a list of scripts to be registered. If there are errors during script parsing/file validation, or if the IDs specified already exist, then no scripts are registered.",
+          "items": {
+            "$ref": "#/types/RegisteredContentScript"
+          }
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the registration.",
+          "parameters": []
+        }
+      ]
+    },
+    {
+      "name": "getRegisteredContentScripts",
+      "type": "function",
+      "description": "Returns all dynamically registered content scripts for this extension that match the given filter.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ContentScriptFilter"
+            },
+            {
+              "name": "filter",
+              "optional": true,
+              "description": "An object to filter the extension's dynamically registered scripts."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "The resulting array contains the registered content scripts.",
+          "parameters": [
+            {
+              "name": "scripts",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/RegisteredContentScript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "unregisterContentScripts",
+      "type": "function",
+      "description": "Unregisters one or more content scripts for this extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/ContentScriptFilter"
+            },
+            {
+              "name": "filter",
+              "optional": true,
+              "description": "If specified, only unregisters dynamic content scripts which match the filter. Otherwise, all of the extension's dynamic content scripts are unregistered."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the unregistration.",
+          "parameters": []
+        }
+      ]
     }
   ],
   "definitions": {
@@ -235,6 +317,66 @@
       },
       "required": [
         "target"
+      ]
+    },
+    "ContentScriptFilter": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "description": "The IDs of specific scripts to retrieve with <code>getRegisteredContentScripts()</code> or to unregister with <code>unregisterContentScripts()</code>.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RegisteredContentScript": {
+      "type": "object",
+      "properties": {
+        "allFrames": {
+          "type": "boolean",
+          "description": "If specified true, it will inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it will not inject into child frames if the URL requirements are not met. Defaults to false, meaning that only the top frame is matched."
+        },
+        "excludeMatches": {
+          "type": "array",
+          "description": "Excludes pages that this content script would otherwise be injected into.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of the content script, specified in the API call."
+        },
+        "js": {
+          "type": "array",
+          "description": "The list of JavaScript files to be injected into matching pages. These are injected in the order they appear in this array.",
+          "items": {
+            "$ref": "manifest#/types/ExtensionURL"
+          }
+        },
+        "matches": {
+          "type": "array",
+          "description": "Specifies which pages this content script will be injected into. Must be specified for <code>registerContentScripts()</code>.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runAt": {
+          "allOf": [
+            {
+              "$ref": "extensionTypes#/types/RunAt"
+            },
+            {
+              "default": "document_idle",
+              "description": "Specifies when JavaScript files are injected into the web page. The preferred and default value is <code>document_idle</code>."
+            }
+          ]
+        }
+      },
+      "required": [
+        "id"
       ]
     }
   }


### PR DESCRIPTION
Fixed #4235

The updated schema data includes the following changes:

- added "noarch" to runtime.json PlatformArch enum, [Bug 1755589](https://bugzilla.mozilla.org/show_bug.cgi?id=1755589)
  (this was likely necessary because of unexpected failure while running tests on the build infrastructure, I wouldn't
  expect it to make any difference for the extensions running in a real Firefox browser instance)

- added `registerContentScripts`, `getRegisteredContentScripts` and `unregisterContentScripts` to the MV3 `scripting` API JSONSchema, [Bug 1736582](https://bugzilla.mozilla.org/show_bug.cgi?id=1736582) / [Bug 1736581](https://bugzilla.mozilla.org/show_bug.cgi?id=1736581) / [Bug 1736584](https://bugzilla.mozilla.org/show_bug.cgi?id=1736584)

NOTE: we don't expect any change in behavior from an addons-linter perspective due to this schema updates.