### PR TITLE
feat: Imported Firefox 106.0b10 schema

### DIFF
--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -1,0 +1,440 @@
+{
+  "$id": "declarativeNetRequest",
+  "description": "Use the declarativeNetRequest API to block or modify network requests by specifying declarative rules.",
+  "permissions": [
+    "declarativeNetRequest",
+    "declarativeNetRequestWithHostAccess"
+  ],
+  "functions": [
+    {
+      "name": "updateSessionRules",
+      "type": "function",
+      "description": "Modifies the current set of session scoped rules for the extension. The rules with IDs listed in options.removeRuleIds are first removed, and then the rules given in options.addRules are added. These rules are not persisted across sessions and are backed in memory.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "object",
+          "properties": {
+            "removeRuleIds": {
+              "type": "array",
+              "description": "IDs of the rules to remove. Any invalid IDs will be ignored.",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "addRules": {
+              "type": "array",
+              "description": "Rules to add.",
+              "items": {
+                "$ref": "#/types/Rule"
+              }
+            }
+          }
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Called when the session rules have been updated",
+          "parameters": []
+        }
+      ]
+    },
+    {
+      "name": "getSessionRules",
+      "type": "function",
+      "description": "Returns the current set of session scoped rules for the extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/types/Rule"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "testMatchOutcome",
+      "type": "function",
+      "description": "Checks if any of the extension's declarativeNetRequest rules would match a hypothetical request.",
+      "permissions": [
+        "declarativeNetRequestFeedback"
+      ],
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "request",
+          "type": "object",
+          "description": "The details of the request to test.",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL of the hypothetical request."
+            },
+            "initiator": {
+              "type": "string",
+              "description": "The initiator URL (if any) for the hypothetical request."
+            },
+            "method": {
+              "type": "string",
+              "description": "Standard HTTP method of the hypothetical request.",
+              "default": "get"
+            },
+            "type": {
+              "allOf": [
+                {
+                  "$ref": "#/types/ResourceType"
+                },
+                {
+                  "description": "The resource type of the hypothetical request."
+                }
+              ]
+            },
+            "tabId": {
+              "type": "integer",
+              "description": "The ID of the tab in which the hypothetical request takes place. Does not need to correspond to a real tab ID. Default is -1, meaning that the request isn't related to a tab.",
+              "default": -1
+            }
+          },
+          "required": [
+            "url",
+            "type"
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Called with the details of matched rules.",
+          "parameters": [
+            {
+              "name": "result",
+              "type": "object",
+              "properties": {
+                "matchedRules": {
+                  "type": "array",
+                  "description": "The rules (if any) that match the hypothetical request.",
+                  "items": {
+                    "$ref": "#/types/MatchedRule"
+                  }
+                }
+              },
+              "required": [
+                "matchedRules"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "Permission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "declarativeNetRequest"
+          ],
+          "min_manifest_version": 3
+        }
+      ]
+    },
+    "PermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "declarativeNetRequestFeedback",
+            "declarativeNetRequestWithHostAccess"
+          ],
+          "min_manifest_version": 3
+        }
+      ]
+    }
+  },
+  "refs": {
+    "declarativeNetRequest#/definitions/Permission": {
+      "namespace": "manifest",
+      "type": "Permission"
+    },
+    "declarativeNetRequest#/definitions/PermissionNoPrompt": {
+      "namespace": "manifest",
+      "type": "PermissionNoPrompt"
+    }
+  },
+  "types": {
+    "ResourceType": {
+      "type": "string",
+      "description": "How the requested resource will be used. Comparable to the webRequest.ResourceType type.",
+      "enum": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "object",
+        "object_subrequest",
+        "xmlhttprequest",
+        "xslt",
+        "ping",
+        "beacon",
+        "xml_dtd",
+        "font",
+        "media",
+        "websocket",
+        "csp_report",
+        "imageset",
+        "web_manifest",
+        "speculative",
+        "other"
+      ]
+    },
+    "MatchedRule": {
+      "type": "object",
+      "properties": {
+        "ruleId": {
+          "type": "integer",
+          "description": "A matching rule's ID."
+        },
+        "rulesetId": {
+          "type": "string",
+          "description": "ID of the Ruleset this rule belongs to."
+        }
+      },
+      "required": [
+        "ruleId",
+        "rulesetId"
+      ]
+    },
+    "Rule": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "An id which uniquely identifies a rule. Mandatory and should be >= 1.",
+          "minimum": 1
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Rule priority. Defaults to 1. When specified, should be >= 1",
+          "minimum": 1,
+          "default": 1
+        },
+        "condition": {
+          "type": "object",
+          "description": "The condition under which this rule is triggered.",
+          "properties": {
+            "urlFilter": {
+              "type": "string",
+              "description": "TODO: link to doc explaining supported pattern. The pattern which is matched against the network request url. Only one of 'urlFilter' or 'regexFilter' can be specified."
+            },
+            "regexFilter": {
+              "type": "string",
+              "description": "Regular expression to match against the network request url. Only one of 'urlFilter' or 'regexFilter' can be specified."
+            },
+            "isUrlFilterCaseSensitive": {
+              "type": "boolean",
+              "description": "Whether 'urlFilter' or 'regexFilter' is case-sensitive. Defaults to true."
+            },
+            "initiatorDomains": {
+              "type": "array",
+              "description": "The rule will only match network requests originating from the list of 'initiatorDomains'. If the list is omitted, the rule is applied to requests from all domains.",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "description": "TODO: describe domain format."
+              }
+            },
+            "excludedInitiatorDomains": {
+              "type": "array",
+              "description": "The rule will not match network requests originating from the list of 'initiatorDomains'. If the list is empty or omitted, no domains are excluded. This takes precedence over 'initiatorDomains'.",
+              "items": {
+                "type": "string",
+                "description": "TODO: describe domain format."
+              }
+            },
+            "requestDomains": {
+              "type": "array",
+              "description": "The rule will only match network requests when the domain matches one from the list of 'requestDomains'. If the list is omitted, the rule is applied to requests from all domains.",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "description": "TODO: describe domain format."
+              }
+            },
+            "excludedRequestDomains": {
+              "type": "array",
+              "description": "The rule will not match network requests when the domains matches one from the list of 'excludedRequestDomains'. If the list is empty or omitted, no domains are excluded. This takes precedence over 'requestDomains'.",
+              "items": {
+                "type": "string",
+                "description": "TODO: describe domain format."
+              }
+            },
+            "resourceTypes": {
+              "type": "array",
+              "description": "List of resource types which the rule can match. When the rule action is 'allowAllRequests', this must be specified and may only contain 'main_frame' or 'sub_frame'. Cannot be specified if 'excludedResourceTypes' is specified. If neither of them is specified, all resource types except 'main_frame' are matched.",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/types/ResourceType"
+              }
+            },
+            "excludedResourceTypes": {
+              "type": "array",
+              "description": "List of resource types which the rule won't match. Cannot be specified if 'resourceTypes' is specified. If neither of them is specified, all resource types except 'main_frame' are matched.",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/types/ResourceType"
+              }
+            },
+            "requestMethods": {
+              "type": "array",
+              "description": "List of HTTP request methods which the rule can match. Should be a lower-case method such as 'connect', 'delete', 'get', 'head', 'options', 'patch', 'post', 'put'.'",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludedRequestMethods": {
+              "type": "array",
+              "description": "List of request methods which the rule won't match. Cannot be specified if 'requestMethods' is specified. If neither of them is specified, all request methods are matched.",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "domainType": {
+              "type": "string",
+              "description": "Specifies whether the network request is first-party or third-party to the domain from which it originated. If omitted, all requests are matched.",
+              "enum": [
+                "firstParty",
+                "thirdParty"
+              ]
+            },
+            "tabIds": {
+              "type": "array",
+              "description": "List of tabIds which the rule should match. An ID of -1 matches requests which don't originate from a tab. Only supported for session-scoped rules.",
+              "minItems": 1,
+              "items": {
+                "type": "integer"
+              }
+            },
+            "excludedTabIds": {
+              "type": "array",
+              "description": "List of tabIds which the rule should not match. An ID of -1 excludes requests which don't originate from a tab. Only supported for session-scoped rules.",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "action": {
+          "type": "object",
+          "description": "The action to take if this rule is matched.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "block",
+                "redirect",
+                "allow",
+                "upgradeScheme",
+                "modifyHeaders",
+                "allowAllRequests"
+              ]
+            },
+            "redirect": {
+              "type": "object",
+              "description": "Describes how the redirect should be performed. Only valid when type is 'redirect'.",
+              "properties": {
+                "extensionPath": {
+                  "type": "string",
+                  "description": "Path relative to the extension directory. Should start with '/'."
+                },
+                "transform": {
+                  "type": "object",
+                  "description": "TODO: URLTransform - Url transformations to perform."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "The redirect url. Redirects to JavaScript urls are not allowed."
+                },
+                "regexSubstitution": {
+                  "type": "string",
+                  "description": "TODO with regexFilter + Substitution pattern for rules which specify a 'regexFilter'."
+                }
+              }
+            },
+            "requestHeaders": {
+              "type": "object",
+              "description": "The request headers to modify for the request. Only valid when type is 'modifyHeaders'.",
+              "properties": {
+                "header": {
+                  "type": "string",
+                  "description": "The name of the request header to be modified."
+                },
+                "operation": {
+                  "type": "string",
+                  "description": "The operation to be performed on a header. The 'append' operation is not supported for request headers.",
+                  "enum": [
+                    "set",
+                    "remove"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The new value for the header. Must be specified for the 'set' operation."
+                }
+              },
+              "required": [
+                "header",
+                "operation"
+              ]
+            },
+            "responseHeaders": {
+              "type": "object",
+              "description": "The response headers to modify for the request. Only valid when type is 'modifyHeaders'.",
+              "properties": {
+                "header": {
+                  "type": "string",
+                  "description": "The name of the response header to be modified."
+                },
+                "operation": {
+                  "type": "string",
+                  "description": "The operation to be performed on a header.",
+                  "enum": [
+                    "append",
+                    "set",
+                    "remove"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The new value for the header. Must be specified for the 'append' and 'set' operations."
+                }
+              },
+              "required": [
+                "header",
+                "operation"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "condition",
+        "action"
+      ]
+    }
+  }
+}

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -163,7 +163,6 @@
       "enum": [
         "java",
         "js",
-        "leaf",
         "mainthreadio",
         "fileio",
         "fileioall",

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -14,6 +14,7 @@ import commands from './commands.json';
 import contentScripts from './content_scripts.json';
 import contextualIdentities from './contextual_identities.json';
 import cookies from './cookies.json';
+import declarativeNetRequest from './declarative_net_request.json';
 import devtools from './devtools.json';
 import dns from './dns.json';
 import downloads from './downloads.json';
@@ -74,6 +75,7 @@ export default [
   contentScripts,
   contextualIdentities,
   cookies,
+  declarativeNetRequest,
   devtools,
   dns,
   downloads,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -329,25 +329,45 @@
                     {
                       "min_manifest_version": 3,
                       "type": "array",
+                      "postprocess": "webAccessibleMatching",
+                      "minItems": 1,
                       "items": {
                         "type": "object",
                         "properties": {
                           "resources": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                               "type": "string"
                             }
                           },
                           "matches": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                               "$ref": "#/types/MatchPattern"
+                            }
+                          },
+                          "extension_ids": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/types/ExtensionID"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "*"
+                                  ]
+                                }
+                              ]
                             }
                           }
                         },
                         "required": [
-                          "resources",
-                          "matches"
+                          "resources"
                         ]
                       }
                     }
