### PR TITLE
feat: Imported Firefox 107.0b8 API schema

### DIFF
--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -280,17 +280,7 @@
           "description": "The result of the script execution."
         },
         "error": {
-          "type": "object",
-          "description": "When the injection has failed, the error is exposed to the caller with this property.",
-          "properties": {
-            "message": {
-              "type": "string",
-              "description": "A message explaining why the injection has failed."
-            }
-          },
-          "required": [
-            "message"
-          ]
+          "description": "The error property is set when the script execution failed. The value is typically an (Error) object with a message property, but could be any value (including primitives and undefined) if the script threw or rejected with such a value."
         }
       },
       "required": [


### PR DESCRIPTION
The updated schema data includes the following changes:
- [Bug 1740608 - Implement proper error handling for `scripting.executeScript()`](https://bugzilla.mozilla.org/show_bug.cgi?id=1740608).

The change is restricted to the `InjectResult` type, which is only used for the type of an API method resolved value, and so we don't expect any particular change in behavior on the addons-linter side.

Fixes #4548