### PR TITLE
Feat/import firefox 100 schema data without ajv v8

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -381,6 +381,11 @@
 <td>Placeholder for message is not</td>
 </tr>
 <tr>
+<td><code>MANIFEST_FIELD_PRIVILEGEDONLY</code></td>
+<td>warning</td>
+<td>A manifest field ignored on non-privileged add-ons</td>
+</tr>
+<tr>
 <td><code>MANIFEST_FIELD_UNSUPPORTED</code></td>
 <td>warning</td>
 <td>A manifest field is not supported (or not supported for the extension manifest_version)</td>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -96,6 +96,7 @@ Rules are sorted by severity.
 | `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
 | `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
 | `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
+| `MANIFEST_FIELD_PRIVILEGEDONLY`                         | warning  | A manifest field ignored on non-privileged add-ons                                              |
 | `MANIFEST_FIELD_UNSUPPORTED`                            | warning  | A manifest field is not supported (or not supported for the extension manifest_version)         |
 | `MANIFEST_PERMISSION_UNSUPPORTED`                       | warning  | A manifest permission is not supported for the extension manifest_version                       |
 | `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -21,6 +21,19 @@ export const MANIFEST_FIELD_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_FIELD_PRIVILEGEDONLY = 'MANIFEST_FIELD_PRIVILEGEDONLY';
+export function manifestFieldPrivilegedOnly(fieldName) {
+  return {
+    code: MANIFEST_FIELD_PRIVILEGEDONLY,
+    message: i18n._(`"${fieldName}" is ignored for non-privileged add-ons.`),
+    description: i18n._(
+      oneLine`"${fieldName} manifest field is only used for privileged
+             and temporarily installed extensions.`
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
 export const MANIFEST_FIELD_UNSUPPORTED = 'MANIFEST_FIELD_UNSUPPORTED';
 export function manifestFieldUnsupported(fieldName, error) {
   const versionRange = errorParamsToUnsupportedVersionRange(error.params);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -456,6 +456,12 @@ export default class ManifestJSONParser extends JSONParser {
       this.collector.addNotice(messages.MANIFEST_UNUSED_UPDATE);
     }
 
+    if (this.parsedJSON.granted_host_permissions) {
+      this.collector.addWarning(
+        messages.manifestFieldPrivilegedOnly('granted_host_permissions')
+      );
+    }
+
     if (this.parsedJSON.background) {
       if (Array.isArray(this.parsedJSON.background.scripts)) {
         this.parsedJSON.background.scripts.forEach((script) => {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -276,6 +276,10 @@
                   },
                   "uniqueItems": true
                 },
+                "granted_host_permissions": {
+                  "type": "boolean",
+                  "default": false
+                },
                 "host_permissions": {
                   "min_manifest_version": 3,
                   "type": "array",

--- a/src/schema/imported/permissions.json
+++ b/src/schema/imported/permissions.json
@@ -1,8 +1,5 @@
 {
   "id": "permissions",
-  "permissions": [
-    "manifest:optional_permissions"
-  ],
   "functions": [
     {
       "name": "getAll",

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -34,7 +34,6 @@
   "functions": [
     {
       "name": "getBackgroundPage",
-      "max_manifest_version": 2,
       "type": "function",
       "description": "Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set.",
       "async": "callback",
@@ -472,13 +471,11 @@
     },
     {
       "name": "onSuspend",
-      "unsupported": true,
       "type": "function",
       "description": "Sent to the event page just before it is unloaded. This gives the extension opportunity to do some clean up. Note that since the page is unloading, any asynchronous operations started while handling this event are not guaranteed to complete. If more activity for the event page occurs before it gets unloaded the onSuspendCanceled event will be sent and the page won't be unloaded. "
     },
     {
       "name": "onSuspendCanceled",
-      "unsupported": true,
       "type": "function",
       "description": "Sent after onSuspend to indicate that the app won't be unloaded after all."
     },

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -170,6 +170,44 @@
           "parameters": []
         }
       ]
+    },
+    {
+      "name": "updateContentScripts",
+      "type": "function",
+      "description": "Updates one or more content scripts for this extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "scripts",
+          "type": "array",
+          "description": "Contains a list of scripts to be updated. If there are errors during script parsing/file validation, or if the IDs specified do not already exist, then no scripts are updated.",
+          "items": {
+            "$merge": {
+              "source": {
+                "$ref": "scripting#/types/RegisteredContentScript"
+              },
+              "with": {
+                "type": "object",
+                "properties": {
+                  "persistAcrossSessions": {
+                    "type": "boolean",
+                    "enum": [
+                      false
+                    ],
+                    "description": "Specifies if this content script will persist into future sessions. This is currently NOT supported."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked when scripts have been updated.",
+          "parameters": []
+        }
+      ]
     }
   ],
   "definitions": {
@@ -222,6 +260,9 @@
               "description": "Details specifying the target into which to inject the script."
             }
           ]
+        },
+        "world": {
+          "$ref": "#/types/ExecutionWorld"
         }
       },
       "required": [
@@ -331,6 +372,13 @@
         }
       }
     },
+    "ExecutionWorld": {
+      "type": "string",
+      "enum": [
+        "ISOLATED"
+      ],
+      "description": "The JavaScript world for a script to execute within. We currently only support the <code>'ISOLATED'</code> world."
+    },
     "RegisteredContentScript": {
       "type": "object",
       "properties": {
@@ -369,14 +417,28 @@
               "$ref": "extensionTypes#/types/RunAt"
             },
             {
-              "default": "document_idle",
               "description": "Specifies when JavaScript files are injected into the web page. The preferred and default value is <code>document_idle</code>."
             }
           ]
+        },
+        "persistAcrossSessions": {
+          "type": "boolean",
+          "enum": [
+            false
+          ],
+          "description": "Specifies if this content script will persist into future sessions. This is currently NOT supported."
+        },
+        "css": {
+          "type": "array",
+          "description": "The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array.",
+          "items": {
+            "$ref": "manifest#/types/ExtensionURL"
+          }
         }
       },
       "required": [
-        "id"
+        "id",
+        "persistAcrossSessions"
       ]
     }
   }

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -288,6 +288,10 @@
             "title": {
               "type": "string",
               "description": "The title used for display if the tab is created in discarded mode."
+            },
+            "muted": {
+              "type": "boolean",
+              "description": "Whether the tab should be muted when created."
             }
           }
         },

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -411,6 +411,24 @@
                 ]
               },
               "maxItems": 15
