### PR TITLE
Document the fact that we use Node 16 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ bin/addons-linter my-addon.zip
 
 ### Required Node version
 
-addons-linter requires Node.js v14 or greater. Have a look at our `.circleci/config.yml` file which Node.js versions we officially test.
+addons-linter requires Node.js v16 or greater. Have a look at our `.circleci/config.yml` file which Node.js versions we officially test.
 
 Using nvm is probably the easiest way to manage multiple Node versions side by side. See [nvm on GitHub](https://github.com/creationix/nvm) for more details.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "yazl": "2.5.1"
       },
       "engines": {
-        "node": ">=12.21.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "addons-linter": "bin/addons-linter"
   },
   "engines": {
-    "node": ">=12.21.0"
+    "node": ">=16.0.0"
   },
   "browserslist": [
-    "node >=12.21.0"
+    "node >=16.0.0"
   ],
   "scripts": {
     "build": "webpack --bail --stats-error-details true --color --config webpack.config.js",


### PR DESCRIPTION
I inadvertently pushed the commit to update the Node versions instead of creating a PR last week... 😪 

Commit is: https://github.com/mozilla/addons-linter/commit/bd5c79f774eb60af83dcc798cce0f31af28e3618