### PR TITLE
feat: Import firefox 108.0b5 schema data

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -314,6 +314,8 @@ export default class Linter {
           privileged: this.config.privileged,
           minManifestVersion: this.config.minManifestVersion,
           maxManifestVersion: this.config.maxManifestVersion,
+          enableBackgroundServiceWorker:
+            this.config.enableBackgroundServiceWorker,
         },
       });
       await manifestParser.validateIcons();

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -40,7 +40,9 @@ export function manifestFieldPrivilegedOnly(fieldName) {
 
 export const MANIFEST_FIELD_UNSUPPORTED = 'MANIFEST_FIELD_UNSUPPORTED';
 export function manifestFieldUnsupported(fieldName, error) {
-  const versionRange = errorParamsToUnsupportedVersionRange(error.params);
+  const versionRange = error
+    ? errorParamsToUnsupportedVersionRange(error.params)
+    : null;
   const messageTmpl = versionRange
     ? i18n._(oneLine`"%(fieldName)s" is in a format not supported in
                      manifest versions %(versionRange)s.`)

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -513,7 +513,15 @@ export default class ManifestJSONParser extends JSONParser {
         );
       }
       if (this.parsedJSON.background.service_worker) {
-        if (this.parsedJSON.manifest_version >= 3) {
+        if (!this.schemaValidatorOptions?.enableBackgroundServiceWorker) {
+          // Report an error and mark the manifest as invalid if
+          // background service worker support isn't enabled by
+          // the addons-linter feature flag.
+          this.collector.addError(
+            messages.manifestFieldUnsupported('/background')
+          );
+          this.isValid = false;
+        } else if (this.parsedJSON.manifest_version >= 3) {
           this.validateFileExistsInPackage(
             this.parsedJSON.background.service_worker,
             'script'

--- a/src/schema/imported/action.json
+++ b/src/schema/imported/action.json
@@ -448,10 +448,23 @@
     {
       "name": "openPopup",
       "type": "function",
-      "requireUserInput": true,
-      "description": "Opens the extension popup window in the active window.",
+      "description": "Opens the extension popup window in the specified window.",
       "async": true,
-      "parameters": []
+      "parameters": [
+        {
+          "name": "options",
+          "optional": true,
+          "type": "object",
+          "description": "An object with information about the popup to open.",
+          "properties": {
+            "windowId": {
+              "type": "integer",
+              "minimum": -2,
+              "description": "Defaults to the $(topic:current-window)[current window]."
+            }
+          }
+        }
+      ]
     }
   ],
   "events": [

--- a/src/schema/imported/browser_action.json
+++ b/src/schema/imported/browser_action.json
@@ -488,10 +488,23 @@
     {
       "name": "openPopup",
       "type": "function",
-      "requireUserInput": true,
-      "description": "Opens the extension popup window in the active window.",
+      "description": "Opens the extension popup window in the specified window.",
       "async": true,
-      "parameters": []
+      "parameters": [
+        {
+          "name": "options",
+          "optional": true,
+          "type": "object",
+          "description": "An object with information about the popup to open.",
+          "properties": {
+            "windowId": {
+              "type": "integer",
+              "minimum": -2,
+              "description": "Defaults to the $(topic:current-window)[current window]."
+            }
+          }
+        }
+      ]
     }
   ],
   "events": [

--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -109,6 +109,17 @@
           ]
         },
         {
+          "name": "options",
+          "type": "object",
+          "optional": true,
+          "properties": {
+            "includeOtherExtensions": {
+              "type": "boolean",
+              "description": "Whether to account for rules from other installed extensions during rule evaluation."
+            }
+          }
+        },
+        {
           "name": "callback",
           "type": "function",
           "description": "Called with the details of matched rules.",
@@ -206,6 +217,10 @@
         "rulesetId": {
           "type": "string",
           "description": "ID of the Ruleset this rule belongs to."
+        },
+        "extensionId": {
+          "type": "string",
+          "description": "ID of the extension, if this rule belongs to a different extension."
         }
       },
       "required": [
@@ -249,7 +264,7 @@
               "minItems": 1,
               "items": {
                 "type": "string",
-                "description": "TODO: describe domain format."
+                "format": "canonicalDomain"
               }
             },
             "excludedInitiatorDomains": {
@@ -257,7 +272,7 @@
               "description": "The rule will not match network requests originating from the list of 'initiatorDomains'. If the list is empty or omitted, no domains are excluded. This takes precedence over 'initiatorDomains'.",
               "items": {
                 "type": "string",
-                "description": "TODO: describe domain format."
+                "format": "canonicalDomain"
               }
             },
             "requestDomains": {
@@ -266,7 +281,7 @@
               "minItems": 1,
               "items": {
                 "type": "string",
-                "description": "TODO: describe domain format."
+                "format": "canonicalDomain"
               }
             },
             "excludedRequestDomains": {
@@ -274,7 +289,7 @@
               "description": "The rule will not match network requests when the domains matches one from the list of 'excludedRequestDomains'. If the list is empty or omitted, no domains are excluded. This takes precedence over 'requestDomains'.",
               "items": {
                 "type": "string",
-                "description": "TODO: describe domain format."
+                "format": "canonicalDomain"
               }
             },
             "resourceTypes": {
@@ -288,7 +303,6 @@
             "excludedResourceTypes": {
               "type": "array",
               "description": "List of resource types which the rule won't match. Cannot be specified if 'resourceTypes' is specified. If neither of them is specified, all resource types except 'main_frame' are matched.",
-              "minItems": 1,
               "items": {
                 "$ref": "#/types/ResourceType"
               }
@@ -304,7 +318,6 @@
             "excludedRequestMethods": {
               "type": "array",
               "description": "List of request methods which the rule won't match. Cannot be specified if 'requestMethods' is specified. If neither of them is specified, all request methods are matched.",
-              "minItems": 1,
               "items": {
                 "type": "string"
               }
@@ -363,6 +376,7 @@
                 },
                 "url": {
                   "type": "string",
+                  "format": "url",
                   "description": "The redirect url. Redirects to JavaScript urls are not allowed."
                 },
                 "regexSubstitution": {
@@ -372,57 +386,65 @@
               }
             },
             "requestHeaders": {
-              "type": "object",
+              "type": "array",
               "description": "The request headers to modify for the request. Only valid when type is 'modifyHeaders'.",
-              "properties": {
-                "header": {
-                  "type": "string",
-                  "description": "The name of the request header to be modified."
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "header": {
+                    "type": "string",
+                    "description": "The name of the request header to be modified."
+                  },
+                  "operation": {
+                    "type": "string",
+                    "description": "The operation to be performed on a header. The 'append' operation is not supported for request headers.",
+                    "enum": [
+                      "set",
+                      "remove"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The new value for the header. Must be specified for the 'set' operation."
+                  }
                 },
-                "operation": {
-                  "type": "string",
-                  "description": "The operation to be performed on a header. The 'append' operation is not supported for request headers.",
-                  "enum": [
-                    "set",
-                    "remove"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "description": "The new value for the header. Must be specified for the 'set' operation."
-                }
-              },
-              "required": [
-                "header",
-                "operation"
-              ]
+                "required": [
+                  "header",
+                  "operation"
+                ]
+              }
             },
             "responseHeaders": {
-              "type": "object",
+              "type": "array",
               "description": "The response headers to modify for the request. Only valid when type is 'modifyHeaders'.",
-              "properties": {
-                "header": {
-                  "type": "string",
-                  "description": "The name of the response header to be modified."
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "header": {
+                    "type": "string",
+                    "description": "The name of the response header to be modified."
+                  },
+                  "operation": {
+                    "type": "string",
+                    "description": "The operation to be performed on a header.",
+                    "enum": [
+                      "append",
+                      "set",
+                      "remove"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The new value for the header. Must be specified for the 'append' and 'set' operations."
+                  }
                 },
-                "operation": {
-                  "type": "string",
-                  "description": "The operation to be performed on a header.",
-                  "enum": [
-                    "append",
-                    "set",
-                    "remove"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "description": "The new value for the header. Must be specified for the 'append' and 'set' operations."
-                }
-              },
-              "required": [
-                "header",
-                "operation"
-              ]
+                "required": [
+                  "header",
+                  "operation"
+                ]
+              }
             }
           },
           "required": [

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -20,7 +20,8 @@
               "$ref": "#/types/BrowserSpecificSettings"
             },
             {
-              "description": "The applications property is deprecated, please use 'browser_specific_settings'"
+              "description": "The applications property is deprecated, please use 'browser_specific_settings'",
+              "max_manifest_version": 2
             }
           ],
           "max_manifest_version": 2
@@ -49,8 +50,8 @@
         },
         "version": {
           "type": "string",
-          "description": "Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3.",
-          "format": "versionString"
+          "format": "versionString",
+          "description": "Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3."
         },
         "homepage_url": {
           "type": "string",
@@ -146,8 +147,7 @@
                       "required": [
                         "page"
                       ],
-                      "additionalProperties": false,
-                      "max_manifest_version": 2
+                      "additionalProperties": false
                     },
                     {
                       "type": "object",
@@ -166,8 +166,7 @@
                       },
                       "required": [
                         "scripts"
-                      ],
-                      "max_manifest_version": 2
+                      ]
                     },
                     {
                       "type": "object",

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -30,12 +30,9 @@
                   "background": {
                     "anyOf": [
                       {
-                        "additionalProperties": false,
-                        "max_manifest_version": 2
+                        "additionalProperties": false
                       },
-                      {
-                        "max_manifest_version": 2
-                      },
+                      {},
                       {
                         "min_manifest_version": 3
                       }

--- a/src/yargs-options.js
+++ b/src/yargs-options.js
@@ -47,6 +47,11 @@ const options = {
     type: 'boolean',
     default: false,
   },
+  'enable-background-service-worker': {
+    describe: 'Enable MV3 background service worker support',
+    type: 'boolean',
+    default: false,
+  },
   'min-manifest-version': {
     describe:
       'Set a custom minimum allowed value for the manifest_version property',

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -2909,6 +2909,46 @@ describe('ManifestJSONParser', () => {
 
       expect(manifestJSONParser.isValid).toBeTruthy();
     });
+
+    it('does not error if background.page is used with manifest_version: 3', () => {
+      const linter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        background: { page: 'background_page.html' },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        linter.collector,
+        {
+          io: { files: { 'background_page.html': '' } },
+          schemaValidatorOptions: {
+            maxManifestVersion: 3,
+          },
+        }
+      );
+
+      expect(manifestJSONParser.isValid).toBeTruthy();
+    });
+
+    it('does not error if background.scripts is used with manifest_version: 3', () => {
+      const linter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        background: { scripts: ['background_script.js'] },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        linter.collector,
+        {
+          io: { files: { 'background_script.js': '' } },
+          schemaValidatorOptions: {
+            maxManifestVersion: 3,
+          },
+        }
+      );
+
+      expect(manifestJSONParser.isValid).toBeTruthy();
+    });
   });
 
   describe('content_scripts', () => {


### PR DESCRIPTION
The updated schema data includes the following changes:
- lifted `max_manifest_version: 2` restriction applied on background.page and background.scripts JSONSchema definitions (applied as part of the addons-linter overrides on every new Firefox JOSNSchema data imports)
- [Bug 1755763](https://bugzilla.mozilla.org/show_bug.cgi?id=1755763) - additions to action and browserAction.openPopup parameters (not used by the addons-linter in practice)
- [Bug 1745758](https://bugzilla.mozilla.org/show_bug.cgi?id=1745758) - updates on the declarative_net_request schema data (these changes are also currently unused by the addons-linter in practice)

In addition to the JSONSchema changes, this PR also adds a new addons-linter feature flag `--mv3-background-service-worker` to explicitly gate support for the `background.service_worker` manifest field (given that it was currently gated by just the `min_manifest_version: 3` keyword in the JSONSchema data but its support is locked behind an explicit about:config pref in Firefox and currently disabled by default on all channels).

Fixes #4603
Fixes #4604
Fixes #4605