### PR TITLE
feat: Imported Firefox 110.0b8 API schema

### DIFF
--- a/src/schema/imported/context_menus.json
+++ b/src/schema/imported/context_menus.json
@@ -725,7 +725,6 @@
       "required": [
         "menuItemId",
         "editable",
-        "bookmarkId",
         "modifiers"
       ]
     }

--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -7,6 +7,40 @@
   ],
   "functions": [
     {
+      "name": "updateDynamicRules",
+      "type": "function",
+      "description": "Modifies the current set of dynamic rules for the extension. The rules with IDs listed in options.removeRuleIds are first removed, and then the rules given in options.addRules are added. These rules are persisted across browser sessions and extension updates.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "object",
+          "properties": {
+            "removeRuleIds": {
+              "type": "array",
+              "description": "IDs of the rules to remove. Any invalid IDs will be ignored.",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "addRules": {
+              "type": "array",
+              "description": "Rules to add.",
+              "items": {
+                "$ref": "#/types/Rule"
+              }
+            }
+          }
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Called when the dynamic rules have been updated",
+          "parameters": []
+        }
+      ]
+    },
+    {
       "name": "updateSessionRules",
       "type": "function",
       "description": "Modifies the current set of session scoped rules for the extension. The rules with IDs listed in options.removeRuleIds are first removed, and then the rules given in options.addRules are added. These rules are not persisted across sessions and are backed in memory.",
@@ -113,6 +147,27 @@
       ]
     },
     {
+      "name": "getDynamicRules",
+      "type": "function",
+      "description": "Returns the current set of dynamic rules for the extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "dynamicRules",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/Rule"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "getSessionRules",
       "type": "function",
       "description": "Returns the current set of session scoped rules for the extension.",
@@ -123,6 +178,7 @@
           "type": "function",
           "parameters": [
             {
+              "name": "sessionRules",
               "type": "array",
               "items": {
                 "$ref": "#/types/Rule"

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -350,7 +350,6 @@
                           },
                           "extension_ids": {
                             "type": "array",
-                            "minItems": 1,
                             "items": {
                               "anyOf": [
                                 {

--- a/src/schema/imported/menus.json
+++ b/src/schema/imported/menus.json
@@ -724,7 +724,6 @@
       "required": [
         "menuItemId",
         "editable",
-        "bookmarkId",
         "modifiers"
       ]
     }

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -8,7 +8,7 @@
     {
       "name": "submitPing",
       "type": "function",
-      "description": "Submits a custom ping to the Telemetry back-end. See <code>submitExternalPing</code> inside TelemetryController.jsm for more details.",
+      "description": "Submits a custom ping to the Telemetry back-end. See <code>submitExternalPing</code> inside TelemetryController.sys.mjs for more details.",
       "async": true,
       "parameters": [
         {

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1387,6 +1387,7 @@
           "enum": [
             "webRequest",
             "webRequestBlocking",
+            "webRequestFilterResponse",
             "webRequestFilterResponse.serviceWorkerScript"
           ]
         }


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1707405](https://bugzilla.mozilla.org/show_bug.cgi?id=1707405), added `optional: true` to the `bookmarkId` property definition (a property part of menus `onClickData`)
- [Bug 1745764](https://bugzilla.mozilla.org/show_bug.cgi?id=1745764), added to `declarativeNetRequest` the `updateDynamicRules` and `getDynamicRules` API methods
- [Bug 1809431](https://bugzilla.mozilla.org/show_bug.cgi?id=1809431), allowed optional `web_accessible_resources`'s `extension_ids` to be set to an empty array
- [Bug 1809235](https://bugzilla.mozilla.org/show_bug.cgi?id=1809235), added a new permission `"webRequestFilterResponse"` (which is mandatory for MV3 extensoions to be allowed to use webRequest.filterResponseData API method)

Fixes #4693