### PR TITLE
fix: Prevent mv3 permissions errors to be wrongly reported in mv2 addon validation

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -235,31 +235,6 @@ export default class ManifestJSONParser extends JSONParser {
   }
 
   errorLookup(error) {
-    if (
-      error.instancePath === '/permissions' &&
-      error.keyword === SCHEMA_KEYWORDS.ANY_OF
-    ) {
-      // With the addition of the schema data for the manifest_version 3
-      // JSONSchema data, permissions has a top level anyOf schema entry
-      // which include the two alternative set of schema definitions
-      // for manifest_version 2 and manifest_version 3, which will produce
-      // one more validation error in addition to the ones reported by the
-      // manifest_version based entries included into it.
-      //
-      // The validation results from the nested entries are being already reported
-      // before the top level anyOf one and so we can ignore this redundant validation
-      // error.
-      const isManifestVersionAnyOf =
-        error.schema &&
-        error.schema.every(
-          (schema) =>
-            'min_manifest_version' in schema || 'max_manifest_version' in schema
-        );
-      if (isManifestVersionAnyOf) {
-        return null;
-      }
-    }
-
     // This is the default message.
     let baseObject = messages.JSON_INVALID;
 

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -153,8 +153,6 @@ function getManifestVersionsRange(validatorOptions) {
       ? getDefaultConfigValue('max-manifest-version')
       : maxManifestVersion;
 
-  const addon = addonManifestVersion == null ? minimum : addonManifestVersion;
-
   // Make sure the version range is valid, if it is not:
   // raise an explicit error.
   if (minimum > maximum) {
@@ -166,7 +164,10 @@ function getManifestVersionsRange(validatorOptions) {
     );
   }
 
-  return { minimum, maximum, addon };
+  const currentAddon =
+    addonManifestVersion == null ? minimum : addonManifestVersion;
+
+  return { minimum, maximum, currentAddon };
 }
 
 export class SchemaValidator {
@@ -412,7 +413,8 @@ export class SchemaValidator {
   }
 
   _compileAddonValidator(validator) {
-    const { minimum, addon, maximum } = this.allowedManifestVersionsRange;
+    const { minimum, currentAddon, maximum } =
+      this.allowedManifestVersionsRange;
 
     const replacer = (key, value) => {
       if (Array.isArray(value)) {
@@ -425,7 +427,7 @@ export class SchemaValidator {
             includeItem =
               item.min_manifest_version >= minimum &&
               item.min_manifest_version <= maximum &&
-              item.min_manifest_version <= addon;
+              item.min_manifest_version <= currentAddon;
           }
           if (
             item?.max_manifest_version &&
@@ -434,7 +436,7 @@ export class SchemaValidator {
             includeItem =
               item.max_manifest_version >= minimum &&
               item.max_manifest_version <= maximum &&
-              item.max_manifest_version >= addon;
+              item.max_manifest_version >= currentAddon;
           }
 
           return includeItem;
@@ -444,7 +446,7 @@ export class SchemaValidator {
       return value;
     };
 
-    // Omit from the manifest schema data all entries that includes a
+    // Omit from the manifest schema data all entries that include a
     // min/max_manifest_version which is outside of the minimum
     // and maximum manifest_version currently allowed per validator
     // config and if they do not apply to the addon manifest_version.
@@ -568,7 +570,7 @@ export class SchemaValidator {
 
         if (!res) {
           // If the addon manifest is out of an enum values min/max manifest version range,
-          // don't report an additional validation error for the mix/max_manifest_version
+          // don't report an additional validation error for the min/max_manifest_version
           // keyword validation function.
           if (schema.enum) {
             return true;

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -87,7 +87,7 @@ function isRelevantError({
   if (error.keyword === 'anyOf') {
     const anyOfSchemaEntries = error.schema?.filter((schema) => {
       const min = schema.min_manifest_version ?? minimum;
-      const max = schema.mix_manifest_version ?? maximum;
+      const max = schema.max_manifest_version ?? maximum;
 
       return manifest_version >= min && manifest_version <= max;
     });

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1427,6 +1427,49 @@ describe('ManifestJSONParser', () => {
       );
     });
 
+    it('should not add a warning on valid host permission if a permission is invalid', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        applications: {
+          gecko: {
+            strict_min_version: '56.0',
+          },
+        },
+        permissions: ['SOME_INVALID_PERMISSION', 'http://example.com/*'],
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        {
+          schemaValidatorOptions: {
+            minManifestVersion: 2,
+            maxManifestVersion: 3,
+          },
+        }
+      );
+      expect(addonLinter.collector.errors).toEqual([]);
+      expect(addonLinter.collector.notices).toEqual([]);
+      // SOME_INVALID_PERMISSION should be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/0',
+          }),
+        ])
+      );
+      // http://example.com/* should NOT be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/1',
+          }),
+        ])
+      );
+      expect(manifestJSONParser.isValid).toEqual(false);
+    });
+
     it('should add a notice on unsupported permissions on android', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -528,6 +528,89 @@ describe('ManifestJSONParser', () => {
       );
       expect(manifestJSONParser.collector.errors).toEqual([]);
     });
