### PR TITLE
chore: simplify CSP validation logic

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -202,10 +202,11 @@ export const TEMPORARY_APIS = [
 // See https://mzl.la/2vwqbGU for more details and allowed options.
 export const CSP_KEYWORD_RE = new RegExp(
   [
+    "^'(", // <-- keywords always start and end with '.
     '(self|none|unsafe-inline|strict-dynamic|unsafe-hashed-attributes|wasm-unsafe-eval)',
-    // Only match these keywords, anything else is forbidden
-    '(?!.)',
-    '|(sha(256|384|512)-|nonce-)',
+    '|(sha(256|384|512)-|nonce-).*',
+    ")'$",
+    '|^moz-extension:',
   ].join('')
 );
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -269,16 +269,11 @@ export function parseCspPolicy(policy) {
 
   // See https://www.w3.org/TR/CSP3/#parse-serialized-policy
 
-  // eslint-disable-next-line no-param-reassign
-  policy = policy.toLowerCase();
-
   const parsedPolicy = {};
-  const directives = policy.split(';');
+  const directives = policy.toLowerCase().split(';');
 
   directives.forEach((directive) => {
-    // eslint-disable-next-line no-param-reassign
-    directive = directive.trim();
-    const tokens = directive.split(/\s+/);
+    const tokens = directive.trim().split(/\s+/);
 
     const name = tokens[0];
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -1653,6 +1653,7 @@ describe('ManifestJSONParser', () => {
 
         'script-src *',
         'script-src moz-extension: *', // mixed with * invalid
+        'script-src self', // should have been "'self'", not "self"
         'script-src ws:',
         'script-src wss:',
         'script-src http:',
@@ -1763,6 +1764,7 @@ describe('ManifestJSONParser', () => {
       const validValues = [
         'default-src moz-extension:',
         'script-src moz-extension:',
+        "script-src  'self' ; object-src 'self' ", // spaces around
 
         // Mix with other directives
         "script-src 'self'; object-src 'self'",


### PR DESCRIPTION
The original CSP validation implementation was unnecessarily complex. This part removes redundant logic that's already covered elsewhere.

This is a refactor that does not change the behavior that we care about. This is evidenced by the unit tests.

I added even two more unit tests:
- Verification that the presence of extra space around the directives is still correctly parsed. This works because consecutive spaces are already erased by the [parseCspPolicy helper](https://github.com/mozilla/addons-linter/blob/d2ef1c846d5074a9566594d39fdf42a0b91a2171/src/utils.js#L280-L281).
- Verification that `script-src self` raises a warning. The previous implementation stripped `'`, so it could not distinguish between `'self'` and `self` (or `self'` or `'self`). Now it does.