### PR TITLE
Add minProperties to experiment_apis in schema

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -250,6 +250,7 @@ export const SCHEMA_KEYWORDS = {
   DEPRECATED: 'deprecated',
   REQUIRED: 'required',
   TYPE: 'type',
+  MIN_PROPERTIES: 'minProperties',
   // Non-standard JSONSchema keywords (defined and used by the Firefox and/or addons-linter).
   ...SCHEMA_KEYWORDS_CUSTOM,
 };

--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -31,6 +31,8 @@ const UNRECOGNIZED_PROPERTY_REFS = [
   'manifest#/types/UnrecognizedProperty',
 ];
 
+const SKIP_SCHEMAS = ['native_host_manifest.json'];
+
 const schemaRegexes = [
   // eslint-disable-next-line prefer-regex-literals
   new RegExp('browser/components/extensions/schemas/.*\\.json'),
@@ -627,8 +629,6 @@ export function processSchemas(schemas) {
   // $extend to $ref.
   return inner.mapExtendToRef(mergedSchemasByNamespace);
 }
-
-const SKIP_SCHEMAS = ['native_host_manifest.json'];
 
 function readSchema(basePath, file) {
   return commentJson.parse(

--- a/src/schema/imported/experiments.json
+++ b/src/schema/imported/experiments.json
@@ -16,6 +16,7 @@
           "additionalProperties": {
             "$ref": "experiments#/types/ExperimentAPI"
           },
+          "minProperties": 1,
           "privileged": true
         }
       }

--- a/src/schema/updates/experiments.json
+++ b/src/schema/updates/experiments.json
@@ -1,0 +1,13 @@
+{
+  "experiments": {
+    "definitions": {
+      "WebExtensionManifest": {
+        "properties": {
+          "experiment_apis": {
+            "minProperties": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/schema/test.experiments.js
+++ b/tests/unit/schema/test.experiments.js
@@ -1,0 +1,28 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import { SCHEMA_KEYWORDS } from 'const';
+import { validateAddon } from 'schema/validator';
+
+import { validManifest } from './helpers';
+
+describe('experiments', () => {
+  describe('/experiment_apis', () => {
+    it('should emit an error when experiment_apis does not have any properties', () => {
+      const manifest = {
+        ...cloneDeep(validManifest),
+        experiment_apis: {},
+      };
+
+      validateAddon(manifest);
+
+      expect(validateAddon.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/experiment_apis',
+            keyword: SCHEMA_KEYWORDS.MIN_PROPERTIES,
+          }),
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/4365

---

With privileged flag:

```
$ ./bin/addons-linter ../test-ext --privileged
Validation Summary:

errors          4
notices         0
warnings        0

ERRORS:

Code                                 Message                          Description                                                     File            Line   Column
JSON_INVALID                         "/manifest_version" must be <=   Your JSON file could not be parsed.
                                     2
PRIVILEGED_FEATURES_REQUIRED         /permissions: Privileged         This extension does not declare any privileged permission. It   manifest.json
                                     extensions should declare        does not need to be signed with the privileged certificate.
                                     privileged permissions.          Please upload it directly to https://addons.mozilla.org/.
MOZILLA_ADDONS_PERMISSION_REQUIRED   /experiment_apis: The            /experiment_apis: The "mozillaAddons" permission is required    manifest.json
                                     "mozillaAddons" permission is    for extensions that include privileged manifest fields.
                                     required for extensions that
                                     include privileged manifest
                                     fields.
JSON_INVALID                         "/experiment_apis" must NOT      Your JSON file could not be parsed.
                                     have fewer than 1 properties
```

Without privileged flag:

```
$ ./bin/addons-linter ../test-ext
Validation Summary:

errors          3
notices         0
warnings        0

ERRORS:

Code                        Message                          Description                                                   File            Line   Column
JSON_INVALID                "/manifest_version" must be <=   Your JSON file could not be parsed.
                            2
MANIFEST_FIELD_PRIVILEGED   /experiment_apis: privileged     Please refer to                                               manifest.json
                            manifest fields are only         https://github.com/mozilla-extensions/xpi-manifest to learn
                            allowed in privileged            more about privileged extensions and signing.
                            extensions.
JSON_INVALID                "/experiment_apis" must NOT      Your JSON file could not be parsed.
                            have fewer than 1 properties

```