### PR TITLE
Raise error when `install_origins` is absent from manifest for self-hosted and MV3

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -605,6 +605,11 @@
 <td>error</td>
 <td>The version string is not valid because its format is too complex.</td>
 </tr>
+<tr>
+<td><code>INSTALL_ORIGINS_REQUIRED</code></td>
+<td>error</td>
+<td>The <code>install_origins</code> property is required in the manifest for self-hosted versions in Manifest Version 3 and above.</td>
+</tr>
 </tbody>
 </table>
 <h3 id="static-theme-%2F-manifest.json" tabindex="-1">Static Theme / manifest.json <a class="header-anchor" href="#static-theme-%2F-manifest.json">¶</a></h3>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -141,6 +141,7 @@ Rules are sorted by severity.
 | `APPLICATIONS_INVALID`                                  | error    | The `applications` property is no longer accepted in Manifest Version 3 and above.                                                                                 |
 | `VERSION_FORMAT_DEPRECATED`                             | warning  | The version string should be simplified.                                                                                                                           |
 | `VERSION_FORMAT_INVALID`                                | error    | The version string is not valid because its format is too complex.                                                                                                 |
+| `INSTALL_ORIGINS_REQUIRED`                              | error    | The `install_origins` property is required in the manifest for self-hosted versions in Manifest Version 3 and above.                                               |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -795,3 +795,14 @@ export const VERSION_FORMAT_INVALID = {
     https://mzl.la/3h3mCRu (MDN Docs) for more information.`),
   file: MANIFEST_JSON,
 };
+
+export const INSTALL_ORIGINS_REQUIRED = {
+  code: 'INSTALL_ORIGINS_REQUIRED',
+  message: i18n._(
+    'The "install_origins" property is required in the manifest.'
+  ),
+  description: i18n._(oneLine`The "install_origins" property is required in the
+    manifest for self-hosted versions in Manifest Version 3 and above. See
+    https://mzl.la/3TEbqbE (MDN Docs) for more information.`),
+  file: MANIFEST_JSON,
+};

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -719,6 +719,15 @@ export default class ManifestJSONParser extends JSONParser {
       this.validateHomePageURL(this.parsedJSON.homepage_url);
     }
 
+    if (
+      this.selfHosted &&
+      this.parsedJSON.manifest_version > 2 &&
+      !this.parsedJSON.install_origins
+    ) {
+      this.collector.addError(messages.INSTALL_ORIGINS_REQUIRED);
+      this.isValid = false;
+    }
+
     this.validateRestrictedPermissions();
     this.validateExtensionID();
     this.validateHiddenAddon();

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4596,6 +4596,78 @@ describe('ManifestJSONParser', () => {
       );
       expect(manifestJSONParser.isValid).toEqual(true);
     });
+
+    it('does not emit an error when the install_origins prop is missing in MV2 self-hosted', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 2,
+        install_origins: undefined,
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { selfHosted: false }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(addonLinter.collector.errors).toEqual([]);
+    });
+
+    it('does not emit an error when the install_origins prop is missing in MV3', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        install_origins: undefined,
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(addonLinter.collector.errors).toEqual([]);
+    });
+
+    it('does not emit an error when the install_origins prop is empty in MV3 self-hosted', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        install_origins: [],
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { selfHosted: true, schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(true);
+      expect(addonLinter.collector.errors).toEqual([]);
+    });
+
+    it('emits an error when the install_origins prop is missing in MV3 self-hosted', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        install_origins: undefined,
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector,
+        { selfHosted: true, schemaValidatorOptions: { maxManifestVersion: 3 } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(false);
+      expect(addonLinter.collector.errors[0]).toMatchObject(
+        expect.objectContaining({
+          code: messages.INSTALL_ORIGINS_REQUIRED.code,
+        })
+      );
+    });
   });
 
   describe('experimentApiPaths', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/3973