+
+    it('should not add a warning on valid host permission if a permission is invalid', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        permissions: ['SOME_INVALID_PERMISSION', 'http://example.com/*'],
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        {
+          schemaValidatorOptions: {
+            minManifestVersion: 2,
+            maxManifestVersion: 3,
+          },
+        }
+      );
+      expect(addonLinter.collector.errors).toEqual([]);
+      expect(addonLinter.collector.notices).toEqual([]);
+      // SOME_INVALID_PERMISSION should be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/0',
+          }),
+        ])
+      );
+      // http://example.com/* should NOT be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/1',
+          }),
+        ])
+      );
+      expect(manifestJSONParser.isValid).toEqual(false);
+
+      // Confirm that the unexpected origin is reported as a validation
+      // error if the extension is a manifest version 3 extension.
+      const jsonv3 = validManifestJSON({
+        manifest_version: 3,
+        applications: {
+          gecko: {
+            id: 'test@extension',
+            strict_min_version: '56.0',
+          },
+        },
+        permissions: ['SOME_INVALID_PERMISSION', 'http://example.com/*'],
+      });
+
+      const manifestJSONParserV3 = new ManifestJSONParser(
+        jsonv3,
+        addonLinter.collector,
+        {
+          schemaValidatorOptions: {
+            minManifestVersion: 2,
+            maxManifestVersion: 3,
+          },
+        }
+      );
+      expect(addonLinter.collector.errors).toEqual([]);
+      expect(addonLinter.collector.notices).toEqual([]);
+      // SOME_INVALID_PERMISSION should still be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/0',
+          }),
+        ])
+      );
+      // http://example.com/* should also be reported as invalid.
+      expect(addonLinter.collector.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MANIFEST_PERMISSIONS',
+            instancePath: '/permissions/1',
+          }),
+        ])
+      );
+      expect(manifestJSONParserV3.isValid).toEqual(false);
+    });
   });
 
   describe('bad permissions', () => {
@@ -1425,49 +1508,6 @@ describe('ManifestJSONParser', () => {
       expect(addonLinter.collector.notices[0].code).toEqual(
         messages.PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION
       );
-    });
-
-    it('should not add a warning on valid host permission if a permission is invalid', () => {
-      const addonLinter = new Linter({ _: ['bar'] });
-      const json = validManifestJSON({
-        applications: {
-          gecko: {
-            strict_min_version: '56.0',
-          },
-        },
-        permissions: ['SOME_INVALID_PERMISSION', 'http://example.com/*'],
-      });
-      const manifestJSONParser = new ManifestJSONParser(
-        json,
-        addonLinter.collector,
-        {
-          schemaValidatorOptions: {
-            minManifestVersion: 2,
-            maxManifestVersion: 3,
-          },
-        }
-      );
-      expect(addonLinter.collector.errors).toEqual([]);
-      expect(addonLinter.collector.notices).toEqual([]);
-      // SOME_INVALID_PERMISSION should be reported as invalid.
-      expect(addonLinter.collector.warnings).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            code: 'MANIFEST_PERMISSIONS',
-            instancePath: '/permissions/0',
-          }),
-        ])
-      );
-      // http://example.com/* should NOT be reported as invalid.
-      expect(addonLinter.collector.warnings).toEqual(
-        expect.not.arrayContaining([
-          expect.objectContaining({
-            code: 'MANIFEST_PERMISSIONS',
-            instancePath: '/permissions/1',
-          }),
-        ])
-      );
-      expect(manifestJSONParser.isValid).toEqual(false);
     });
 
     it('should add a notice on unsupported permissions on android', () => {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -570,7 +570,7 @@ describe('ManifestJSONParser', () => {
       // error if the extension is a manifest version 3 extension.
       const jsonv3 = validManifestJSON({
         manifest_version: 3,
-        applications: {
+        browser_specific_settings: {
           gecko: {
             id: 'test@extension',
             strict_min_version: '56.0',

--- a/tests/unit/schema/test.schema.js
+++ b/tests/unit/schema/test.schema.js
@@ -226,7 +226,7 @@ describe('Schema JSON', () => {
         ])
       );
 
-      // Errors for values in the fantary_api enum restricted to MV1 and MV3 should not be reported.
+      // Errors for values in the fantasy_api enum restricted to MV1 and MV3 should not be reported.
       expect(validateAddon.errors).toEqual(
         expect.not.arrayContaining([
           expect.objectContaining({
@@ -253,7 +253,7 @@ describe('Schema JSON', () => {
         ])
       );
 
-      // Errors for values in the fantary_api enum supported by MV2 should be reported.
+      // Errors for values in the fantasy_api enum supported by MV2 should be reported.
       expect(validateAddon.errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -294,7 +294,7 @@ describe('Schema JSON', () => {
         ])
       );
 
-      // Errors for values in the fantary_api enum restricted to MV1 and MV2 should not be reported.
+      // Errors for values in the fantasy_api enum restricted to MV1 and MV2 should not be reported.
       expect(validateAddon.errors).toEqual(
         expect.not.arrayContaining([
           expect.objectContaining({
@@ -321,7 +321,7 @@ describe('Schema JSON', () => {
         ])
       );
 
-      // Errors for values in the fantary_api enum supported by MV3 should be reported.
+      // Errors for values in the fantasy_api enum supported by MV3 should be reported.
       expect(validateAddon.errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/tests/unit/schema/test.schema.js
+++ b/tests/unit/schema/test.schema.js
@@ -123,21 +123,75 @@ describe('Schema JSON', () => {
       expect(isValidMV3).toBe(true);
     });
 
-    it('does report a validation error on max_manifest_version', () => {
+    it('does not report errors if addon manifest_version > error max_manifest_version', () => {
       // Create a validator with custom fake schema that
       // contains a `page_action` manifest property only supported
       // for manifest_version 2 extensions
       const validator = getValidatorWithFakeSchema({
         maxManifestVersion: 3,
         apiSchemas: {
-          page_action: {
-            $id: 'page_action',
+          browser_action: {
+            $id: 'browser_action',
             definitions: {
               WebExtensionManifest: {
                 properties: {
-                  page_action: {
-                    max_manifest_version: 2,
+                  browser_action: {
                     type: 'object',
+                    properties: {
+                      popup: {
+                        max_manifest_version: 2,
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          fantasy_api: {
+            $id: 'fantasy_api',
+            definitions: {
+              WebExtensionManifest: {
+                properties: {
+                  fantasy_api: {
+                    optional: true,
+                    type: 'object',
+                    properties: {
+                      fantasy_key: {
+                        anyOf: [
+                          {
+                            type: 'string',
+                            enum: ['fantasy_value01'],
+                            max_manifest_version: 1,
+                          },
+                          {
+                            type: 'string',
+                            enum: ['fantasy_value02'],
+                            max_manifest_version: 2,
+                          },
+                          {
+                            type: 'string',
+                            enum: ['fantasy_value03'],
+                            min_manifest_version: 3,
+                            max_manifest_version: 3,
+                          },
+                        ],
+                      },
+                      fantasy_key_obsolete: {
+                        anyOf: [
+                          {
+                            type: 'string',
+                            enum: ['fantasy_obsolete'],
+                            max_manifest_version: 1,
+                          },
+                          {
+                            type: 'string',
+                            enum: ['fantasy_obsolete02'],
+                            max_manifest_version: 1,
+                          },
+                        ],
+                      },
+                    },
                   },
                 },
               },
@@ -146,33 +200,138 @@ describe('Schema JSON', () => {
         },
       });
 
-      const isValidMV2 = validator.validateAddon({
-        ...validManifest,
-        // Add properties that are expected to be valid
-        // with manifest_version 2.
-        manifest_version: 2,
-        page_action: {},
-      });
-      expect(validator.validateAddon.errors).toEqual(null);
-      expect(isValidMV2).toBe(true);
+      const isValidMV2 = validateAddon(
+        {
+          ...validManifest,
+          // Add properties that are expected to be valid
+          // with manifest_version 2.
+          manifest_version: 2,
+          browser_action: { popup: false },
+          fantasy_api: {
+            fantasy_key: 'fantasy_value04',
+            fantasy_key_obsolete: 'fantasy_value',
+          },
+        },
+        { validator }
+      );
 
-      const isValidMV3 = validator.validateAddon({
-        ...validManifest,
-        // Add properties that are expected to be triggering
-        // validation errors because unsupported with manifest_version 3.
-        manifest_version: 3,
-        page_action: {},
-      });
-
-      expect(validator.validateAddon.errors).toEqual(
+      // Errors for properties only available in MV2 to be reported on MV2 addon.
+      expect(validateAddon.errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            instancePath: '/page_action',
-            keyword: 'max_manifest_version',
-            params: { max_manifest_version: 2 },
+            instancePath: '/browser_action/popup',
+            keyword: 'type',
+            message: 'must be string',
           }),
         ])
       );
+
+      // Errors for values in the fantary_api enum restricted to MV1 and MV3 should not be reported.
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value01'] },
+          }),
+        ])
+      );
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value03'] },
+          }),
+        ])
+      );
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key_obsolete',
+          }),
+        ])
+      );
+
+      // Errors for values in the fantary_api enum supported by MV2 should be reported.
+      expect(validateAddon.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value02'] },
+          }),
+        ])
+      );
+
+      expect(isValidMV2).toBe(false);
+
+      // Verify validation on MV3 extension.
+
+      const isValidMV3 = validateAddon(
+        {
+          ...validManifest,
+          // Add properties that are expected to be triggering
+          // validation errors because unsupported with manifest_version 3.
+          manifest_version: 3,
+          browser_action: { popup: false },
+          fantasy_api: {
+            fantasy_key: 'fantasy_value04',
+            fantasy_key_obsolete: 'fantasy_value',
+          },
+        },
+        { validator, maxManifestVersion: 3 }
+      );
+
+      // Errors for properties only available in MV2 not to be reported on MV3 addon.
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/browser_action/popup',
+            keyword: 'type',
+            message: 'must be string',
+          }),
+        ])
+      );
+
+      // Errors for values in the fantary_api enum restricted to MV1 and MV2 should not be reported.
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value01'] },
+          }),
+        ])
+      );
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value02'] },
+          }),
+        ])
+      );
+      expect(validateAddon.errors).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key_obsolete',
+          }),
+        ])
+      );
+
+      // Errors for values in the fantary_api enum supported by MV3 should be reported.
+      expect(validateAddon.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            instancePath: '/fantasy_api/fantasy_key',
+            keyword: 'enum',
+            params: { allowedValues: ['fantasy_value03'] },
+          }),
+        ])
+      );
+
       expect(isValidMV3).toBe(false);
     });
   });