@@ -760,6 +780,9 @@
           "$ref": "contextualIdentities#/definitions/PermissionNoPrompt"
         },
         {
+          "$ref": "declarativeNetRequest#/definitions/PermissionNoPrompt"
+        },
+        {
           "$ref": "dns#/definitions/PermissionNoPrompt"
         },
         {
@@ -786,6 +809,9 @@
         },
         {
           "$ref": "#/types/OptionalPermission"
+        },
+        {
+          "$ref": "declarativeNetRequest#/definitions/Permission"
         },
         {
           "$ref": "experiments#/definitions/Permission"

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -190,10 +190,7 @@
                 "properties": {
                   "persistAcrossSessions": {
                     "type": "boolean",
-                    "enum": [
-                      false
-                    ],
-                    "description": "Specifies if this content script will persist into future sessions. This is currently NOT supported."
+                    "description": "Specifies if this content script will persist into future sessions."
                   }
                 }
               }
@@ -425,10 +422,8 @@
         },
         "persistAcrossSessions": {
           "type": "boolean",
-          "enum": [
-            false
-          ],
-          "description": "Specifies if this content script will persist into future sessions. This is currently NOT supported."
+          "default": true,
+          "description": "Specifies if this content script will persist into future sessions. Defaults to true."
         },
         "css": {
           "type": "array",
@@ -439,8 +434,7 @@
         }
       },
       "required": [
-        "id",
-        "persistAcrossSessions"
+        "id"
       ]
     }
   }

