### PR TITLE
Encourage the use of 'browser_specific_settings' over 'applications' in MV2, forbid the latter in MV3+

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -600,6 +600,16 @@
 <td>error</td>
 <td>The <code>hidden</code> and <code>browser_action</code>/<code>page_action</code> (or <code>action</code>) properties are mutually exclusive</td>
 </tr>
+<tr>
+<td><code>APPLICATIONS_DEPRECATED</code></td>
+<td>warning</td>
+<td>The <code>applications</code> property in the manifest is deprecated and will no longer be accepted in Manifest Version 3 and above. Use <code>browser_specific_settings</code> instead.</td>
+</tr>
+<tr>
+<td><code>APPLICATIONS_INVALID</code></td>
+<td>error</td>
+<td>The <code>applications</code> property is no longer accepted in Manifest Version 3 and above.</td>
+</tr>
 </tbody>
 </table>
 <h3 id="static-theme-%2F-manifest.json" tabindex="-1">Static Theme / manifest.json <a class="header-anchor" href="#static-theme-%2F-manifest.json">¶</a></h3>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -78,68 +78,70 @@ Rules are sorted by severity.
 
 ## Web Extensions / manifest.json
 
-| Message code                                            | Severity | Description                                                                                     |
-| ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `MANIFEST_UNUSED_UPDATE`                                | notice   | update_url ignored in manifest.json                                                             |
-| `PROP_VERSION_TOOLKIT_ONLY`                             | notice   | version is in the toolkit format in manifest.json                                               |
-| `CORRUPT_ICON_FILE`                                     | warning  | Icons must not be corrupt                                                                       |
-| `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                      |
-| `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                  |
-| `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                              |
-| `MANIFEST_OPTIONAL_PERMISSIONS`                         | warning  | Unknown optional permission                                                                     |
-| `MANIFEST_HOST_PERMISSIONS`                             | warning  | Unknown host permission                                                                         |
-| `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                            |
-| `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                      |
-| `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                    |
-| `UNSUPPORTED_API`                                       | warning  | Unsupported or unknown browser API                                                              |
-| `DANGEROUS_EVAL`                                        | warning  | `eval` and the `Function` constructor are discouraged                                           |
-| `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                 |
-| `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                        |
-| `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                  |
-| `MANIFEST_FIELD_PRIVILEGEDONLY`                         | warning  | A manifest field ignored on non-privileged extensions                                           |
-| `MANIFEST_FIELD_UNSUPPORTED`                            | warning  | A manifest field is not supported (or not supported for the extension manifest_version)         |
-| `MANIFEST_PERMISSION_UNSUPPORTED`                       | warning  | A manifest permission is not supported for the extension manifest_version                       |
-| `MANIFEST_PERMISSIONS_PRIVILEGED`                       | error    | A manifest permission is only allowed in privileged extensions                                  |
-| `MOZILLA_ADDONS_PERMISSION_REQUIRED`                    | error    | The "mozillaAddons" permission must be specified in privileged extensions                       |
-| `PRIVILEGED_FEATURES_REQUIRED`                          | error    | Privileged features are mandatory for privileged extensions, but none has been detected         |
-| `MANIFEST_FIELD_PRIVILEGED`                             | error    | A manifest field is only allowed in privileged extensions                                       |
-| `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                 |
-| `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                         |
-| `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                     |
-| `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                              |
-| `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                           |
-| `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                  |
-| `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                         |
-| `MANIFEST_BAD_HOST_PERMISSION`                          | error    | Bad host permission                                                                             |
-| `MANIFEST_INSTALL_ORIGINS`                              | error    | Invalid install_origins                                                                         |
-| `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                          |
-| `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                          |
-| `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                          |
-| `CONTENT_SCRIPT_EMPTY`                                  | error    | Content script file name should not be empty                                                    |
-| `NO_MESSAGE`                                            | error    | Translation string is missing the message                                                       |
-| `INVALID_MESSAGE_NAME`                                  | error    | String name contains invalid characters                                                         |
-| `INVALID_PLACEHOLDER_NAME`                              | error    | Placeholder name contains invalid characters                                                    |
-| `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                              |
-| `JSON_INVALID`                                          | error    | JSON is not well formed                                                                         |
-| `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                           |
-| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid                                                  |
-| `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                        |
-| `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                       |
-| `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                     |
-| `PROP_VERSION_INVALID`                                  | error    | version is invalid in manifest.json                                                             |
-| `MANIFEST_DICT_NOT_FOUND`                               | error    | A dictionary file defined in the manifest could not be found                                    |
-| `MANIFEST_MULTIPLE_DICTS`                               | error    | Multiple dictionaries found                                                                     |
-| `MANIFEST_EMPTY_DICTS`                                  | error    | Empty `dictionaries` object                                                                     |
-| `MANIFEST_DICT_MISSING_ID`                              | error    | Missing `applications.gecko.id` property for a dictionary                                       |
-| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`                | warning  | Manifest key not compatible with `applications.gecko.strict_min_version`                        |
-| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version` |
-| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                          |
-| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`   |
-| `IGNORED_APPLICATIONS_PROPERTY`                         | warning  | Usage of both `applications` and `browser_specific_settings` properties                         |
-| `RESTRICTED_HOMEPAGE_URL`                               | error    | Linking to addons.mozilla.org in `homepage_url` or `developer.url` is not allowed               |
-| `RESTRICTED_PERMISSION`                                 | error    | A permission requires "strict_min_version" to be set to a specific Firefox version              |
-| `EXTENSION_ID_REQUIRED`                                 | error    | The extension ID is mandatory for Manifest Version 3 (and above) extensions                     |
-| `HIDDEN_NO_ACTION`                                      | error    | The `hidden` and `browser_action`/`page_action` (or `action`) properties are mutually exclusive |
+| Message code                                            | Severity | Description                                                                                                                                                        |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MANIFEST_UNUSED_UPDATE`                                | notice   | update_url ignored in manifest.json                                                                                                                                |
+| `PROP_VERSION_TOOLKIT_ONLY`                             | notice   | version is in the toolkit format in manifest.json                                                                                                                  |
+| `CORRUPT_ICON_FILE`                                     | warning  | Icons must not be corrupt                                                                                                                                          |
+| `MANIFEST_CSP`                                          | warning  | content_security_policy in manifest.json means more review                                                                                                         |
+| `MANIFEST_CSP_UNSAFE_EVAL`                              | warning  | usage of 'unsafe-eval' is strongly discouraged                                                                                                                     |
+| `MANIFEST_PERMISSIONS`                                  | warning  | Unknown permission                                                                                                                                                 |
+| `MANIFEST_OPTIONAL_PERMISSIONS`                         | warning  | Unknown optional permission                                                                                                                                        |
+| `MANIFEST_HOST_PERMISSIONS`                             | warning  | Unknown host permission                                                                                                                                            |
+| `NO_MESSAGES_FILE`                                      | warning  | When default_locale is specified a matching messages.json must exist                                                                                               |
+| `NO_DEFAULT_LOCALE`                                     | warning  | When \_locales directory exists, default_locale must exist                                                                                                         |
+| `UNSAFE_VAR_ASSIGNMENT`                                 | warning  | Assignment using dynamic, unsanitized values                                                                                                                       |
+| `UNSUPPORTED_API`                                       | warning  | Unsupported or unknown browser API                                                                                                                                 |
+| `DANGEROUS_EVAL`                                        | warning  | `eval` and the `Function` constructor are discouraged                                                                                                              |
+| `STRICT_MAX_VERSION`                                    | warning  | strict_max_version not required                                                                                                                                    |
+| `PREDEFINED_MESSAGE_NAME`                               | warning  | String name is reserved for a predefined                                                                                                                           |
+| `MISSING_PLACEHOLDER`                                   | warning  | Placeholder for message is not                                                                                                                                     |
+| `MANIFEST_FIELD_PRIVILEGEDONLY`                         | warning  | A manifest field ignored on non-privileged extensions                                                                                                              |
+| `MANIFEST_FIELD_UNSUPPORTED`                            | warning  | A manifest field is not supported (or not supported for the extension manifest_version)                                                                            |
+| `MANIFEST_PERMISSION_UNSUPPORTED`                       | warning  | A manifest permission is not supported for the extension manifest_version                                                                                          |
+| `MANIFEST_PERMISSIONS_PRIVILEGED`                       | error    | A manifest permission is only allowed in privileged extensions                                                                                                     |
+| `MOZILLA_ADDONS_PERMISSION_REQUIRED`                    | error    | The "mozillaAddons" permission must be specified in privileged extensions                                                                                          |
+| `PRIVILEGED_FEATURES_REQUIRED`                          | error    | Privileged features are mandatory for privileged extensions, but none has been detected                                                                            |
+| `MANIFEST_FIELD_PRIVILEGED`                             | error    | A manifest field is only allowed in privileged extensions                                                                                                          |
+| `WRONG_ICON_EXTENSION`                                  | error    | Icons must have valid extension                                                                                                                                    |
+| `MANIFEST_UPDATE_URL`                                   | error    | update_url not allowed in manifest.json                                                                                                                            |
+| `MANIFEST_FIELD_REQUIRED`                               | error    | A required field is missing                                                                                                                                        |
+| `MANIFEST_FIELD_INVALID`                                | error    | A field is invalid                                                                                                                                                 |
+| `MANIFEST_FIELD_DEPRECATED`                             | error    | A field is deprecated                                                                                                                                              |
+| `MANIFEST_BAD_PERMISSION`                               | error    | Bad permission                                                                                                                                                     |
+| `MANIFEST_BAD_OPTIONAL_PERMISSION`                      | error    | Bad optional permission                                                                                                                                            |
+| `MANIFEST_BAD_HOST_PERMISSION`                          | error    | Bad host permission                                                                                                                                                |
+| `MANIFEST_INSTALL_ORIGINS`                              | error    | Invalid install_origins                                                                                                                                            |
+| `JSON_BLOCK_COMMENTS`                                   | error    | Block Comments are not allowed in JSON                                                                                                                             |
+| `MANIFEST_INVALID_CONTENT`                              | error    | This add-on contains forbidden content                                                                                                                             |
+| `CONTENT_SCRIPT_NOT_FOUND`                              | error    | Content script file could not be found                                                                                                                             |
+| `CONTENT_SCRIPT_EMPTY`                                  | error    | Content script file name should not be empty                                                                                                                       |
+| `NO_MESSAGE`                                            | error    | Translation string is missing the message                                                                                                                          |
+| `INVALID_MESSAGE_NAME`                                  | error    | String name contains invalid characters                                                                                                                            |
+| `INVALID_PLACEHOLDER_NAME`                              | error    | Placeholder name contains invalid characters                                                                                                                       |
+| `NO_PLACEHOLDER_CONTENT`                                | error    | Placeholder is missing the content                                                                                                                                 |
+| `JSON_INVALID`                                          | error    | JSON is not well formed                                                                                                                                            |
+| `JSON_DUPLICATE_KEY`                                    | error    | Duplicate key in JSON                                                                                                                                              |
+| `MANIFEST_VERSION_INVALID`                              | error    | manifest_version in manifest.json is not valid                                                                                                                     |
+| `PROP_NAME_MISSING`                                     | error    | name property missing from manifest.json                                                                                                                           |
+| `PROP_NAME_INVALID`                                     | error    | name property is invalid in manifest.json                                                                                                                          |
+| `PROP_VERSION_MISSING`                                  | error    | version property missing from manifest.json                                                                                                                        |
+| `PROP_VERSION_INVALID`                                  | error    | version is invalid in manifest.json                                                                                                                                |
+| `MANIFEST_DICT_NOT_FOUND`                               | error    | A dictionary file defined in the manifest could not be found                                                                                                       |
+| `MANIFEST_MULTIPLE_DICTS`                               | error    | Multiple dictionaries found                                                                                                                                        |
+| `MANIFEST_EMPTY_DICTS`                                  | error    | Empty `dictionaries` object                                                                                                                                        |
+| `MANIFEST_DICT_MISSING_ID`                              | error    | Missing `applications.gecko.id` property for a dictionary                                                                                                          |
+| `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`                | warning  | Manifest key not compatible with `applications.gecko.strict_min_version`                                                                                           |
+| `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION`        | warning  | Manifest key not compatible with Firefox for Android at `applications.gecko.strict_min_version`                                                                    |
+| `PERMISSION_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`         | notice   | Permission not compatible with `applications.gecko.strict_min_version`                                                                                             |
+| `PERMISSION_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` | notice   | Permission not compatible with Firefox for Android at `applications.gecko.strict_min_version`                                                                      |
+| `IGNORED_APPLICATIONS_PROPERTY`                         | warning  | Usage of both `applications` and `browser_specific_settings` properties                                                                                            |
+| `RESTRICTED_HOMEPAGE_URL`                               | error    | Linking to addons.mozilla.org in `homepage_url` or `developer.url` is not allowed                                                                                  |
+| `RESTRICTED_PERMISSION`                                 | error    | A permission requires "strict_min_version" to be set to a specific Firefox version                                                                                 |
+| `EXTENSION_ID_REQUIRED`                                 | error    | The extension ID is mandatory for Manifest Version 3 (and above) extensions                                                                                        |
+| `HIDDEN_NO_ACTION`                                      | error    | The `hidden` and `browser_action`/`page_action` (or `action`) properties are mutually exclusive                                                                    |
+| `APPLICATIONS_DEPRECATED`                               | warning  | The `applications` property in the manifest is deprecated and will no longer be accepted in Manifest Version 3 and above. Use `browser_specific_settings` instead. |
+| `APPLICATIONS_INVALID`                                  | error    | The `applications` property is no longer accepted in Manifest Version 3 and above.                                                                                 |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -774,3 +774,22 @@ export const HIDDEN_NO_ACTION = {
     exclusive.`),
   file: MANIFEST_JSON,
 };
+
+export const APPLICATIONS_DEPRECATED = {
+  code: 'APPLICATIONS_DEPRECATED',
+  message: i18n._('Use "browser_specific_settings" instead of "applications".'),
+  description: i18n._(oneLine`The "applications" property in the manifest is
+    deprecated and will no longer be accepted in Manifest Version 3 and
+    above.`),
+  file: MANIFEST_JSON,
+};
+
+export const APPLICATIONS_INVALID = {
+  code: 'APPLICATIONS_INVALID',
+  message: i18n._(oneLine`"applications" is no longer allowed in Manifest
+    Version 3 and above.`),
+  description: i18n._(oneLine`The "applications" property in the manifest is
+    no longer allowed in Manifest Version 3 and above. Use
+    "browser_specific_settings" instead.`),
+  file: MANIFEST_JSON,
+};

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -316,6 +316,8 @@ export default class ManifestJSONParser extends JSONParser {
       // add-on manifest_version.
       if (PERMS_DATAPATH_REGEX.test(error.instancePath)) {
         baseObject = messages.manifestPermissionUnsupported(error.data, error);
+      } else if (error.instancePath === '/applications') {
+        baseObject = messages.APPLICATIONS_INVALID;
       } else {
         baseObject = messages.manifestFieldUnsupported(
           error.instancePath,
@@ -490,11 +492,15 @@ export default class ManifestJSONParser extends JSONParser {
       });
     }
 
-    if (
-      this.parsedJSON.browser_specific_settings &&
-      this.parsedJSON.applications
-    ) {
-      this.collector.addWarning(messages.IGNORED_APPLICATIONS_PROPERTY);
+    if (this.parsedJSON.manifest_version < 3) {
+      if (
+        this.parsedJSON.browser_specific_settings &&
+        this.parsedJSON.applications
+      ) {
+        this.collector.addWarning(messages.IGNORED_APPLICATIONS_PROPERTY);
+      } else if (this.parsedJSON.applications) {
+        this.collector.addWarning(messages.APPLICATIONS_DEPRECATED);
+      }
     }
 
     if (

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -22,7 +22,8 @@
             {
               "description": "The applications property is deprecated, please use 'browser_specific_settings'"
             }
-          ]
+          ],
+          "max_manifest_version": 2
         },
         "browser_specific_settings": {
           "$ref": "#/types/BrowserSpecificSettings"

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -86,6 +86,9 @@
       },
       "ManifestBase": {
         "properties": {
+          "applications": {
+            "max_manifest_version": 2
+          },
           "homepage_url": {
             "format": "ignore",
             "oneOf": [

--- a/tests/fixtures/webextension_es6_module/manifest.json
+++ b/tests/fixtures/webextension_es6_module/manifest.json
@@ -1,5 +1,5 @@
 {
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "@webextension-guid"
     }

--- a/tests/fixtures/webextension_node_modules_bower/manifest.json
+++ b/tests/fixtures/webextension_node_modules_bower/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "My WebExtension Addon",
   "version": "0.0.1",
-  "applications": {
+  "browser_specific_settings": {
       "gecko": {
           "id": "@webextension-guid"
       }

--- a/tests/fixtures/webextension_scan_file/manifest.json
+++ b/tests/fixtures/webextension_scan_file/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "My WebExtension Addon",
   "version": "0.0.1",
-  "applications": {
+  "browser_specific_settings": {
       "gecko": {
           "id": "@webextension-guid"
       }

--- a/tests/fixtures/webextension_with_eslintignore/manifest.json
+++ b/tests/fixtures/webextension_with_eslintignore/manifest.json
@@ -1,5 +1,5 @@
 {
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "@webextension-guid"
     }

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -124,7 +124,7 @@ export function validManifestJSON(extra) {
   return JSON.stringify({
     name: 'my extension',
     manifest_version: 2,
-    applications: {
+    browser_specific_settings: {
       gecko: {
         id: '{daf44bf7-a45e-4450-979c-91cf07434c3d}',
         strict_min_version: '48.0.0',
@@ -143,7 +143,7 @@ export function validDictionaryManifestJSON(extra) {
     dictionaries: {
       fr: '/path/to/fr.dic',
     },
-    applications: {
+    browser_specific_settings: {
       gecko: {
         id: '@my-dictionary',
       },
@@ -216,7 +216,7 @@ export function validSitePermissionManifestJSON(extra) {
     version: '1.0a1',
     site_permissions: ['midi'],
     install_origins: ['http://mozilla.org'],
-    applications: {
+    browser_specific_settings: {
       gecko: {
         id: '@my-exaple-sitepermission',
       },

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -249,7 +249,7 @@ describe('ManifestJSONParser', () => {
       // id is something incorrect, you shouldn't even be calling getMetadata.
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: { gecko: { id: 'wat' } },
+        browser_specific_settings: { gecko: { id: 'wat' } },
       });
       const manifestJSONParser = new ManifestJSONParser(
         json,
@@ -258,14 +258,14 @@ describe('ManifestJSONParser', () => {
       expect(manifestJSONParser.isValid).toEqual(false);
       assertHasMatchingError(addonLinter.collector.errors, {
         code: messages.JSON_INVALID.code,
-        message: /"\/applications\/gecko\/id" must match pattern/,
+        message: /"\/browser_specific_settings\/gecko\/id" must match pattern/,
       });
     });
 
     it('should fail on id containing unicode chars', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: { gecko: { id: '@fôobar' } },
+        browser_specific_settings: { gecko: { id: '@fôobar' } },
       });
       const manifestJSONParser = new ManifestJSONParser(
         json,
@@ -274,7 +274,7 @@ describe('ManifestJSONParser', () => {
       expect(manifestJSONParser.isValid).toEqual(false);
       assertHasMatchingError(addonLinter.collector.errors, {
         code: messages.JSON_INVALID.code,
-        message: /"\/applications\/gecko\/id" must match pattern/,
+        message: /"\/browser_specific_settings\/gecko\/id" must match pattern/,
       });
     });
 
@@ -283,7 +283,7 @@ describe('ManifestJSONParser', () => {
       const json = validManifestJSON({
         // ids containing non-ascii chars are forbidden per the schema
         // definition so we only need to test ascii here.
-        applications: { gecko: { id: `@${'a'.repeat(80)}` } }, // 81 chars
+        browser_specific_settings: { gecko: { id: `@${'a'.repeat(80)}` } }, // 81 chars
       });
       const manifestJSONParser = new ManifestJSONParser(
         json,
@@ -293,13 +293,13 @@ describe('ManifestJSONParser', () => {
       assertHasMatchingError(addonLinter.collector.errors, {
         code: messages.JSON_INVALID.code,
         message:
-          /"\/applications\/gecko\/id" must NOT have more than 80 characters/,
+          /"\/browser_specific_settings\/gecko\/id" must NOT have more than 80 characters/,
       });
     });
 
     it('should return null if undefined', () => {
       const addonLinter = new Linter({ _: ['bar'] });
-      const json = validManifestJSON({ applications: {} });
+      const json = validManifestJSON({ browser_specific_settings: {} });
       const manifestJSONParser = new ManifestJSONParser(
         json,
         addonLinter.collector
@@ -541,7 +541,7 @@ describe('ManifestJSONParser', () => {
 
         const json = validManifestJSON({
           [manifestKey]: ['idle', 'fileSystem'],
-          applications: { gecko: { strict_min_version: '55.0' } },
+          browser_specific_settings: { gecko: { strict_min_version: '55.0' } },
         });
         const manifestJSONParser = new ManifestJSONParser(
           json,
@@ -569,7 +569,7 @@ describe('ManifestJSONParser', () => {
               fileSystem: ['write'],
             },
           ],
-          applications: { gecko: { strict_min_version: '55.0' } },
+          browser_specific_settings: { gecko: { strict_min_version: '55.0' } },
         });
 
         const manifestJSONParser = new ManifestJSONParser(
@@ -590,7 +590,7 @@ describe('ManifestJSONParser', () => {
             : messages.MANIFEST_BAD_OPTIONAL_PERMISSION.code;
         const json = validManifestJSON({
           [manifestKey]: ['idle', 'idle'],
-          applications: { gecko: { strict_min_version: '55.0' } },
+          browser_specific_settings: { gecko: { strict_min_version: '55.0' } },
         });
 
         const manifestJSONParser = new ManifestJSONParser(
@@ -1046,7 +1046,7 @@ describe('ManifestJSONParser', () => {
         const addonLinter = new Linter({ _: ['bar'] });
         const json = validManifestJSON({
           [mainfestKey]: ['idle', 'wat'],
-          applications: { gecko: { strict_max_version: '55.0' } },
+          browser_specific_settings: { gecko: { strict_max_version: '55.0' } },
         });
         const manifestJSONParser = new ManifestJSONParser(
           json,
@@ -1165,7 +1165,7 @@ describe('ManifestJSONParser', () => {
     it('warns on strict_max_version', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_max_version: '58.0',
           },
@@ -1184,7 +1184,7 @@ describe('ManifestJSONParser', () => {
     it('does not warn on strict_max_version in language packs', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validLangpackManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_max_version: '58.0',
           },
@@ -1201,7 +1201,7 @@ describe('ManifestJSONParser', () => {
     it('errors on strict_max_version in dictionaries', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validDictionaryManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             id: '@my-dictionary',
             strict_max_version: '58.0',
@@ -1224,7 +1224,7 @@ describe('ManifestJSONParser', () => {
     it('should warn when using a manifest key before Firefox marks it as supported', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '47.0',
           },
@@ -1255,7 +1255,7 @@ describe('ManifestJSONParser', () => {
     it('should warn when using a manifest key before Firefox for Android marks it as supported', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '47.0',
           },
@@ -1293,7 +1293,7 @@ describe('ManifestJSONParser', () => {
     it('should not warn when all manifest keys are supported in Firefox and Firefox for Android with the given strict_min_version', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '48.0a1',
           },
@@ -1311,7 +1311,7 @@ describe('ManifestJSONParser', () => {
     it('should ignore manifest key version support for dictionaries', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validDictionaryManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             id: '@my-dictionary',
             strict_min_version: '47.0',
@@ -1333,7 +1333,7 @@ describe('ManifestJSONParser', () => {
     it('should ignore manifest key version support for langpacks', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validLangpackManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '47.0',
           },
@@ -1351,7 +1351,7 @@ describe('ManifestJSONParser', () => {
     it('should warn on unsupported subkeys', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '54.0',
           },
@@ -1378,7 +1378,7 @@ describe('ManifestJSONParser', () => {
     it('should warn on unsupported subsubkeys', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '56.0',
           },
@@ -1407,7 +1407,7 @@ describe('ManifestJSONParser', () => {
     it('should add a notice on unsupported permissions', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '56.0',
           },
@@ -1430,7 +1430,7 @@ describe('ManifestJSONParser', () => {
     it('should add a notice on unsupported permissions on android', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             strict_min_version: '55.0',
           },
@@ -1559,7 +1559,7 @@ describe('ManifestJSONParser', () => {
         const jsonV3 = validManifestJSON({
           manifest_version: 3,
           content_security_policy: contentSecurityPolicy,
-          applications: {
+          browser_specific_settings: {
             // The new content_security_policy syntax is only supported
             // on Firefox >= 72.
             gecko: { strict_min_version: '72.0', id: 'some@id' },
@@ -1664,7 +1664,7 @@ describe('ManifestJSONParser', () => {
             content_scripts: validValue,
             isolated_world: validValue,
           },
-          applications: {
+          browser_specific_settings: {
             // The new content_security_policy syntax is only supported
             // on Firefox >= 72.
             gecko: { strict_min_version: '72.0', id: 'some@id' },
@@ -1727,7 +1727,7 @@ describe('ManifestJSONParser', () => {
         const jsonV3 = validManifestJSON({
           manifest_version: 3,
           content_security_policy: contentSecurityPolicy,
-          applications: {
+          browser_specific_settings: {
             // The new content_security_policy syntax is only supported
             // on Firefox >= 72.
             gecko: { strict_min_version: '72.0', id: 'some@id' },
@@ -1773,12 +1773,12 @@ describe('ManifestJSONParser', () => {
       expect(notices[0].message).toContain('update_url');
     });
 
-    // applications.gecko.update_url isn't allowed if the add-on is being
-    // hosted on AMO.
+    // browser_specific_settings.gecko.update_url isn't allowed if the add-on is
+    // being hosted on AMO.
     it('is not allowed', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             update_url: 'https://foo.com/bar',
           },
@@ -1798,7 +1798,7 @@ describe('ManifestJSONParser', () => {
     it('emits a warning for privileged extensions', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             update_url: 'https://foo.com/bar',
           },
@@ -1826,7 +1826,7 @@ describe('ManifestJSONParser', () => {
     it('is not an issue if self-hosted and privileged', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             update_url: 'https://foo.com/bar',
           },
@@ -1852,7 +1852,7 @@ describe('ManifestJSONParser', () => {
     it('is not an issue if self-hosted', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
-        applications: {
+        browser_specific_settings: {
           gecko: {
             update_url: 'https://foo.com/bar',
           },
@@ -2216,9 +2216,8 @@ describe('ManifestJSONParser', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const icon = 'tests/fixtures/default.png';
       const json = validManifestJSON({
-        // Avoid any type of warning by setting the appropriate
-        // firefox version.
-        applications: {
+        // Avoid any type of warning by setting the appropriate firefox version.
+        browser_specific_settings: {
           gecko: {
             id: '{daf44bf7-a45e-4450-979c-91cf07434c3d}',
             strict_min_version: '55.0.0',
@@ -2919,7 +2918,7 @@ describe('ManifestJSONParser', () => {
     it('throws error on dictionary with missing applications->gecko', () => {
       const linter = new Linter({ _: ['bar'] });
       const json = validDictionaryManifestJSON({
-        applications: {},
+        browser_specific_settings: {},
       });
       const manifestJSONParser = new ManifestJSONParser(
         json,
@@ -2940,7 +2939,7 @@ describe('ManifestJSONParser', () => {
     it('throws error on dictionary with missing applications->gecko->id', () => {
       const linter = new Linter({ _: ['bar'] });
       const json = validDictionaryManifestJSON({
-        applications: { gecko: {} },
+        browser_specific_settings: { gecko: {} },
       });
       const manifestJSONParser = new ManifestJSONParser(
         json,
@@ -4547,5 +4546,155 @@ describe('ManifestJSONParser', () => {
         expect(Array.from(experimentApiPaths)).toEqual(expected);
       }
     );
+  });
+
+  describe('applications property - MV2', () => {
+    it('does not emit any warning or error when a MV2 extension does not use applications or browser_specific_settings', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 2,
+          name: 'some name',
+          version: '1',
+        }),
+        linter.collector
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(linter.collector.errors).toEqual([]);
+      expect(linter.collector.warnings).toEqual([]);
+    });
+
+    it('does not emit a warning when a MV2 extension uses browser_specific_settings', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 2,
+          name: 'some name',
+          version: '1',
+          browser_specific_settings: {},
+        }),
+        linter.collector
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(linter.collector.errors).toEqual([]);
+      expect(linter.collector.warnings).toEqual([]);
+    });
+
+    it('emits a warning when a MV2 extension uses applications', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 2,
+          name: 'some name',
+          version: '1',
+          applications: {},
+        }),
+        linter.collector
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(linter.collector.errors).toEqual([]);
+
+      expect(linter.collector.warnings.length).toEqual(1);
+      assertHasMatchingError(linter.collector.warnings, {
+        code: messages.APPLICATIONS_DEPRECATED.code,
+      });
+    });
+
+    it('only emits a single warning when a MV2 extension uses both applications and browser_specific_settings', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 2,
+          name: 'some name',
+          version: '1',
+          applications: {},
+          browser_specific_settings: {},
+        }),
+        linter.collector
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(linter.collector.errors).toEqual([]);
+
+      expect(linter.collector.warnings.length).toEqual(1);
+      // Since the `applications` property is already reported as ignored, we
+      // don't warn about the deprecation of it.
+      assertHasMatchingError(linter.collector.warnings, {
+        code: messages.IGNORED_APPLICATIONS_PROPERTY.code,
+      });
+    });
+  });
+
+  describe('applications property - MV3', () => {
+    it('does not emit any warning or error when a MV3 extension uses browser_specific_settings', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 3,
+          name: 'some name',
+          version: '1',
+          browser_specific_settings: { gecko: { id: 'some@id' } },
+        }),
+        linter.collector,
+        { schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(linter.collector.errors).toEqual([]);
+      expect(linter.collector.warnings).toEqual([]);
+    });
+
+    it('emits an error when a MV3 extension uses applications', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 3,
+          name: 'some name',
+          version: '1',
+          applications: {},
+        }),
+        linter.collector,
+        { schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(false);
+      expect(linter.collector.warnings).toEqual([]);
+
+      assertHasMatchingError(linter.collector.errors, {
+        code: messages.APPLICATIONS_INVALID.code,
+      });
+    });
+
+    it('emits an error when a MV3 extension uses both applications and browser_specific_settings', () => {
+      const linter = new Linter({ _: ['bar'] });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        JSON.stringify({
+          manifest_version: 3,
+          name: 'some name',
+          version: '1',
+          applications: {},
+          browser_specific_settings: {},
+        }),
+        linter.collector,
+        { schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(false);
+      expect(linter.collector.warnings).toEqual([]);
+
+      assertHasMatchingError(linter.collector.errors, {
+        code: messages.APPLICATIONS_INVALID.code,
+      });
+    });
   });
 });

--- a/tests/unit/schema/helpers.js
+++ b/tests/unit/schema/helpers.js
@@ -6,7 +6,7 @@ export const validManifest = {
   manifest_version: 2,
   name: 'test-manifest',
   version: '1.0',
-  applications: {
+  browser_specific_settings: {
     gecko: {
       id: 'test-manifest@mozilla.org',
     },

--- a/tests/unit/schema/test.browser_specific_settings.js
+++ b/tests/unit/schema/test.browser_specific_settings.js
@@ -4,57 +4,57 @@ import { validateAddon } from 'schema/validator';
 
 import { validManifest } from './helpers';
 
-describe('/applications/*', () => {
+describe('/browser_specific_settings/*', () => {
   it('should not require an application object', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications = undefined;
+    manifest.browser_specific_settings = undefined;
     validateAddon(manifest);
     expect(validateAddon.errors).toBeNull();
   });
 });
 
-describe('/applications/gecko/*', () => {
+describe('/browser_specific_settings/gecko/*', () => {
   it('should not require a gecko object', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko = undefined;
+    manifest.browser_specific_settings.gecko = undefined;
     validateAddon(manifest);
     expect(validateAddon.errors).toBeNull();
   });
 
   it('should be invalid due to invalid update_url', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.update_url = 'whatevs';
+    manifest.browser_specific_settings.gecko.update_url = 'whatevs';
     validateAddon(manifest);
     expect(validateAddon.errors.length).toEqual(1);
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/update_url'
+      '/browser_specific_settings/gecko/update_url'
     );
   });
 
   it('should be invalid because http update_url', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.update_url = 'http://foo.com';
+    manifest.browser_specific_settings.gecko.update_url = 'http://foo.com';
     validateAddon(manifest);
     expect(validateAddon.errors.length).toEqual(1);
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/update_url'
+      '/browser_specific_settings/gecko/update_url'
     );
   });
 
   it('should be valid because https update_url', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.update_url = 'https://foo.com';
+    manifest.browser_specific_settings.gecko.update_url = 'https://foo.com';
     validateAddon(manifest);
     expect(validateAddon.errors).toBeNull();
   });
 
   it('should be invalid due to invalid strict_min_version type', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.strict_min_version = 42;
+    manifest.browser_specific_settings.gecko.strict_min_version = 42;
     validateAddon(manifest);
     expect(validateAddon.errors.length).toEqual(1);
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/strict_min_version'
+      '/browser_specific_settings/gecko/strict_min_version'
     );
   });
 
@@ -64,7 +64,7 @@ describe('/applications/gecko/*', () => {
   validMinVersions.forEach((version) => {
     const manifest = cloneDeep(validManifest);
     it(`${version} should be a valid strict_min_version`, () => {
-      manifest.applications.gecko.strict_min_version = version;
+      manifest.browser_specific_settings.gecko.strict_min_version = version;
       expect(validateAddon(manifest)).toBeTruthy();
     });
   });
@@ -73,22 +73,22 @@ describe('/applications/gecko/*', () => {
   invalidMinVersions.forEach((version) => {
     it(`${version} should be an invalid strict_min_version`, () => {
       const manifest = cloneDeep(validManifest);
-      manifest.applications.gecko.strict_min_version = version;
+      manifest.browser_specific_settings.gecko.strict_min_version = version;
       validateAddon(manifest);
       expect(validateAddon.errors.length).toEqual(1);
       expect(validateAddon.errors[0].instancePath).toEqual(
-        '/applications/gecko/strict_min_version'
+        '/browser_specific_settings/gecko/strict_min_version'
       );
     });
   });
 
   it('should be invalid due to invalid strict_max_version type', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.strict_max_version = 42;
+    manifest.browser_specific_settings.gecko.strict_max_version = 42;
     validateAddon(manifest);
     expect(validateAddon.errors.length).toEqual(1);
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/strict_max_version'
+      '/browser_specific_settings/gecko/strict_max_version'
     );
   });
 
@@ -97,58 +97,59 @@ describe('/applications/gecko/*', () => {
   validMaxVersions.forEach((version) => {
     it(`${version} should be a valid strict_max_version`, () => {
       const manifest = cloneDeep(validManifest);
-      manifest.applications.gecko.strict_max_version = version;
+      manifest.browser_specific_settings.gecko.strict_max_version = version;
       expect(validateAddon(manifest)).toBeTruthy();
     });
   });
 
   it('should be invalid due to invalid strict_max_version', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.strict_max_version = 'fifty';
+    manifest.browser_specific_settings.gecko.strict_max_version = 'fifty';
     expect(validateAddon(manifest)).toBeFalsy();
   });
 
   it('should be a valid id (email-like format)', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = 'extensionname@example.org';
+    manifest.browser_specific_settings.gecko.id = 'extensionname@example.org';
     expect(validateAddon(manifest)).toBeTruthy();
   });
 
   it('should be a valid id @whatever', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = '@example.org';
+    manifest.browser_specific_settings.gecko.id = '@example.org';
     expect(validateAddon(manifest)).toBeTruthy();
   });
 
   it('should be a valid id (guid format)', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = '{daf44bf7-a45e-4450-979c-91cf07434c3d}';
+    manifest.browser_specific_settings.gecko.id =
+      '{daf44bf7-a45e-4450-979c-91cf07434c3d}';
     expect(validateAddon(manifest)).toBeTruthy();
   });
 
   it('should be invalid for a number', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = 10;
+    manifest.browser_specific_settings.gecko.id = 10;
     validateAddon(manifest);
     expect(validateAddon.errors.length >= 1).toBeTruthy();
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/id'
+      '/browser_specific_settings/gecko/id'
     );
   });
 
   it('should be invalid id format', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = 'whatevs';
+    manifest.browser_specific_settings.gecko.id = 'whatevs';
     validateAddon(manifest);
     expect(validateAddon.errors.length >= 1).toBeTruthy();
     expect(validateAddon.errors[0].instancePath).toEqual(
-      '/applications/gecko/id'
+      '/browser_specific_settings/gecko/id'
     );
   });
 
   it('should accept an add-on without an id', () => {
     const manifest = cloneDeep(validManifest);
-    manifest.applications.gecko.id = undefined;
+    manifest.browser_specific_settings.gecko.id = undefined;
     validateAddon(manifest);
     expect(validateAddon.errors).toBeNull();
   });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/4533

This PR adds two new messages:

1. `APPLICATIONS_DEPRECATED` for MV2 extensions to let developers know that they should be using `browser_specific_settings` instead of `applications`
2. `APPLICTIONS_INVALID` for MV3 extensions, for which we want to prevent the use of `applications` in the manifest