### PR TITLE
fix: validation fails with NO_MESSAGES_FILE_IN_LOCALES ...

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -686,7 +686,10 @@ export default class ManifestJSONParser extends JSONParser {
       // get arrays of found locales and valid locales (has messages.json)
       for (let i = 0; i < fileList.length; i++) {
         const matches = fileList[i].match(localeDirRe);
-        if (matches && !seen.includes(matches[1])) seen.push(matches[1]);
+
+        if (matches && !seen.includes(matches[1])) {
+          seen.push(matches[1]);
+        }
 
         if (matches && fileList[i].match(localeFileRe)) {
           validated.push(matches[1]);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -697,7 +697,7 @@ export default class ManifestJSONParser extends JSONParser {
         }
       }
 
-      // compare found locales with validated locales and push errors
+      // Emit an error for each locale without a `messages.json` file.
       for (let i = 0; i < seen.length; i++) {
         if (!validated.includes(seen[i])) {
           errors.push(

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -683,7 +683,8 @@ export default class ManifestJSONParser extends JSONParser {
       const validated = [];
       const errors = [];
 
-      // get arrays of found locales and valid locales (has messages.json)
+      // Collect distinct locales (based on the content of `_locales/`) as
+      // well as the locales for which we have a `messages.json` file.
       for (let i = 0; i < fileList.length; i++) {
         const matches = fileList[i].match(localeDirRe);
 

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -688,8 +688,9 @@ export default class ManifestJSONParser extends JSONParser {
         const matches = fileList[i].match(localeDirRe);
         if (matches && !seen.includes(matches[1])) seen.push(matches[1]);
 
-        if (matches && fileList[i].match(localeFileRe))
+        if (matches && fileList[i].match(localeFileRe)) {
           validated.push(matches[1]);
+        }
       }
 
       // compare found locales with validated locales and push errors

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -679,8 +679,8 @@ export default class ManifestJSONParser extends JSONParser {
         `^${LOCALES_DIRECTORY}/.*?/${MESSAGES_JSON}$`
       );
 
-      const seen = [];
-      const validated = [];
+      const locales = [];
+      const localesWithMessagesJson = [];
       const errors = [];
 
       // Collect distinct locales (based on the content of `_locales/`) as
@@ -688,21 +688,21 @@ export default class ManifestJSONParser extends JSONParser {
       for (let i = 0; i < fileList.length; i++) {
         const matches = fileList[i].match(localeDirRe);
 
-        if (matches && !seen.includes(matches[1])) {
-          seen.push(matches[1]);
+        if (matches && !locales.includes(matches[1])) {
+          locales.push(matches[1]);
         }
 
         if (matches && fileList[i].match(localeFileRe)) {
-          validated.push(matches[1]);
+          localesWithMessagesJson.push(matches[1]);
         }
       }
 
       // Emit an error for each locale without a `messages.json` file.
-      for (let i = 0; i < seen.length; i++) {
-        if (!validated.includes(seen[i])) {
+      for (let i = 0; i < locales.length; i++) {
+        if (!localesWithMessagesJson.includes(locales[i])) {
           errors.push(
             messages.noMessagesFileInLocales(
-              path.join(LOCALES_DIRECTORY, seen[i])
+              path.join(LOCALES_DIRECTORY, locales[i])
             )
           );
         }
@@ -711,7 +711,7 @@ export default class ManifestJSONParser extends JSONParser {
       // When there is no default locale, we do not want to emit errors for
       // missing locale files because we ignore those files.
       if (!this.parsedJSON.default_locale) {
-        if (validated.length) {
+        if (localesWithMessagesJson.length) {
           this.collector.addError(messages.NO_DEFAULT_LOCALE);
           this.isValid = false;
         }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -686,8 +686,7 @@ export default class ManifestJSONParser extends JSONParser {
       // get arrays of found locales and valid locales (has messages.json)
       for (let i = 0; i < fileList.length; i++) {
         const matches = fileList[i].match(localeDirRe);
-        if (matches && !seen.includes(matches[1]))
-          seen.push(matches[1]);
+        if (matches && !seen.includes(matches[1])) seen.push(matches[1]);
 
         if (matches && fileList[i].match(localeFileRe))
           validated.push(matches[1]);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -685,7 +685,7 @@ export default class ManifestJSONParser extends JSONParser {
 
       // get arrays of found locales and valid locales (has messages.json)
       for (let i = 0; i < fileList.length; i++) {
-        let matches = fileList[i].match(localeDirRe);
+        const matches = fileList[i].match(localeDirRe);
         if (matches && !seen.includes(matches[1]))
           seen.push(matches[1]);
 
@@ -695,7 +695,7 @@ export default class ManifestJSONParser extends JSONParser {
 
       // compare found locales with validated locales and push errors
       for (let i = 0; i < seen.length; i++) {
-        if ( !validated.includes(seen[i]) ) {
+        if (!validated.includes(seen[i])) {
           errors.push(
             messages.noMessagesFileInLocales(
               path.join(LOCALES_DIRECTORY, seen[i])

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -3542,7 +3542,7 @@ describe('ManifestJSONParser', () => {
       expect(errors).toEqual([]);
     });
 
-    it('does not emit an error when files other than messsages.json are present in language directory', () => {
+    it('does not emit an error when files other than messages.json are present in language directory', () => {
       const addonLinter = new Linter({ _: ['bar'] });
       const json = validManifestJSON({
         default_locale: 'en',

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -3541,6 +3541,32 @@ describe('ManifestJSONParser', () => {
       const { errors } = addonLinter.collector;
       expect(errors).toEqual([]);
     });
+
+    it('does not emit an error when files other than messsages.json are present in language directory', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        default_locale: 'en',
+      });
+      const directory = {
+        files: {
+          '_locales/en/messages.json': { size: 1000 },
+          '_locales/de/messages.json': { size: 1120 },
+          '_locales/hi/messages.json': { size: 1120 },
+          '_locales/en/styles.css': { size: 1000 },
+          '_locales/de/styles.css': { size: 1120 },
+          '_locales/hi/styles.css': { size: 1120 },
+        },
+      };
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { io: directory }
+      );
+      expect(manifestJSONParser.isValid).toEqual(true);
+      const { errors } = addonLinter.collector;
+      expect(errors).toEqual([]);
+    });
   });
 
   describe('sitepermission', () => {


### PR DESCRIPTION
 ... if directory contains files other than messages.json #4535

Fixes #4535

Patch tracks _locale directories and messages.json files in separate arrays, then compares arrays to determine which locales, if any, are invalid before registering errors. Prevents files not named `messages.json` from throwing `NO_MESSAGES_FILE_IN_LOCALES` errors. 