### PR TITLE
chore: Add test + comment for version_added: "preview"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -387,6 +387,7 @@ export function basicCompatVersionComparison(versionAdded, minVersion) {
  *          or a boolean indicating if the feature is supported at all. We do
  *          not consider any holes in the supported versions, only the first
  *          stable version is taken into account.
+ *          May also return "preview", as defined at https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#choosing-preview-values
  */
 export function firstStableVersion(supportInfo) {
   let supportInfoArray = supportInfo;
@@ -423,6 +424,7 @@ export function isCompatible(bcd, path, minVersion, application) {
   if (api.__compat) {
     const supportInfo = api.__compat.support[application];
     const versionAdded = firstStableVersion(supportInfo);
+    // Note: if versionAdded is false or not a number, this will return true.
     return !basicCompatVersionComparison(versionAdded, minVersion);
   }
   return true;

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -605,6 +605,20 @@ describe('isCompatible', () => {
     ).toBe(true);
   });
 
+  it('should be compatible if version_added is "preview"', () => {
+    // "preview" means that the supported version is unknown or uncertain. That
+    // means that the feature could be compatible, and therefore isCompatible
+    // should return true.
+    expect(
+      isCompatible(
+        getBCDForFeature({ version_added: 'preview' }),
+        'foo',
+        60,
+        'firefox'
+      )
+    ).toBe(true);
+  });
+
   it('should report devtools.network.onRequestFinished as compatible for Firefox 60', () => {
     expect(
       isCompatible(bcd, 'devtools.network.onRequestFinished', 60, 'firefox')


### PR DESCRIPTION
This does not change behavior, it merely verifies existing behavior.

Note that technically, the function name `firstStableVersion` suggests that the version number should be a version number, but that the actual consumers of it does not care: the callers use `basicCompatVersionComparison` to compare the version strings, which treats `false` and strings and generally any NaN value as equivalent.

Fixes #4713.