### PR TITLE
feat: allow 'wasm-unsafe-eval' keyword

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -202,7 +202,7 @@ export const TEMPORARY_APIS = [
 // See https://mzl.la/2vwqbGU for more details and allowed options.
 export const CSP_KEYWORD_RE = new RegExp(
   [
-    '(self|none|unsafe-inline|strict-dynamic|unsafe-hashed-attributes)',
+    '(self|none|unsafe-inline|strict-dynamic|unsafe-hashed-attributes|wasm-unsafe-eval)',
     // Only match these keywords, anything else is forbidden
     '(?!.)',
     '|(sha(256|384|512)-|nonce-)',

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1456,12 +1456,22 @@ describe('ManifestJSONParser', () => {
         // forseeable future. See http://bit.ly/2wG6LP0 for more details-
         "script-src 'self' 'unsafe-inline';",
 
+        // 'wasm-unsafe-eval' is permitted, despite the unsafe-eval substring.
+        "script-src 'self' 'wasm-unsafe-eval'",
+
         // 'default-src' is insecure, but the limiting 'script-src' prevents
         // remote script injection
         "default-src *; script-src 'self'",
         "default-src https:; script-src 'self'",
         "default-src example.com; script-src 'self'",
         "default-src http://remote.com/; script-src 'self'",
+
+        // In theory, script-src should override default-src, and the insecure
+        // 'unsafe-eval' directive should be ignored. But the implementation
+        // rejects 'unsafe-eval' unconditionally, despite the script-src
+        // override. So this test case fails with MANIFEST_CSP_UNSAFE_EVAL.
+        // See https://github.com/mozilla/addons-linter/pull/4345#discussion_r881860151
+        // "script-src 'wasm-unsafe-eval'; default-src 'unsafe-eval'",
       ];
 
       validValues.forEach((validValue) => {


### PR DESCRIPTION
Fixes #4343
