### PR TITLE
Detect import.meta as module in .js files

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -244,20 +244,20 @@ export default class JavaScriptScanner {
     return 'script';
   }
 
-  /*
-    Analyze the source-code by naively parsing the source code manually and
-    checking for module syntax errors in order to determine the source type of
-    the file.
-
-    This function returns an object with the source type (`script` or `module`)
-    and a non-null parsing error object when parsing has failed with the default
-    source type. The parsing error object contains the `error` message and the
-    source `type`.
-  */
-  detectSourceType(filename) {
+  detectSourceType() {
+    /*
+     * Analyze the source-code by naively parsing the source code manually and
+     * checking for module syntax errors and/or some features in the source code
+     * in order to determine the source type of the file.
+  
+     * This function returns an object with the source type (`script` or
+     * `module`) and a non-null parsing error object when parsing has failed with
+     * the default source type. The parsing error object contains the `error`
+     * message and the source `type`.
+    */
     // Default options taken from eslint/lib/linter:parse
     const parserOptions = {
-      filePath: filename,
+      filePath: this.filename,
       sourceType: 'module',
       ecmaVersion: ECMA_VERSION,
     };
@@ -269,9 +269,10 @@ export default class JavaScriptScanner {
 
     try {
       const ast = espree.parse(this.code, parserOptions);
-      detected.sourceType = filename.endsWith('.mjs')
-        ? 'module'
-        : this._getSourceType(ast);
+      detected.sourceType =
+        this.filename.endsWith('.mjs') || this.code.includes('import.meta')
+          ? 'module'
+          : this._getSourceType(ast);
     } catch (exc) {
       const line = exc.lineNumber || '(unknown)';
       const column = exc.column || '(unknown)';

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -484,7 +484,7 @@ describe('JavaScript Scanner', () => {
       `;
 
       const jsScanner = new JavaScriptScanner(code, 'code.js');
-      const detectedSourceType = jsScanner.detectSourceType('code.js');
+      const detectedSourceType = jsScanner.detectSourceType();
 
       expect(detectedSourceType.sourceType).toEqual('script');
       expect(detectedSourceType.parsingError).toEqual({
@@ -497,7 +497,7 @@ describe('JavaScript Scanner', () => {
       const code = `(function () {})();`;
       const jsScanner = new JavaScriptScanner(code, 'code.js');
 
-      const detectedSourceType = jsScanner.detectSourceType('code.js');
+      const detectedSourceType = jsScanner.detectSourceType();
 
       expect(detectedSourceType.sourceType).toEqual('script');
       expect(detectedSourceType.parsingError).toEqual(null);
@@ -508,7 +508,7 @@ describe('JavaScript Scanner', () => {
       const jsScanner = new JavaScriptScanner(code, 'code.js');
       sinon.stub(jsScanner, '_getSourceType').throws(new Error('some error'));
 
-      const detectedSourceType = jsScanner.detectSourceType('code.js');
+      const detectedSourceType = jsScanner.detectSourceType();
 
       expect(detectedSourceType.sourceType).toEqual('script');
       expect(detectedSourceType.parsingError).toEqual({

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -454,6 +454,15 @@ describe('JavaScript Scanner', () => {
       expect(jsScanner.sourceType).toEqual('module');
     });
 
+    it('should detect module (import.meta in .js file)', async () => {
+      const code = 'const url = import.meta.url;';
+
+      const jsScanner = new JavaScriptScanner(code, 'code.js');
+      await runJsScanner(jsScanner);
+
+      expect(jsScanner.sourceType).toEqual('module');
+    });
+
     it('should detect script', async () => {
       const code = oneLine`
         eval('foo');


### PR DESCRIPTION
Fixes #4331 and #3639

When using import.meta in a .js file, the linter returns an error, "Cannot use 'import.meta' outside a module", unless the source type is detected as a module by the use of an import/export. This patch parses the code as a script if a .js file contains import.meta and it hasn't already been detected as a module by the use of an import/export. If the specific import.meta error is found during the catch block, then the source type is set as a module.

This patch does result in the code being parsed again, but that happens only in the specific situation that currently causes an error. Considering that the use of import.meta within a .js file is currently preventing  addons from being able to pass the linter, I believe this is an acceptable workaround.

A unit test has also been added to test the patch.