### PR DESCRIPTION
Fixes #4367
(also fixes #4521, including the fix for the typo in `isRelevantError` helper function and additional test coverage added to test.schema.js to cover the fixed typo with an explicit test case).  

The unexpected validation warning reported for a valid host permission (filed as addons-linter issue #4367)
seems to be due to the fact that both manifest_version 2 and manifest_version 3 definitions for the
permissions manifest field are being processed.

The current implementation is trying to make sure to filter out the errors not relevant for the current
add-on based on the error.parentSchema property (See isRelevantError helper function defined in
src/schema/validator.js).

Unfortunately this approach is unable to filter out all irrelevant errors, in particular for JSONSchema
types that are referenced in a min/max_manifest_version conditioned entry with more then 1 level deep nesting,
the error.parentSchema will not be the one explicitly including the min/max_manifest_version property and
this is what makes the error triggered by the min_manifest_version 3 version of the "permissions" to be
wrongly reported as part of a manifest_version 2 add-on validation.

This patch is currently filtering the schema data at "JSONSchema data compile"-time and omitting from the
schema data all entries with min/max_manifest_version that do not match the minimum and maximum manifest_version
set per schema validator config or if they don't apply to the actual add-on manifest_version.

NOTE: Ideally a better (and less expesive at runtime) approach may be to this kind of JSONSchema data filtering
at import time (by creating a different set of JSONSchema data per manifest_version).