+            },
+            "color_scheme": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "light",
+                "dark",
+                "system"
+              ]
+            },
+            "content_color_scheme": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "light",
+                "dark",
+                "system"
+              ]
             }
           },
           "additionalProperties": {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -444,6 +444,32 @@ describe('ManifestJSONParser', () => {
     }
   });
 
+  describe('granted_host_permissions', () => {
+    it('warns on granted_permissions manifest key', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 2,
+        granted_host_permissions: true,
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      expect(manifestJSONParser.collector.errors).toEqual([]);
+      expect(manifestJSONParser.collector.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_FIELD_PRIVILEGEDONLY',
+            message: expect.stringMatching(
+              /"granted_host_permissions" is ignored for non-privileged add-ons/
+            ),
+          }),
+        ])
+      );
+    });
+  });
+
   describe('type', () => {
     it('should have the right type', () => {
       // Type is always returned as PACKAGE_EXTENSION presently.


### PR DESCRIPTION
Fixes #4274

The updated schema data includes the following changes:

- updates to the scripting API schema, [Bug 1736585](https://bugzilla.mozilla.org/show_bug.cgi?id=1736585) / [Bug 1759932](https://bugzilla.mozilla.org/show_bug.cgi?id=1759932) / [Bug 1755976](https://bugzilla.mozilla.org/show_bug.cgi?id=1755976) / [Bug 1758007](https://bugzilla.mozilla.org/show_bug.cgi?id=1758007)
- new theme properties to allow overriding global color scheme heuristics, [Bug 1750932](https://bugzilla.mozilla.org/show_bug.cgi?id=1750932)
- reintroduced support for `runtime.getBackgroundPage` in MV3 addons, [Bug 1759308](https://bugzilla.mozilla.org/show_bug.cgi?id=1759308)
- added `runtime.onSuspend` and `runtime.onSuspendCanceled` to the supported runtime API events, [Bug 1753850](https://bugzilla.mozilla.org/show_bug.cgi?id=1753850)
- added `muted` to the properties expected by `tabs.create`, [Bug 1372100](https://bugzilla.mozilla.org/show_bug.cgi?id=1372100)
- `granted_host_permission` manifest property, [Bug 1745818](https://bugzilla.mozilla.org/show_bug.cgi?id=1745818)

It looks that the `granted_host_permission` manifest property is ignored on non-privileged add-ons (unless installed temporarily) and so in a separate commit I also added a new validation warning with code `"MANIFEST_FIELD_PRIVILEGEDONLY"` when that manifest property is found in a manifest.

As a side note:
- I have also prepared another branch with the same set of changes included in this PR but built on top of the ajv v8 PR #4263 (https://github.com/rpl/addons-linter/tree/feat/import-firefox-100-schema-data-with-ajv-v8), we may opt to replace this PR with a new one created from that alternative branch if we manage to review and merge #4263 right before this one.