### PR TITLE
fix: array pattern with omitted element should not cause the file to be interpreted as script

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -231,7 +231,7 @@ export default class JavaScriptScanner {
 
         if (Array.isArray(child)) {
           for (let j = 0; j < child.length; ++j) {
-            if (this._getSourceType(child[j]) === 'module') {
+            if (child[j] && this._getSourceType(child[j]) === 'module') {
               return 'module';
             }
           }

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -445,6 +445,7 @@ describe('JavaScript Scanner', () => {
     it('should detect module (multiple statements)', async () => {
       const code = oneLine`
         let value = 0;
+        let [, x] = [, 0];
         export { value };
       `;
 


### PR DESCRIPTION
`ArrayPattern.elements[i]` may be `null` if the element is omitted, which would cause js error and fallback to script mode regardless of the actual source type

Fixes #4581