### PR TITLE
Add a new --privileged CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ The addons-linter will check your add-on and show you errors, warnings, and frie
 addons-linter --help
 ```
 
+#### Privileged extensions
+
+The addons-linter can lint privileged extensions **only** when the `--privileged` option is passed to it. This option changes the behavior of the linter to:
+
+1. emit errors when the input file (or directory) is a regular extension (i.e. the extension does not use privileged features)
+2. hide messages related to privileged features (e.g., permissions and properties) when the input file (or directory) is a privileged extension
+
 ### Linter API Usage
 
 You can use the linter directly as a library to integrate it better into your development process.

--- a/src/yargs-options.js
+++ b/src/yargs-options.js
@@ -6,7 +6,7 @@ const options = {
     choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
   },
   'warnings-as-errors': {
-    describe: 'Treat warning as errors',
+    describe: 'Treat warnings as errors',
     type: 'boolean',
     default: false,
   },
@@ -33,12 +33,17 @@ const options = {
     default: false,
   },
   boring: {
-    describe: 'Disables colorful shell output',
+    describe: 'Disable colorful shell output',
+    type: 'boolean',
+    default: false,
+  },
+  privileged: {
+    describe: 'Treat the input file (or directory) as a privileged extension',
     type: 'boolean',
     default: false,
   },
   'self-hosted': {
-    describe: 'Disables messages related to hosting on addons.mozilla.org.',
+    describe: 'Disable messages related to hosting on addons.mozilla.org',
     type: 'boolean',
     default: false,
   },

--- a/tests/test.yargs-options.js
+++ b/tests/test.yargs-options.js
@@ -3,6 +3,7 @@ import { getDefaultConfigValue } from 'yargs-options';
 describe('getDefaultConfigValue()', () => {
   it('should return the default value', () => {
     expect(getDefaultConfigValue('self-hosted')).toEqual(false);
+    expect(getDefaultConfigValue('privileged')).toEqual(false);
   });
 
   it('should return undefined for unknown option', () => {


### PR DESCRIPTION
Fixes #4324

---

This PR adds a new CLI flag that does not do anything (so far, see: #https://github.com/mozilla/addons-linter/issues/4306).  (I also fixed typos)