### PR TITLE
feat: Import Firefox 103 schema data

### DIFF
--- a/src/schema/firefox-schemas-import.js
+++ b/src/schema/firefox-schemas-import.js
@@ -703,17 +703,14 @@ function loadSchemasFromFile(basePath) {
 
 export function importSchemas(firefoxPath, ourPath, importedPath) {
   const rawSchemas = loadSchemasFromFile(firefoxPath);
-  const ourSchemas = {
-    ...readSchema(ourPath, 'manifest.json'),
-    ...readSchema(ourPath, 'contextMenus.json'),
-    // The "action" API namespace is currently part of browser_action.json
-    // along with "browserAction", the following is needed to make sure we
-    // will normalize and import the "action" API namespace in a file named
-    // "src/schema/imported/action.json" (similar to what contextMenus.json
-    // does for the "contextMenus" API namespace which is defined along with
-    // the "menus" API namespaces).
-    ...readSchema(ourPath, 'action.json'),
-  };
+  // Somehow we need a different shape for `ourSchemas` (that isn't an array of
+  // schemas but an object) so let's do it!
+  const ourSchemas = loadSchemasFromFile(ourPath).reduce((acc, { schema }) => {
+    return {
+      ...acc,
+      ...schema,
+    };
+  }, {});
   const processedSchemas = processSchemas(rawSchemas);
   const updatedSchemas = inner.updateWithAddonsLinterData(
     processedSchemas,

--- a/src/schema/imported/experiments.json
+++ b/src/schema/imported/experiments.json
@@ -16,8 +16,8 @@
           "additionalProperties": {
             "$ref": "experiments#/types/ExperimentAPI"
           },
-          "minProperties": 1,
-          "privileged": true
+          "privileged": true,
+          "minProperties": 1
         }
       }
     }


### PR DESCRIPTION
This PR includes a refresh of the Firefox imported JSONSchema data.

There is no change to the actual JSONSchema, besides a tweak to the experiments.json file which is actually equivalent to the one previously set in #4363 

In addition to that this PR include another commit to reimport a small set of changes to the import script to make sure the updates for experiments.json are actually applied (which used to be in #4363 but got lost in the final updates of the PR and didn't land in master as it should have).

NOTE: no change of the previous addons-linter behaviors is expected to be introduced by these changes.