### PR TITLE
Move to @fluent/syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.28.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@fluent/syntax": "0.14.0",
         "@mdn/browser-compat-data": "5.2.35",
         "addons-moz-compare": "1.3.0",
         "addons-scanner-utils": "8.3.0",
@@ -24,7 +25,6 @@
         "espree": "9.4.1",
         "esprima": "4.0.1",
         "fast-json-patch": "3.1.1",
-        "fluent-syntax": "0.14.0",
         "glob": "8.1.0",
         "image-size": "1.0.2",
         "is-mergeable-object": "1.1.1",
@@ -2166,6 +2166,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fluent/syntax": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.14.0.tgz",
+      "integrity": "sha512-E+1yHdSo/4PTS6bCbj5J+kzEpucf3eJ0U5mLk7VtnUiMvlPHSbmEL68GLCL9QNTOP3laxZtCHCYDD0Ci/2n97w==",
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5587,15 +5595,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
-    },
-    "node_modules/fluent-syntax": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.14.0.tgz",
-      "integrity": "sha512-+k8uXWfRpSrE33764RbpjIKMzIX6R9EnSjFBgaA1s0Mboc3KnW9sYe0c6vjIoZQY1C4Gst1VFvAOP6YGJjTJuA==",
-      "deprecated": "Renamed to @fluent/syntax 0.14.0",
-      "engines": {
-        "node": ">=8.9.0"
-      }
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "homepage": "https://github.com/mozilla/addons-linter#readme",
   "dependencies": {
+    "@fluent/syntax": "0.14.0",
     "@mdn/browser-compat-data": "5.2.35",
     "addons-moz-compare": "1.3.0",
     "addons-scanner-utils": "8.3.0",
@@ -59,7 +60,6 @@
     "espree": "9.4.1",
     "esprima": "4.0.1",
     "fast-json-patch": "3.1.1",
-    "fluent-syntax": "0.14.0",
     "glob": "8.1.0",
     "image-size": "1.0.2",
     "is-mergeable-object": "1.1.1",

--- a/src/parsers/fluent.js
+++ b/src/parsers/fluent.js
@@ -1,4 +1,4 @@
-import { parse, lineOffset, columnOffset } from 'fluent-syntax';
+import { parse, lineOffset, columnOffset } from '@fluent/syntax';
 
 import * as messages from 'messages';
 


### PR DESCRIPTION
Fixes #4702.

npm module `fluent-syntax` was renamed to `@fluent/syntax`, this PR replaces `fluent-syntax@0.14.0` with `@fluent/syntax@0.14.0` which is functionally identical.

Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

Please delete anything that isn't relevant to your patch.

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.

This code is already tested by existing tests.

Once you have met the above requirements please replace this section with a `Fixes #ISSUENUM` linking to the issue fixed by this PR along with an explanation of the changes. Thanks for your contribution!
