### PR TITLE
feat: Imported Firefox 101 API schema

### DIFF
--- a/src/schema/imported/content_scripts.json
+++ b/src/schema/imported/content_scripts.json
@@ -1,5 +1,6 @@
 {
   "$id": "contentScripts",
+  "max_manifest_version": 2,
   "functions": [
     {
       "name": "register",

--- a/src/schema/imported/context_menus.json
+++ b/src/schema/imported/context_menus.json
@@ -84,6 +84,7 @@
             },
             "onclick": {
               "type": "function",
+              "max_manifest_version": 2,
               "description": "A function that will be called back when the menu item is clicked. Event pages cannot use this; instead, they should register a listener for $(ref:contextMenus.onClicked).",
               "parameters": [
                 {
@@ -238,6 +239,7 @@
             },
             "onclick": {
               "type": "function",
+              "max_manifest_version": 2,
               "parameters": [
                 {
                   "allOf": [

--- a/src/schema/imported/extension.json
+++ b/src/schema/imported/extension.json
@@ -104,7 +104,6 @@
     {
       "name": "getBackgroundPage",
       "type": "function",
-      "max_manifest_version": 2,
       "description": "Returns the JavaScript 'window' object for the background page running inside the current extension. Returns null if the extension has no background page.",
       "parameters": [],
       "returns": {

--- a/src/schema/imported/menus.json
+++ b/src/schema/imported/menus.json
@@ -83,6 +83,7 @@
             },
             "onclick": {
               "type": "function",
+              "max_manifest_version": 2,
               "description": "A function that will be called back when the menu item is clicked. Event pages cannot use this; instead, they should register a listener for $(ref:contextMenus.onClicked).",
               "parameters": [
                 {
@@ -237,6 +238,7 @@
             },
             "onclick": {
               "type": "function",
+              "max_manifest_version": 2,
               "parameters": [
                 {
                   "allOf": [

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -263,6 +263,10 @@
         },
         "world": {
           "$ref": "#/types/ExecutionWorld"
+        },
+        "injectImmediately": {
+          "type": "boolean",
+          "description": "Whether the injection should be triggered in the target as soon as possible (but not necessarily prior to page load)."
         }
       },
       "required": [

--- a/src/schema/imported/storage.json
+++ b/src/schema/imported/storage.json
@@ -281,6 +281,23 @@
             }
           ]
         }
+      ],
+      "events": [
+        {
+          "name": "onChanged",
+          "type": "function",
+          "description": "Fired when one or more items change.",
+          "parameters": [
+            {
+              "name": "changes",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/types/StorageChange"
+              },
+              "description": "Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item."
+            }
+          ]
+        }
       ]
     },
     "StorageAreaSync": {
@@ -427,6 +444,23 @@
               "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
               "parameters": [],
               "optional": true
+            }
+          ]
+        }
+      ],
+      "events": [
+        {
+          "name": "onChanged",
+          "type": "function",
+          "description": "Fired when one or more items change.",
+          "parameters": [
+            {
+              "name": "changes",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/types/StorageChange"
+              },
+              "description": "Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item."
             }
           ]
         }

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -101,34 +101,6 @@
       }
     },
     {
-      "name": "sendRequest",
-      "deprecated": "Please use $(ref:runtime.sendMessage).",
-      "unsupported": true,
-      "type": "function",
-      "description": "Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:extension.onRequest) event is fired in each content script running in the specified tab for the current extension.",
-      "parameters": [
-        {
-          "type": "integer",
-          "name": "tabId",
-          "minimum": 0
-        },
-        {
-          "name": "request"
-        },
-        {
-          "type": "function",
-          "name": "responseCallback",
-          "optional": true,
-          "parameters": [
-            {
-              "name": "response",
-              "description": "The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message."
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "sendMessage",
       "type": "function",
       "description": "Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:runtime.onMessage) event is fired in each content script running in the specified tab for the current extension.",
@@ -168,69 +140,6 @@
       ]
     },
     {
-      "name": "getSelected",
-      "deprecated": "Please use $(ref:tabs.query) <code>{active: true}</code>.",
-      "unsupported": true,
-      "type": "function",
-      "description": "Gets the tab that is selected in the specified window.",
-      "async": "callback",
-      "parameters": [
-        {
-          "type": "integer",
-          "name": "windowId",
-          "minimum": -2,
-          "optional": true,
-          "description": "Defaults to the $(topic:current-window)[current window]."
-        },
-        {
-          "type": "function",
-          "name": "callback",
-          "parameters": [
-            {
-              "allOf": [
-                {
-                  "$ref": "#/types/Tab"
-                },
-                {
-                  "name": "tab"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "getAllInWindow",
-      "deprecated": "Please use $(ref:tabs.query) <code>{windowId: windowId}</code>.",
-      "unsupported": true,
-      "type": "function",
-      "description": "Gets details about all tabs in the specified window.",
-      "async": "callback",
-      "parameters": [
-        {
-          "type": "integer",
-          "name": "windowId",
-          "minimum": -2,
-          "optional": true,
-          "description": "Defaults to the $(topic:current-window)[current window]."
-        },
-        {
-          "type": "function",
-          "name": "callback",
-          "parameters": [
-            {
-              "name": "tabs",
-              "type": "array",
-              "items": {
-                "$ref": "#/types/Tab"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "create",
       "type": "function",
       "description": "Creates a new tab.",
@@ -257,12 +166,6 @@
             "active": {
               "type": "boolean",
               "description": "Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see $(ref:windows.update)). Defaults to <var>true</var>."
-            },
-            "selected": {
-              "deprecated": "Please use <em>active</em>.",
-              "unsupported": true,
-              "type": "boolean",
-              "description": "Whether the tab should become the selected tab in the window. Defaults to <var>true</var>"
             },
             "pinned": {
               "type": "boolean",
@@ -611,12 +514,6 @@
               "type": "boolean",
               "description": "Adds or removes the tab from the current selection."
             },
-            "selected": {
-              "unsupported": true,
-              "deprecated": "Please use <em>highlighted</em>.",
-              "type": "boolean",
-              "description": "Whether the tab should be selected."
-            },
             "pinned": {
               "type": "boolean",
               "description": "Whether the tab should be pinned."
@@ -944,6 +841,7 @@
     {
       "name": "executeScript",
       "type": "function",
+      "max_manifest_version": 2,
       "description": "Injects JavaScript code into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
       "async": "callback",
       "parameters": [
@@ -985,6 +883,7 @@
     {
       "name": "insertCSS",
       "type": "function",
+      "max_manifest_version": 2,
       "description": "Injects CSS into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
       "async": "callback",
       "parameters": [
@@ -1018,6 +917,7 @@
     {
       "name": "removeCSS",
       "type": "function",
+      "max_manifest_version": 2,
       "description": "Removes injected CSS from a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
       "async": "callback",
       "parameters": [
@@ -1531,64 +1431,6 @@
       ]
     },
     {
-      "name": "onSelectionChanged",
-      "deprecated": "Please use $(ref:tabs.onActivated).",
-      "unsupported": true,
-      "type": "function",
-      "description": "Fires when the selected tab in a window changes.",
-      "parameters": [
-        {
-          "type": "integer",
-          "name": "tabId",
-          "minimum": 0,
-          "description": "The ID of the tab that has become active."
-        },
-        {
-          "type": "object",
-          "name": "selectInfo",
-          "properties": {
-            "windowId": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "The ID of the window the selected tab changed inside of."
-            }
-          },
-          "required": [
-            "windowId"
-          ]
-        }
-      ]
-    },
-    {
-      "name": "onActiveChanged",
-      "deprecated": "Please use $(ref:tabs.onActivated).",
-      "unsupported": true,
-      "type": "function",
-      "description": "Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to $(ref:tabs.onUpdated) events to be notified when a URL is set.",
-      "parameters": [
-        {
-          "type": "integer",
-          "name": "tabId",
-          "minimum": 0,
-          "description": "The ID of the tab that has become active."
-        },
-        {
-          "type": "object",
-          "name": "selectInfo",
-          "properties": {
-            "windowId": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "The ID of the window the selected tab changed inside of."
-            }
-          },
-          "required": [
-            "windowId"
-          ]
-        }
-      ]
-    },
-    {
       "name": "onActivated",
       "type": "function",
       "description": "Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.",
@@ -1616,38 +1458,6 @@
           "required": [
             "tabId",
             "windowId"
-          ]
-        }
-      ]
-    },
-    {
-      "name": "onHighlightChanged",
-      "deprecated": "Please use $(ref:tabs.onHighlighted).",
-      "unsupported": true,
-      "type": "function",
-      "description": "Fired when the highlighted or selected tabs in a window changes.",
-      "parameters": [
-        {
-          "type": "object",
-          "name": "selectInfo",
-          "properties": {
-            "windowId": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "The window whose tabs changed."
-            },
-            "tabIds": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "description": "All highlighted tabs in the window."
-            }
-          },
-          "required": [
-            "windowId",
-            "tabIds"
           ]
         }
       ]
@@ -1947,12 +1757,6 @@
           "minimum": 0,
           "description": "The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists."
         },
-        "selected": {
-          "type": "boolean",
-          "description": "Whether the tab is selected.",
-          "deprecated": "Please use $(ref:tabs.Tab.highlighted).",
-          "unsupported": true
-        },
         "highlighted": {
           "type": "boolean",
           "description": "Whether the tab is highlighted. Works as an alias of active"
@@ -2066,7 +1870,6 @@
       },
       "required": [
         "index",
-        "selected",
         "highlighted",
         "active",
         "pinned",

--- a/src/schema/imported/userScripts.json
+++ b/src/schema/imported/userScripts.json
@@ -1,5 +1,6 @@
 {
   "$id": "userScripts",
+  "max_manifest_version": 2,
   "permissions": [
     "manifest:user_scripts"
   ],
@@ -28,6 +29,7 @@
       "properties": {
         "user_scripts": {
           "type": "object",
+          "max_manifest_version": 2,
           "properties": {
             "api_script": {
               "$ref": "manifest#/types/ExtensionURL"


### PR DESCRIPTION
Fixes #4317 

The updated schema data includes the following changes:
- [Bug 1764566](https://bugzilla.mozilla.org/show_bug.cgi?id=1764566)
  - added `max_manifest_version: 2` on APIs which are not meant to be available in "manifest_version: 3" extensions (contentScrips / userScripts API namespaces and a subset of the tabs API, all replaced with the scripting API in MV3)
  -  removal from the schema of APIs and manifest properties never supported and fully deprecated in "manifest_version: 3"
- [Bug 1761814](https://bugzilla.mozilla.org/show_bug.cgi?id=1761814) `max_manifest_version: 2` set on menus API onclick callback (which can't be used with event pages)
- Bug [1762366](https://bugzilla.mozilla.org/show_bug.cgi?id=1762366) - Added `injectImmediately` to the options supported by `scripting.executeScripting`
- Bug [1758475](https://bugzilla.mozilla.org/show_bug.cgi?id=1758475) - Added the onChanged event to the StorageArea sub-namespaces (`storage.local` and `storage.sync`)

NOTE: we don't expect any change in behavior from an addons-linter perspective due to this schema updates.