### PR TITLE
Make hidden and action/page_action/browser_action mutually exclusive (for privileged add-ons)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -513,7 +513,7 @@
 <tr>
 <td><code>MANIFEST_VERSION_INVALID</code></td>
 <td>error</td>
-<td>manifest_version in manifest.json is not valid.</td>
+<td>manifest_version in manifest.json is not valid</td>
 </tr>
 <tr>
 <td><code>PROP_NAME_MISSING</code></td>
@@ -593,7 +593,12 @@
 <tr>
 <td><code>EXTENSION_ID_REQUIRED</code></td>
 <td>error</td>
-<td>The extension ID is mandatory for Manifest Version 3 (and above) extensions.</td>
+<td>The extension ID is mandatory for Manifest Version 3 (and above) extensions</td>
+</tr>
+<tr>
+<td><code>HIDDEN_NO_ACTION</code></td>
+<td>error</td>
+<td>The <code>hidden</code> and <code>browser_action</code>/<code>page_action</code> (or <code>action</code>) properties are mutually exclusive</td>
 </tr>
 </tbody>
 </table>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -122,7 +122,7 @@ Rules are sorted by severity.
 | `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                              |
 | `JSON_INVALID`                                          | error    | JSON is not well formed                                                                         |
 | `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                           |
-| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid.                                                 |
+| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid                                                  |
 | `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                        |
 | `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                       |
 | `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                     |
@@ -138,7 +138,8 @@ Rules are sorted by severity.
 | `IGNORED_APPLICATIONS_PROPERTY`                         | warning  | Usage of both `applications` and `browser_specific_settings` properties                         |
 | `RESTRICTED_HOMEPAGE_URL`                               | error    | Linking to addons.mozilla.org in `homepage_url` or `developer.url` is not allowed               |
 | `RESTRICTED_PERMISSION`                                 | error    | A permission requires "strict_min_version" to be set to a specific Firefox version              |
-| `EXTENSION_ID_REQUIRED`                                 | error    | The extension ID is mandatory for Manifest Version 3 (and above) extensions.                    |
+| `EXTENSION_ID_REQUIRED`                                 | error    | The extension ID is mandatory for Manifest Version 3 (and above) extensions                     |
+| `HIDDEN_NO_ACTION`                                      | error    | The `hidden` and `browser_action`/`page_action` (or `action`) properties are mutually exclusive |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -765,3 +765,12 @@ export function mozillaAddonsPermissionRequired(error) {
     file: MANIFEST_JSON,
   };
 }
+
+export const HIDDEN_NO_ACTION = {
+  code: 'HIDDEN_NO_ACTION',
+  message: i18n._('Cannot use actions in hidden add-ons.'),
+  description: i18n._(oneLine`The hidden and browser_action/page_action (or
+    action in Manifest Version 3 and above) properties are mutually
+    exclusive.`),
+  file: MANIFEST_JSON,
+};

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -730,6 +730,26 @@ export default class ManifestJSONParser extends JSONParser {
 
     this.validateRestrictedPermissions();
     this.validateExtensionID();
+    this.validateHiddenAddon();
+  }
+
+  validateHiddenAddon() {
+    // Only privileged add-ons can use the `hidden` manifest property.
+    if (!this.isPrivilegedAddon) {
+      return;
+    }
+
+    if (
+      this.parsedJSON.hidden &&
+      ('action' in this.parsedJSON ||
+        'browser_action' in this.parsedJSON ||
+        // Note: When this was introduced, it was stricter than the Firefox
+        // side because Firefox didn't restrict `page_action` in Bug 1781998.
+        'page_action' in this.parsedJSON)
+    ) {
+      this.collector.addError(messages.HIDDEN_NO_ACTION);
+      this.isValid = false;
+    }
   }
 
   validateRestrictedPermissions() {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/4432