### PR TITLE
feat: Imported Firefox 104.0b8 API schema

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -171,7 +171,6 @@
         "screenshots",
         "seqstyle",
         "stackwalk",
-        "jstracer",
         "jsallocations",
         "nostacksampling",
         "preferencereads",
@@ -185,6 +184,7 @@
         "markersallthreads",
         "unregisteredthreads",
         "processcpu",
+        "power",
         "responsiveness"
       ]
     },

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -341,7 +341,7 @@
                           "matches": {
                             "type": "array",
                             "items": {
-                              "$ref": "#/types/MatchPatternRestricted"
+                              "$ref": "#/types/MatchPattern"
                             }
                           }
                         },

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1807,6 +1807,8 @@
         "fingerprinting_content",
         "cryptomining",
         "cryptomining_content",
+        "emailtracking",
+        "emailtracking_content",
         "tracking",
         "tracking_ad",
         "tracking_analytics",


### PR DESCRIPTION
Fixes #4435

The updated schema data includes the following changes:

- [bug 1773695](https://bugzilla.mozilla.org/show_bug.cgi?id=1773695), added new `"emailtracking"` and `"emailtracking_content"` to `webRequest` API `urlClarrificationFlags` type
- [bug 1774844](https://bugzilla.mozilla.org/show_bug.cgi?id=1774844) and [bug 1777529](https://bugzilla.mozilla.org/show_bug.cgi?id=1777529), updated to the `geckoProfiler` API `ProfilerFeature` type (removed `jstracer` and added `power`)
- [bug 1776841](https://bugzilla.mozilla.org/show_bug.cgi?id=1776841), allow `"<all_urls>"` to the MV3 `web_accessible_resources`'s `matches` property