### PR TITLE
feat: Imported Firefox 112.0b10 API schema

### DIFF
--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -189,6 +189,66 @@
       ]
     },
     {
+      "name": "isRegexSupported",
+      "type": "function",
+      "description": "Checks if the given regular expression will be supported as a 'regexFilter' rule condition.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "regexOptions",
+          "type": "object",
+          "properties": {
+            "regex": {
+              "type": "string",
+              "description": "The regular expresson to check."
+            },
+            "isCaseSensitive": {
+              "type": "boolean",
+              "description": "Whether the 'regex' specified is case sensitive.",
+              "default": false
+            },
+            "requireCapturing": {
+              "type": "boolean",
+              "description": "Whether the 'regex' specified requires capturing. Capturing is only required for redirect rules which specify a 'regexSubstition' action.",
+              "default": false
+            }
+          },
+          "required": [
+            "regex"
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "result",
+              "type": "object",
+              "properties": {
+                "isSupported": {
+                  "type": "boolean",
+                  "description": "Whether the given regex is supported"
+                },
+                "reason": {
+                  "allOf": [
+                    {
+                      "$ref": "#/types/UnsupportedRegexReason"
+                    },
+                    {
+                      "description": "Specifies the reason why the regular expression is not supported. Only provided if 'isSupported' is false."
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "isSupported"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "testMatchOutcome",
       "type": "function",
       "description": "Checks if any of the extension's declarativeNetRequest rules would match a hypothetical request.",
@@ -295,6 +355,10 @@
       "type": "number",
       "description": "The maximum number of dynamic and session rules an extension can add. NOTE: in the Firefox we are enforcing this limit to the session and dynamic rules count separately, instead of enforcing it to the rules count for both combined as the Chrome implementation does."
     },
+    "MAX_NUMBER_OF_REGEX_RULES": {
+      "type": "number",
+      "description": "The maximum number of regular expression rules that an extension can add. This limit is evaluated separately for the set of session rules, dynamic rules and those specified in the rule_resources file."
+    },
     "SESSION_RULESET_ID": {
       "type": "string",
       "value": "_session",
@@ -313,12 +377,22 @@
         }
       ]
     },
+    "OptionalPermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "declarativeNetRequestFeedback"
+          ],
+          "min_manifest_version": 3
+        }
+      ]
+    },
     "PermissionNoPrompt": {
       "anyOf": [
         {
           "type": "string",
           "enum": [
-            "declarativeNetRequestFeedback",
             "declarativeNetRequestWithHostAccess"
           ],
           "min_manifest_version": 3
@@ -377,6 +451,10 @@
       "namespace": "manifest",
       "type": "Permission"
     },
+    "declarativeNetRequest#/definitions/OptionalPermission": {
+      "namespace": "manifest",
+      "type": "OptionalPermission"
+    },
     "declarativeNetRequest#/definitions/PermissionNoPrompt": {
       "namespace": "manifest",
       "type": "PermissionNoPrompt"
@@ -411,6 +489,14 @@
         "web_manifest",
         "speculative",
         "other"
+      ]
+    },
+    "UnsupportedRegexReason": {
+      "type": "string",
+      "description": "Describes the reason why a given regular expression isn't supported.",
+      "enum": [
+        "syntaxError",
+        "memoryLimitExceeded"
       ]
     },
     "MatchedRule": {
@@ -673,7 +759,7 @@
                 },
                 "regexSubstitution": {
                   "type": "string",
-                  "description": "TODO with regexFilter + Substitution pattern for rules which specify a 'regexFilter'."
+                  "description": "Substitution pattern for rules which specify a 'regexFilter'. The first match of regexFilter within the url will be replaced with this pattern. Within regexSubstitution, backslash-escaped digits (\\1 to \\9) can be used to insert the corresponding capture groups. \\0 refers to the entire matching text."
                 }
               }
             },

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -166,7 +166,7 @@
         "mainthreadio",
         "fileio",
         "fileioall",
-        "noiostacks",
+        "nomarkerstacks",
         "screenshots",
         "seqstyle",
         "stackwalk",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -158,6 +158,13 @@
                             "$ref": "manifest#/types/ExtensionURL"
                           }
                         },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "module",
+                            "classic"
+                          ]
+                        },
                         "persistent": {
                           "type": "boolean",
                           "max_manifest_version": 2,
@@ -672,6 +679,9 @@
         },
         {
           "$ref": "browsingData#/definitions/OptionalPermission"
+        },
+        {
+          "$ref": "declarativeNetRequest#/definitions/OptionalPermission"
         },
         {
           "$ref": "devtools#/definitions/OptionalPermission"

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1797,6 +1797,22 @@
             "$ref": "#/types/TransportWeaknessReasons"
           },
           "description": "list of reasons that cause the request to be considered weak, if state is \"weak\""
+        },
+        "usedEch": {
+          "type": "boolean",
+          "description": "True if the TLS connection used Encrypted Client Hello."
+        },
+        "usedDelegatedCredentials": {
+          "type": "boolean",
+          "description": "True if the TLS connection used Delegated Credentials."
+        },
+        "usedOcsp": {
+          "type": "boolean",
+          "description": "True if the TLS connection made OCSP requests."
+        },
+        "usedPrivateDns": {
+          "type": "boolean",
+          "description": "True if the TLS connection used a privacy-preserving DNS transport like DNS-over-HTTPS."
         }
       },
       "required": [


### PR DESCRIPTION
The updated schema data includes the following changes:
- [Bug 1745767](https://bugzilla.mozilla.org/show_bug.cgi?id=1745767) - Added `isRegexSupported` API method to `declarativeNetRequest`
- [Bug 1745760](https://bugzilla.mozilla.org/show_bug.cgi?id=1745760) - exposed `MAX_NUMBER_OF_REGEX_RULES` as an additional constant property of the declarativeNetRequest API namespace
- [Bug 1811947](https://bugzilla.mozilla.org/show_bug.cgi?id=1811947) - changed `declarativeNetRequestFeedback` to be supported as an optional permission
- [Bug 1814908](https://bugzilla.mozilla.org/show_bug.cgi?id=1814908) - Renamed geckoProfiler `noiostacks` into `nomarkerstacks`
- [Bug 1811443](https://bugzilla.mozilla.org/show_bug.cgi?id=1811443) - Added support for `type` property (set to `"module"` or `"classic"`) along with `background`'s `scripts` manifest property.
- [Bug 1804460](https://bugzilla.mozilla.org/show_bug.cgi?id=1804460) - Added additional details (`usedEch`, `usedDelegatedCredentials`, `usedOcsp` and `usedPrivateDns`) to `webRequest`'s `SecurityInfo`. 

Fixes #4791 