--- a/src/schema/imported/test.json
+++ b/src/schema/imported/test.json
@@ -151,9 +151,8 @@
       ]
     },
     {
-      "name": "checkDeepEq",
+      "name": "assertDeepEq",
       "type": "function",
-      "unsupported": true,
       "allowAmbiguousOptionalArguments": true,
       "parameters": [
         {
@@ -161,6 +160,11 @@
         },
         {
           "name": "actual"
+        },
+        {
+          "type": "string",
+          "name": "message",
+          "optional": true
         }
       ]
     },

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1742,18 +1742,30 @@
             "$ref": "#/types/CertificateInfo"
           }
         },
+        "overridableErrorCategory": {
+          "description": "The type of certificate error that was overridden for this connection, if any.",
+          "type": "string",
+          "enum": [
+            "trust_error",
+            "domain_mismatch",
+            "expired_or_not_yet_valid"
+          ]
+        },
         "isDomainMismatch": {
           "description": "The domain name does not match the certificate domain.",
-          "type": "boolean"
-        },
-        "isExtendedValidation": {
-          "type": "boolean"
+          "type": "boolean",
+          "deprecated": "Please use $(ref:SecurityInfo.overridableErrorCategory)."
         },
         "isNotValidAtThisTime": {
           "description": "The certificate is either expired or is not yet valid.  See <code>CertificateInfo.validity</code> for start and end dates.",
-          "type": "boolean"
+          "type": "boolean",
+          "deprecated": "Please use $(ref:SecurityInfo.overridableErrorCategory)."
         },
         "isUntrusted": {
+          "type": "boolean",
+          "deprecated": "Please use $(ref:SecurityInfo.overridableErrorCategory)."
+        },
+        "isExtendedValidation": {
           "type": "boolean"
         },
         "certificateTransparencyStatus": {

--- a/src/schema/imported/windows.json
+++ b/src/schema/imported/windows.json
@@ -181,14 +181,12 @@
               "description": "A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.",
               "anyOf": [
                 {
-                  "type": "string",
-                  "format": "relativeUrl"
+                  "type": "string"
                 },
                 {
                   "type": "array",
                   "items": {
-                    "type": "string",
-                    "format": "relativeUrl"
+                    "type": "string"
                   }
                 }
               ]


### PR DESCRIPTION
The updated schema data includes the following changes:
- [Bug 1571089](https://bugzilla.mozilla.org/show_bug.cgi?id=1571089) - Remove the "leaf" profiler feature
- [Bug 1780747](https://bugzilla.mozilla.org/show_bug.cgi?id=1780747) - Register DNR schema and permissions
- [Bug 1711168](https://bugzilla.mozilla.org/show_bug.cgi?id=1711168) support extension matching in webAccessibleResources / [Bug 1773115](https://bugzilla.mozilla.org/show_bug.cgi?id=1773115) ensure extension access to its own web accessible resources
- [Bug 1751436](https://bugzilla.mozilla.org/show_bug.cgi?id=1751436) - Add support for `persistAcrossSessions` in `scripting.RegisteredContentScript` / [Bug 1740608](https://bugzilla.mozilla.org/show_bug.cgi?id=1740608) - Return actual errors in `scripting.executeScript()`

Fixes #4514