### PR TITLE
feat: Imported Firefox 102.0b8 API schema

### DIFF
--- a/src/schema/imported/privacy.json
+++ b/src/schema/imported/privacy.json
@@ -297,7 +297,8 @@
         "nonPersistentCookies": {
           "type": "boolean",
           "default": false,
-          "description": "Whether to create all cookies as nonPersistent (i.e., session) cookies."
+          "description": "Whether to create all cookies as nonPersistent (i.e., session) cookies.",
+          "deprecated": "This property has no effect anymore and its value is always <code>false<code>."
         }
       }
     }

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -4,7 +4,6 @@
   "permissions": [
     "scripting"
   ],
-  "min_manifest_version": 3,
   "functions": [
     {
       "name": "executeScript",
@@ -217,8 +216,7 @@
           "type": "string",
           "enum": [
             "scripting"
-          ],
-          "min_manifest_version": 3
+          ]
         }
       ]
     }


### PR DESCRIPTION
Fixes #4371 

The updated schema data includes the following remaining changes ("remaining" because we imported the subset of changes applied in Firefox 102 as an internal JSONSchema data refactoring which we imported as part of #4307):

- [Bug 1766615](https://bugzilla.mozilla.org/show_bug.cgi?id=1766615), enabling `scripting` API namespace also to "manifest_version 2" extensions
- Bug [1754924](https://bugzilla.mozilla.org/show_bug.cgi?id=1754924), deprecating `nonPersistentCookies` option from the `privacy.websites.cookieConfig` API. 

NOTE: we don't expect any change in behavior from an addons-linter perspective due to this schema updates.