### PR TITLE
Require extension ID for MV3+

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -570,6 +570,11 @@
 <td>error</td>
 <td>A permission requires &quot;strict_min_version&quot; to be set to a specific Firefox version</td>
 </tr>
+<tr>
+<td><code>EXTENSION_ID_REQUIRED</code></td>
+<td>error</td>
+<td>The extension ID is mandatory for Manifest Version 3 (and above) extensions.</td>
+</tr>
 </tbody>
 </table>
 <h3 id="static-theme-%2F-manifest.json" tabindex="-1">Static Theme / manifest.json <a class="header-anchor" href="#static-theme-%2F-manifest.json">¶</a></h3>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -134,6 +134,7 @@ Rules are sorted by severity.
 | `IGNORED_APPLICATIONS_PROPERTY`                         | warning  | Usage of both `applications` and `browser_specific_settings` properties                         |
 | `RESTRICTED_HOMEPAGE_URL`                               | error    | Linking to addons.mozilla.org in `homepage_url` or `developer.url` is not allowed               |
 | `RESTRICTED_PERMISSION`                                 | error    | A permission requires "strict_min_version" to be set to a specific Firefox version              |
+| `EXTENSION_ID_REQUIRED`                                 | error    | The extension ID is mandatory for Manifest Version 3 (and above) extensions.                    |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -665,3 +665,14 @@ export const makeRestrictedPermission = (permission, minFirefoxVersion) => {
     file: MANIFEST_JSON,
   };
 };
+
+export const EXTENSION_ID_REQUIRED = {
+  code: 'EXTENSION_ID_REQUIRED',
+  message: i18n._(
+    'The extension ID is required in Manifest Version 3 and above.'
+  ),
+  description: i18n._(
+    'See https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/ for more information.'
+  ),
+  file: MANIFEST_JSON,
+};

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -669,6 +669,7 @@ export default class ManifestJSONParser extends JSONParser {
     }
 
     this.validateRestrictedPermissions();
+    this.validateExtensionID();
   }
 
   validateRestrictedPermissions() {
@@ -698,6 +699,17 @@ export default class ManifestJSONParser extends JSONParser {
           this.isValid = false;
         }
       }
+    }
+  }
+
+  validateExtensionID() {
+    if (this.parsedJSON.manifest_version < 3) {
+      return;
+    }
+
+    if (!this.parsedJSON.applications?.gecko?.id) {
+      this.collector.addError(messages.EXTENSION_ID_REQUIRED);
+      this.isValid = false;
     }
   }
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -177,6 +177,36 @@ describe('ManifestJSONParser', () => {
       const metadata = manifestJSONParser.getMetadata();
       expect(metadata.id).toEqual(null);
     });
+
+    it('is optional in MV2', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 2,
+        browser_specific_settings: { gecko: {} },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      expect(manifestJSONParser.isValid).toEqual(true);
+    });
+
+    it('should be mandatory in MV3', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        browser_specific_settings: { gecko: {} },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      expect(manifestJSONParser.isValid).toEqual(false);
+      assertHasMatchingError(
+        addonLinter.collector.errors,
+        messages.EXTENSION_ID_REQUIRED
+      );
+    });
   });
 
   describe('manifestVersion', () => {
@@ -1166,7 +1196,7 @@ describe('ManifestJSONParser', () => {
           applications: {
             // The new content_security_policy syntax is only supported
             // on Firefox >= 72.
-            gecko: { strict_min_version: '72.0' },
+            gecko: { strict_min_version: '72.0', id: 'some@id' },
           },
         });
 
@@ -1241,7 +1271,7 @@ describe('ManifestJSONParser', () => {
           applications: {
             // The new content_security_policy syntax is only supported
             // on Firefox >= 72.
-            gecko: { strict_min_version: '72.0' },
+            gecko: { strict_min_version: '72.0', id: 'some@id' },
           },
         });
 
@@ -1295,7 +1325,7 @@ describe('ManifestJSONParser', () => {
         applications: {
           // The new content_security_policy syntax is only supported
           // on Firefox >= 72.
-          gecko: { strict_min_version: '72.0' },
+          gecko: { strict_min_version: '72.0', id: 'some@id' },
         },
       });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/4303

---

I couldn't use the schema because it is MV3+ only and it was easier to introduce another method.

The link to the EW page is also mentioned in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings so I thought it'd make sense to use that as well. We'll probably want to add a notice for this new MV3+ requirement, see: https://github.com/mozilla/extension-workshop/issues/1310.