### PR TITLE
feat: Imported Firefox 111.0b7 API schema

### DIFF
--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -273,6 +273,34 @@
       ]
     }
   ],
+  "properties": {
+    "DYNAMIC_RULESET_ID": {
+      "type": "string",
+      "value": "_dynamic",
+      "description": "Ruleset ID for the dynamic rules added by the extension."
+    },
+    "GUARANTEED_MINIMUM_STATIC_RULES": {
+      "type": "number",
+      "description": "The minimum number of static rules guaranteed to an extension across its enabled static rulesets. Any rules above this limit will count towards the global static rule limit."
+    },
+    "MAX_NUMBER_OF_STATIC_RULESETS": {
+      "type": "number",
+      "description": "The maximum number of static Rulesets an extension can specify as part of the rule_resources manifest key."
+    },
+    "MAX_NUMBER_OF_ENABLED_STATIC_RULESETS": {
+      "type": "number",
+      "description": "The maximum number of static Rulesets an extension can enable at any one time."
+    },
+    "MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES": {
+      "type": "number",
+      "description": "The maximum number of dynamic and session rules an extension can add. NOTE: in the Firefox we are enforcing this limit to the session and dynamic rules count separately, instead of enforcing it to the rules count for both combined as the Chrome implementation does."
+    },
+    "SESSION_RULESET_ID": {
+      "type": "string",
+      "value": "_session",
+      "description": "Ruleset ID for the session-scoped rules added by the extension."
+    }
+  },
   "definitions": {
     "Permission": {
       "anyOf": [
@@ -514,7 +542,7 @@
             },
             "isUrlFilterCaseSensitive": {
               "type": "boolean",
-              "description": "Whether 'urlFilter' or 'regexFilter' is case-sensitive. Defaults to true."
+              "description": "Whether 'urlFilter' or 'regexFilter' is case-sensitive."
             },
             "initiatorDomains": {
               "type": "array",

--- a/src/schema/imported/find.json
+++ b/src/schema/imported/find.json
@@ -31,6 +31,10 @@
               "type": "boolean",
               "description": "Find only ranges with case sensitive match."
             },
+            "matchDiacritics": {
+              "type": "boolean",
+              "description": "Find only ranges with diacritic sensitive match."
+            },
             "entireWord": {
               "type": "boolean",
               "description": "Find only ranges that match entire word."

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -172,7 +172,6 @@
         "stackwalk",
         "jsallocations",
         "nostacksampling",
-        "preferencereads",
         "nativeallocations",
         "ipcmessages",
         "audiocallbacktracing",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -454,11 +454,6 @@
           "type": "object",
           "description": "Represents a WebExtension language pack manifest.json file",
           "properties": {
-            "homepage_url": {
-              "type": "string",
-              "format": "url",
-              "preprocess": "localize"
-            },
             "langpack_id": {
               "type": "string",
               "pattern": "^[a-zA-Z][a-zA-Z-]+$"
@@ -540,11 +535,6 @@
           "type": "object",
           "description": "Represents a WebExtension dictionary manifest.json file",
           "properties": {
-            "homepage_url": {
-              "type": "string",
-              "format": "url",
-              "preprocess": "localize"
-            },
             "dictionaries": {
               "type": "object",
               "patternProperties": {

--- a/src/schema/imported/search.json
+++ b/src/schema/imported/search.json
@@ -30,14 +30,65 @@
               "type": "string",
               "description": "Search engine to use. Uses the default if not specified."
             },
+            "disposition": {
+              "allOf": [
+                {
+                  "$ref": "#/types/Disposition"
+                },
+                {
+                  "description": "Location where search results should be displayed. NEW_TAB is the default."
+                }
+              ]
+            },
             "tabId": {
               "type": "integer",
-              "description": "The ID of the tab for the search results. If not specified, a new tab is created."
+              "description": "The ID of the tab for the search results. If not specified, a new tab is created, unless disposition is set. tabId cannot be used with disposition."
             }
           },
           "required": [
             "query"
           ]
+        }
+      ]
+    },
+    {
+      "name": "query",
+      "type": "function",
+      "async": "callback",
+      "description": "Use the chrome.search API to search via the default provider.",
+      "parameters": [
+        {
+          "type": "object",
+          "name": "queryInfo",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "String to query with the default search provider."
+            },
+            "disposition": {
+              "allOf": [
+                {
+                  "$ref": "#/types/Disposition"
+                },
+                {
+                  "description": "Location where search results should be displayed. CURRENT_TAB is the default."
+                }
+              ]
+            },
+            "tabId": {
+              "type": "integer",
+              "description": "Location where search results should be displayed. tabId cannot be used with disposition."
+            }
+          },
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "optional": true,
+          "parameters": []
         }
       ]
     }
@@ -82,6 +133,15 @@
       "required": [
         "name",
         "isDefault"
+      ]
+    },
+    "Disposition": {
+      "type": "string",
+      "description": "Location where search results should be displayed.",
+      "enum": [
+        "CURRENT_TAB",
+        "NEW_TAB",
+        "NEW_WINDOW"
       ]
     }
   }


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1816319](https://bugzilla.mozilla.org/show_bug.cgi?id=1816319):  exposed `DYNAMIC_RULESET_ID` and `SESSION_RULESET_ID` as constant properties of the `declarativeNetRequest` API namespace
- [Bug 1809721](https://bugzilla.mozilla.org/show_bug.cgi?id=1809721): exposed `GUARANTEED_MINIMUM_STATIC_RULES`, `MAX_NUMBER_OF_STATIC_RULESETS`, `MAX_NUMBER_OF_ENABLED_STATIC_RULESETS` and `MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES` as constant properties of the `declarativeNetRequest` API namespace
- [Bug 1680606](https://bugzilla.mozilla.org/show_bug.cgi?id=1680606): Added `matchDiacritics` option to `browser.find.find` API method.
- [Bug 1815438](https://bugzilla.mozilla.org/show_bug.cgi?id=1815438): Removed the 'preferenceread' as a `geckoProfiler` optional feature (these markers are now recorded unconditionally)
- [Bug 1741897](https://bugzilla.mozilla.org/show_bug.cgi?id=1741897) : Removed redundant definition of the `homepage_url` manifest field JSONSchema
- [Bug 1804357](https://bugzilla.mozilla.org/show_bug.cgi?id=1804357): Added JSONSchema for the new `browser.search.query` API method
- [Bug 1811274](https://bugzilla.mozilla.org/show_bug.cgi?id=1811274): Added new `disposition` property to `browser.search.search` API method

Fixes #4732