### PR TITLE
Do not use oneLine on localized strings

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -69,12 +69,15 @@ export default class Linter {
     const { minManifestVersion, maxManifestVersion } = this.config;
     if (maxManifestVersion < minManifestVersion) {
       throw new AddonsLinterUserError(
-        i18n._(`
-        Invalid manifest version range requested:
-        --min-manifest-version (currently set to ${minManifestVersion})
-        should not be greater than
-        --max-manifest-version (currently set to ${maxManifestVersion}).
-      `)
+        i18n.sprintf(
+          i18n._(
+            `Invalid manifest version range requested:
+            --min-manifest-version (currently set to %(minManifestVersion)s)
+            should not be greater than
+            --max-manifest-version (currently set to %(maxManifestVersion)s).`
+          ),
+          { minManifestVersion, maxManifestVersion }
+        )
       );
     }
   }

--- a/src/linter.js
+++ b/src/linter.js
@@ -69,7 +69,7 @@ export default class Linter {
     const { minManifestVersion, maxManifestVersion } = this.config;
     if (maxManifestVersion < minManifestVersion) {
       throw new AddonsLinterUserError(
-        i18n._(oneLine`
+        i18n._(`
         Invalid manifest version range requested:
         --min-manifest-version (currently set to ${minManifestVersion})
         should not be greater than

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -4,8 +4,8 @@ export const CSS_SYNTAX_ERROR = {
   code: 'CSS_SYNTAX_ERROR',
   // This will be overriden by the reason passed from the error.
   message: i18n._('A CSS syntax error was encountered'),
-  description: i18n._(`An error was found in the CSS file being
-    processed as a result further processing of that file is not possible`),
+  description: i18n._(`An error was found in the CSS file being processed as a
+    result further processing of that file is not possible`),
 };
 
 export const INVALID_SELECTOR_NESTING = {

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -1,17 +1,15 @@
-import { oneLine } from 'common-tags';
-
 import { i18n } from 'utils';
 
 export const CSS_SYNTAX_ERROR = {
   code: 'CSS_SYNTAX_ERROR',
   // This will be overriden by the reason passed from the error.
   message: i18n._('A CSS syntax error was encountered'),
-  description: i18n._(oneLine`An error was found in the CSS file being
+  description: i18n._(`An error was found in the CSS file being
     processed as a result further processing of that file is not possible`),
 };
 
 export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   message: i18n._('Invalid nesting of selectors found'),
-  description: i18n._(oneLine`Selectors should not be nested`),
+  description: i18n._(`Selectors should not be nested`),
 };

--- a/src/messages/html.js
+++ b/src/messages/html.js
@@ -1,17 +1,15 @@
-import { oneLine } from 'common-tags';
-
 import { i18n } from 'utils';
 
 export const INLINE_SCRIPT = {
   code: 'INLINE_SCRIPT',
   message: i18n._('Inline scripts blocked by default'),
-  description: i18n._(oneLine`Default CSP rules prevent inline JavaScript
+  description: i18n._(`Default CSP rules prevent inline JavaScript
     from running (https://mzl.la/2pn32nd).`),
 };
 
 export const REMOTE_SCRIPT = {
   code: 'REMOTE_SCRIPT',
   message: i18n._('Remote scripts are not allowed as per the Add-on Policies.'),
-  description: i18n._(oneLine`Please include all scripts in the add-on.
+  description: i18n._(`Please include all scripts in the add-on.
     For more information, refer to https://mzl.la/2uEOkYp.`),
 };

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,11 +1,9 @@
-import { oneLine } from 'common-tags';
-
 import { apiToMessage, i18n } from 'utils';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
   message: i18n._('JavaScript syntax error'),
-  description: i18n._(oneLine`There is a JavaScript syntax error in your
+  description: i18n._(`There is a JavaScript syntax error in your
     code, which might be related to some experimental JavaScript features that
     aren't an official part of the language specification and therefore not
     supported yet. The validation cannot continue on this file.`),
@@ -29,7 +27,7 @@ export function _nonLiteralUri(method) {
   return {
     code: `${method}_NONLIT_URI`.toUpperCase(),
     message: i18n._(`'${method}' called with a non-literal uri`),
-    description: i18n._(oneLine`Calling '${method}' with variable
+    description: i18n._(`Calling '${method}' with variable
       parameters can result in potential security vulnerabilities if the
       variable contains a remote URI. Consider using 'window.open' with
       the 'chrome=no' flag.`),
@@ -40,7 +38,7 @@ export function _methodPassedRemoteUri(method) {
   return {
     code: `${method}_REMOTE_URI`.toUpperCase(),
     message: i18n._(`'${method}' called with non-local URI`),
-    description: i18n._(oneLine`Calling '${method}' with a non-local
+    description: i18n._(`Calling '${method}' with a non-local
       URI will result in the dialog being opened with chrome privileges.`),
   };
 }
@@ -51,7 +49,7 @@ export const OPENDIALOG_NONLIT_URI = _nonLiteralUri('openDialog');
 export const DANGEROUS_EVAL = {
   code: 'DANGEROUS_EVAL',
   message: null,
-  description: i18n._(oneLine`Evaluation of strings as code can lead to
+  description: i18n._(`Evaluation of strings as code can lead to
     security vulnerabilities and performance issues, even in the
     most innocuous of circumstances. Please avoid using \`eval\` and the
     \`Function\` constructor when at all possible.'`),
@@ -60,7 +58,7 @@ export const DANGEROUS_EVAL = {
 export const NO_IMPLIED_EVAL = {
   code: 'NO_IMPLIED_EVAL',
   message: null,
-  description: i18n._(oneLine`setTimeout, setInterval and execScript
+  description: i18n._(`setTimeout, setInterval and execScript
     functions should be called only with function expressions as their
     first argument`),
 };
@@ -68,14 +66,14 @@ export const NO_IMPLIED_EVAL = {
 export const UNEXPECTED_GLOGAL_ARG = {
   code: 'UNEXPECTED_GLOGAL_ARG',
   message: i18n._('Unexpected global passed as an argument'),
-  description: i18n._(oneLine`Passing a global as an argument
+  description: i18n._(`Passing a global as an argument
     is not recommended. Please make this a var instead.`),
 };
 
 export const NO_DOCUMENT_WRITE = {
   code: 'NO_DOCUMENT_WRITE',
   message: i18n._('Use of document.write strongly discouraged.'),
-  description: i18n._(oneLine`document.write will fail in many
+  description: i18n._(`document.write will fail in many
     circumstances when used in extensions, and has potentially severe security
     repercussions when used improperly. Therefore, it should not be used.`),
 };
@@ -83,21 +81,21 @@ export const NO_DOCUMENT_WRITE = {
 export const BANNED_LIBRARY = {
   code: 'BANNED_LIBRARY',
   message: i18n._('Banned 3rd-party JS library'),
-  description: i18n._(oneLine`Your add-on uses a JavaScript library we
+  description: i18n._(`Your add-on uses a JavaScript library we
     consider unsafe. Read more: https://bit.ly/1TRIyZY`),
 };
 
 export const UNADVISED_LIBRARY = {
   code: 'UNADVISED_LIBRARY',
   message: i18n._('Unadvised 3rd-party JS library'),
-  description: i18n._(oneLine`Your add-on uses a JavaScript library we do
+  description: i18n._(`Your add-on uses a JavaScript library we do
     not recommend. Read more: https://bit.ly/1TRIyZY`),
 };
 
 export const KNOWN_LIBRARY = {
   code: 'KNOWN_LIBRARY',
   message: i18n._('Known JS library detected'),
-  description: i18n._(oneLine`JavaScript libraries are discouraged for
+  description: i18n._(`JavaScript libraries are discouraged for
     simple add-ons, but are generally accepted.`),
 };
 
@@ -105,7 +103,7 @@ export const UNSAFE_DYNAMIC_VARIABLE_ASSIGNMENT = {
   code: 'UNSAFE_VAR_ASSIGNMENT',
   // Uses original message from eslint
   message: null,
-  description: i18n._(oneLine`Due to both security and performance
+  description: i18n._(`Due to both security and performance
     concerns, this may not be set using dynamic values which have
     not been adequately sanitized. This can lead to security issues or fairly
     serious performance degradation.`),
@@ -151,7 +149,7 @@ function temporaryAPI(api) {
   return {
     code: apiToMessage(api),
     message: i18n._(`"${api}" can cause issues when loaded temporarily`),
-    description: i18n._(oneLine`This API can cause issues when loaded
+    description: i18n._(`This API can cause issues when loaded
       temporarily using about:debugging in Firefox unless you specify
       applications|browser_specific_settings > gecko > id in the manifest.
       Please see: https://mzl.la/2hizK4a for more.`),

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -26,20 +26,30 @@ export const CONTENT_SCRIPT_EMPTY = {
 export function _nonLiteralUri(method) {
   return {
     code: `${method}_NONLIT_URI`.toUpperCase(),
-    message: i18n._(`'${method}' called with a non-literal uri`),
-    description: i18n._(`Calling '${method}' with variable
-      parameters can result in potential security vulnerabilities if the
-      variable contains a remote URI. Consider using 'window.open' with
-      the 'chrome=no' flag.`),
+    message: i18n.sprintf(
+      i18n._(`"%(method)s" called with a non-literal uri`),
+      { method }
+    ),
+    description: i18n.sprintf(
+      i18n._(`Calling "%(method)s" with variable parameters can result in
+        potential security vulnerabilities if the variable contains a remote
+        URI. Consider using 'window.open' with the 'chrome=no' flag.`),
+      { method }
+    ),
   };
 }
 
 export function _methodPassedRemoteUri(method) {
   return {
     code: `${method}_REMOTE_URI`.toUpperCase(),
-    message: i18n._(`'${method}' called with non-local URI`),
-    description: i18n._(`Calling '${method}' with a non-local
-      URI will result in the dialog being opened with chrome privileges.`),
+    message: i18n.sprintf(i18n._(`"%(method)s" called with non-local URI`), {
+      method,
+    }),
+    description: i18n.sprintf(
+      i18n._(`Calling "%(method)s" with a non-local URI will result in the
+        dialog being opened with chrome privileges.`),
+      { method }
+    ),
   };
 }
 
@@ -148,10 +158,13 @@ export const DEPRECATED_CHROME_API = {
 function temporaryAPI(api) {
   return {
     code: apiToMessage(api),
-    message: i18n._(`"${api}" can cause issues when loaded temporarily`),
+    message: i18n.sprintf(
+      i18n._(`"$(api)s" can cause issues when loaded temporarily`),
+      { api }
+    ),
     description: i18n._(`This API can cause issues when loaded
       temporarily using about:debugging in Firefox unless you specify
-      applications|browser_specific_settings > gecko > id in the manifest.
+      "browser_specific_settings.gecko.id" in the manifest.
       Please see: https://mzl.la/2hizK4a for more.`),
   };
 }

--- a/src/messages/json.js
+++ b/src/messages/json.js
@@ -1,5 +1,3 @@
-import { oneLine } from 'common-tags';
-
 import { i18n } from 'utils';
 
 export const JSON_INVALID = {
@@ -11,7 +9,7 @@ export const JSON_INVALID = {
 export const JSON_BLOCK_COMMENTS = {
   code: 'JSON_BLOCK_COMMENTS',
   message: i18n._('Your JSON contains block comments.'),
-  description: i18n._(oneLine`Only line comments (comments beginning with
+  description: i18n._(`Only line comments (comments beginning with
     "//") are allowed in JSON files. Please remove block comments (comments
     beginning with "/*")`),
 };
@@ -19,5 +17,5 @@ export const JSON_BLOCK_COMMENTS = {
 export const JSON_DUPLICATE_KEY = {
   code: 'JSON_DUPLICATE_KEY',
   message: i18n._('Duplicate keys are not allowed in JSON files.'),
-  description: i18n._(oneLine`Duplicate key found in JSON file.`),
+  description: i18n._(`Duplicate key found in JSON file.`),
 };

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -43,10 +43,13 @@ export const TYPE_NO_MANIFEST_JSON = {
 export const FILE_TOO_LARGE = {
   code: 'FILE_TOO_LARGE',
   message: i18n._('File is too large to parse.'),
-  description: i18n._(`This file is not binary and is too large to
-    parse. Files larger than ${MAX_FILE_SIZE_TO_PARSE_MB}MB will not be
-    parsed. Consider moving large lists of data out of JavaScript files and
-    into JSON files, or splitting very large files into smaller ones.`),
+  description: i18n.sprintf(
+    i18n._(`This file is not binary and is too large to parse. Files larger
+      than %(maxFileSizeToParseMB)sMB will not be parsed. Consider moving
+      large lists of data out of JavaScript files and into JSON files, or
+      splitting very large files into smaller ones.`),
+    { maxFileSizeToParseMB: MAX_FILE_SIZE_TO_PARSE_MB }
+  ),
 };
 
 export const HIDDEN_FILE = {

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -1,12 +1,10 @@
-import { oneLine } from 'common-tags';
-
 import { MAX_FILE_SIZE_TO_PARSE_MB } from 'const';
 import { i18n } from 'utils';
 
 export const DUPLICATE_XPI_ENTRY = {
   code: 'DUPLICATE_XPI_ENTRY',
   message: i18n._('Package contains duplicate entries'),
-  description: i18n._(oneLine`The package contains multiple entries
+  description: i18n._(`The package contains multiple entries
     with the same name. This practice has been banned. Try unzipping
     and re-zipping your add-on package and try again.`),
 };
@@ -21,7 +19,7 @@ export const INVALID_XPI_ENTRY = {
   // format:
   //   `invalid characters in fileName: nameOfTheInvalidZipFileEntry`
   message: 'Invalid ZIP file entry',
-  description: i18n._(oneLine`The package is invalid. It may contain
+  description: i18n._(`The package is invalid. It may contain
     entries using invalid characters, as an example using '\\' as a
     path separator is not allowed in Firefox. Try to recreate your
     add-on package (ZIP) and make sure all entries are using '/' as the
@@ -37,8 +35,7 @@ export const BAD_ZIPFILE = {
 export const TYPE_NO_MANIFEST_JSON = {
   code: 'TYPE_NO_MANIFEST_JSON',
   message: i18n._('manifest.json was not found'),
-  description:
-    i18n._(oneLine`No manifest.json was found at the root of the extension.
+  description: i18n._(`No manifest.json was found at the root of the extension.
     The package file must be a ZIP of the extension's files themselves, not of the
     containing directory. See: https://mzl.la/2r2McKv for more on packaging.`),
 };
@@ -46,7 +43,7 @@ export const TYPE_NO_MANIFEST_JSON = {
 export const FILE_TOO_LARGE = {
   code: 'FILE_TOO_LARGE',
   message: i18n._('File is too large to parse.'),
-  description: i18n._(oneLine`This file is not binary and is too large to
+  description: i18n._(`This file is not binary and is too large to
     parse. Files larger than ${MAX_FILE_SIZE_TO_PARSE_MB}MB will not be
     parsed. Consider moving large lists of data out of JavaScript files and
     into JSON files, or splitting very large files into smaller ones.`),
@@ -55,7 +52,7 @@ export const FILE_TOO_LARGE = {
 export const HIDDEN_FILE = {
   code: 'HIDDEN_FILE',
   message: i18n._('Hidden file flagged'),
-  description: i18n._(oneLine`Hidden files complicate the
+  description: i18n._(`Hidden files complicate the
     review process and can contain sensitive information about the system that
     generated the add-on. Please modify the packaging process so that these
     files aren't included.`),
@@ -64,21 +61,21 @@ export const HIDDEN_FILE = {
 export const FLAGGED_FILE = {
   code: 'FLAGGED_FILE',
   message: i18n._('Flagged filename found'),
-  description: i18n._(oneLine`Files were found that are either unnecessary
+  description: i18n._(`Files were found that are either unnecessary
     or have been included unintentionally. They should be removed.`),
 };
 
 export const FLAGGED_FILE_EXTENSION = {
   code: 'FLAGGED_FILE_EXTENSION',
   message: i18n._('Flagged file extensions found'),
-  description: i18n._(oneLine`Files were found that are either unnecessary
+  description: i18n._(`Files were found that are either unnecessary
     or have been included unintentionally. They should be removed.`),
 };
 
 export const FLAGGED_FILE_TYPE = {
   code: 'FLAGGED_FILE_TYPE',
   message: i18n._('Flagged file type found'),
-  description: i18n._(oneLine`Files whose names end with flagged extensions
+  description: i18n._(`Files whose names end with flagged extensions
     have been found in the add-on. The extension of these files are flagged
     because they usually identify binary components. Please see
     https://bit.ly/review-policy for more information on the binary content
@@ -88,7 +85,7 @@ export const FLAGGED_FILE_TYPE = {
 export const ALREADY_SIGNED = {
   code: 'ALREADY_SIGNED',
   message: i18n._('Package already signed'),
-  description: i18n._(oneLine`Add-ons which are already signed will be
+  description: i18n._(`Add-ons which are already signed will be
     re-signed when published on AMO. This will replace any existing signatures
     on the add-on.`),
 };
@@ -96,7 +93,7 @@ export const ALREADY_SIGNED = {
 export const COINMINER_USAGE_DETECTED = {
   code: 'COINMINER_USAGE_DETECTED',
   message: i18n._('Firefox add-ons are not allowed to run coin miners.'),
-  description: i18n._(oneLine`We do not allow coinminer scripts to be run inside
+  description: i18n._(`We do not allow coinminer scripts to be run inside
     WebExtensions.
     See https://github.com/mozilla/addons-linter/issues/1643 for more
     details.`),
@@ -105,6 +102,6 @@ export const COINMINER_USAGE_DETECTED = {
 export const RESERVED_FILENAME = {
   code: 'RESERVED_FILENAME',
   message: i18n._('Reserved filename found.'),
-  description: i18n._(oneLine`Files whose names are reserved have been found in
+  description: i18n._(`Files whose names are reserved have been found in
     the add-on. Please refrain from using them and rename your files.`),
 };

--- a/src/messages/locale-messagesjson.js
+++ b/src/messages/locale-messagesjson.js
@@ -1,5 +1,3 @@
-import { oneLine } from 'common-tags';
-
 import { i18n } from 'utils';
 
 export const NO_MESSAGE = {
@@ -13,15 +11,14 @@ export const NO_MESSAGE = {
 export const PREDEFINED_MESSAGE_NAME = {
   code: 'PREDEFINED_MESSAGE_NAME',
   message: i18n._('String name is reserved for a predefined message'),
-  description:
-    i18n._(oneLine`String names starting with @@ get translated to built-in
+  description: i18n._(`String names starting with @@ get translated to built-in
     constants (https://mzl.la/2BL9ZjE).`),
 };
 
 export const INVALID_MESSAGE_NAME = {
   code: 'INVALID_MESSAGE_NAME',
   message: 'String name contains invalid characters',
-  description: i18n._(oneLine`String name should only contain alpha-numeric
+  description: i18n._(`String name should only contain alpha-numeric
     characters, _ and @ (https://mzl.la/2Eztyi5).`),
 };
 
@@ -34,14 +31,13 @@ export const MISSING_PLACEHOLDER = {
 export const INVALID_PLACEHOLDER_NAME = {
   code: 'INVALID_PLACEHOLDER_NAME',
   message: i18n._('Placeholder name contains invalid characters'),
-  description: i18n._(oneLine`Placeholder name should only contain alpha-numeric
+  description: i18n._(`Placeholder name should only contain alpha-numeric
     characters, _ and @ (https://mzl.la/2ExbYez).`),
 };
 
 export const NO_PLACEHOLDER_CONTENT = {
   code: 'NO_PLACEHOLDER_CONTENT',
   message: i18n._('Placeholder is missing the content property'),
-  description:
-    i18n._(oneLine`A placeholder needs a content property defining the
+  description: i18n._(`A placeholder needs a content property defining the
     replacement of it (https://mzl.la/2DT1MQd)`),
 };

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -1,9 +1,7 @@
-import { oneLine } from 'common-tags';
-
 import { i18n, errorParamsToUnsupportedVersionRange } from 'utils';
 import { MANIFEST_JSON, PERMS_DATAPATH_REGEX } from 'const';
 
-const PRIVILEGED_EXTENSION_SIGNING_DOCS = i18n._(oneLine`
+const PRIVILEGED_EXTENSION_SIGNING_DOCS = i18n._(`
   Please refer to https://github.com/mozilla-extensions/xpi-manifest to learn more about privileged extensions and signing.
 `);
 
@@ -31,7 +29,7 @@ export function manifestFieldPrivilegedOnly(fieldName) {
     code: MANIFEST_FIELD_PRIVILEGEDONLY,
     message: i18n._(`"${fieldName}" is ignored for non-privileged add-ons.`),
     description: i18n._(
-      oneLine`"${fieldName} manifest field is only used for privileged
+      `"${fieldName} manifest field is only used for privileged
              and temporarily installed extensions.`
     ),
     file: MANIFEST_JSON,
@@ -44,9 +42,9 @@ export function manifestFieldUnsupported(fieldName, error) {
     ? errorParamsToUnsupportedVersionRange(error.params)
     : null;
   const messageTmpl = versionRange
-    ? i18n._(oneLine`"%(fieldName)s" is not supported in manifest versions
+    ? i18n._(`"%(fieldName)s" is not supported in manifest versions
         %(versionRange)s.`)
-    : i18n._(oneLine`"%(fieldName)s" is not supported.`);
+    : i18n._(`"%(fieldName)s" is not supported.`);
   const message = i18n.sprintf(messageTmpl, { fieldName, versionRange });
 
   return {
@@ -59,8 +57,7 @@ export function manifestFieldUnsupported(fieldName, error) {
 
 export const MANIFEST_FIELD_PRIVILEGED = 'MANIFEST_FIELD_PRIVILEGED';
 export function manifestFieldPrivileged(error) {
-  const messageTmpl =
-    i18n._(oneLine`%(instancePath)s: privileged manifest fields
+  const messageTmpl = i18n._(`%(instancePath)s: privileged manifest fields
                      are only allowed in privileged extensions.`);
   const message = i18n.sprintf(messageTmpl, {
     instancePath: error.instancePath,
@@ -79,9 +76,9 @@ export const MANIFEST_PERMISSION_UNSUPPORTED =
 export function manifestPermissionUnsupported(permissionName, error) {
   const versionRange = errorParamsToUnsupportedVersionRange(error.params);
   const messageTmpl = versionRange
-    ? i18n._(oneLine`/%(fieldName)s: "%(permissionName)s" is not supported in
+    ? i18n._(`/%(fieldName)s: "%(permissionName)s" is not supported in
                      manifest versions %(versionRange)s.`)
-    : i18n._(oneLine`/%(fieldName)s: "%(permissionName)s" is not supported.`);
+    : i18n._(`/%(fieldName)s: "%(permissionName)s" is not supported.`);
   const message = i18n.sprintf(messageTmpl, {
     permissionName,
     versionRange,
@@ -99,7 +96,7 @@ export function manifestPermissionUnsupported(permissionName, error) {
 export const MANIFEST_BAD_PERMISSION = {
   code: 'MANIFEST_BAD_PERMISSION',
   message: i18n._('The permission type is unsupported.'),
-  description: i18n._(oneLine`See https://mzl.la/1R1n1t0
+  description: i18n._(`See https://mzl.la/1R1n1t0
     (MDN Docs) for more information.`),
   file: MANIFEST_JSON,
 };
@@ -107,7 +104,7 @@ export const MANIFEST_BAD_PERMISSION = {
 export const MANIFEST_BAD_OPTIONAL_PERMISSION = {
   code: 'MANIFEST_BAD_OPTIONAL_PERMISSION',
   message: i18n._('The permission type is unsupported.'),
-  description: i18n._(oneLine`See https://mzl.la/2Qn0fWC
+  description: i18n._(`See https://mzl.la/2Qn0fWC
     (MDN Docs) for more information.`),
   file: MANIFEST_JSON,
 };
@@ -134,7 +131,7 @@ export const MANIFEST_PERMISSIONS_PRIVILEGED =
   'MANIFEST_PERMISSIONS_PRIVILEGED';
 export function manifestPermissionsPrivileged(error) {
   const messageTmpl =
-    i18n._(oneLine`%(instancePath)s: the following privileged permissions
+    i18n._(`%(instancePath)s: the following privileged permissions
                      are only allowed in privileged extensions:
                      %(privilegedPermissions)s.`);
   const message = i18n.sprintf(messageTmpl, {
@@ -171,7 +168,7 @@ export const MANIFEST_HOST_PERMISSIONS = {
 export const MANIFEST_INSTALL_ORIGINS = {
   code: 'MANIFEST_INSTALL_ORIGINS',
   message: i18n._('Invalid install origin.'),
-  description: i18n._(oneLine`Invalid install origin. A valid origin has - only
+  description: i18n._(`Invalid install origin. A valid origin has - only
     - a scheme, hostname and optional port. See https://mzl.la/3TEbqbE (MDN
     Docs) for more information.`),
   file: MANIFEST_JSON,
@@ -194,7 +191,7 @@ export function manifestCsp(property) {
     // Note: don't change this 'code' without updating addons-server first, as
     // it depends on it to detect add-ons with a custom content security policy.
     code: MANIFEST_CSP,
-    message: i18n._(oneLine`
+    message: i18n._(`
       "${property}" allows remote code execution in manifest.json`),
     description: i18n._(`A custom ${property} needs additional review.`),
     file: MANIFEST_JSON,
@@ -205,9 +202,9 @@ export const MANIFEST_CSP_UNSAFE_EVAL = 'MANIFEST_CSP_UNSAFE_EVAL';
 export function manifestCspUnsafeEval(property) {
   return {
     code: MANIFEST_CSP_UNSAFE_EVAL,
-    message: i18n._(oneLine`
+    message: i18n._(`
       ${property} allows 'eval', which has strong security and performance implications.`),
-    description: i18n._(oneLine`
+    description: i18n._(`
       In most cases the same result can be achieved differently,
       therefore it is generally prohibited`),
     file: MANIFEST_JSON,
@@ -226,7 +223,7 @@ export const PROP_NAME_INVALID = {
 export const MANIFEST_UPDATE_URL = {
   code: 'MANIFEST_UPDATE_URL',
   message: i18n._('"update_url" is not allowed.'),
-  description: i18n._(oneLine`
+  description: i18n._(`
     "applications.gecko.update_url" or
     "browser_specific_settings.gecko.update_url" are not allowed for
     Mozilla-hosted add-ons.`),
@@ -236,7 +233,7 @@ export const MANIFEST_UPDATE_URL = {
 export const MANIFEST_UNUSED_UPDATE = {
   code: 'MANIFEST_UNUSED_UPDATE',
   message: i18n._('The "update_url" property is not used by Firefox.'),
-  description: i18n._(oneLine`The "update_url" is not used by Firefox in
+  description: i18n._(`The "update_url" is not used by Firefox in
     the root of a manifest; your add-on will be updated via the Add-ons
     site and not your "update_url". See: https://mzl.la/25zqk4O`),
   file: MANIFEST_JSON,
@@ -245,7 +242,7 @@ export const MANIFEST_UNUSED_UPDATE = {
 export const STRICT_MAX_VERSION = {
   code: 'STRICT_MAX_VERSION',
   message: i18n._('"strict_max_version" not required.'),
-  description: i18n._(oneLine`"strict_max_version" shouldn't be used unless
+  description: i18n._(`"strict_max_version" shouldn't be used unless
     the add-on is expected not to work with future versions of Firefox.`),
   file: MANIFEST_JSON,
 };
@@ -401,7 +398,7 @@ export function iconSizeInvalid({ path, expected, actual }) {
     code: ICON_SIZE_INVALID,
     message: i18n._('The size of the icon does not match the manifest.'),
     description: i18n.sprintf(
-      i18n._(oneLine`
+      i18n._(`
       Expected icon at "%(path)s" to be %(expected)d pixels wide but was %(actual)d.
     `),
       { path, expected, actual }
@@ -522,7 +519,7 @@ export const PROP_NAME_MISSING = manifestPropMissing('name');
 export const NO_MESSAGES_FILE = {
   code: 'NO_MESSAGES_FILE',
   message: i18n._('The "default_locale" is missing localizations.'),
-  description: i18n._(oneLine`The "default_locale" value is specified in
+  description: i18n._(`The "default_locale" value is specified in
     the manifest, but no matching "messages.json" in the "_locales" directory
     exists. See: https://mzl.la/2hjcaEE`),
   file: MANIFEST_JSON,
@@ -531,7 +528,7 @@ export const NO_MESSAGES_FILE = {
 export const NO_DEFAULT_LOCALE = {
   code: 'NO_DEFAULT_LOCALE',
   message: i18n._('The "default_locale" is missing but "_locales" exist.'),
-  description: i18n._(oneLine`The "default_locale" value is not specifed in
+  description: i18n._(`The "default_locale" value is not specifed in
     the manifest, but a "_locales" directory exists.
     See: https://mzl.la/2hjcaEE`),
   file: MANIFEST_JSON,
@@ -552,7 +549,7 @@ export const IGNORED_APPLICATIONS_PROPERTY = {
     '"applications" property overridden by "browser_specific_settings" property'
   ),
   description: i18n._(
-    oneLine`The "applications" property is being ignored because it is superseded by the "browser_specific_settings" property which is also defined in your manifest. Consider removing applications.`
+    `The "applications" property is being ignored because it is superseded by the "browser_specific_settings" property which is also defined in your manifest. Consider removing applications.`
   ),
   file: MANIFEST_JSON,
 };
@@ -583,7 +580,7 @@ export function keyFirefoxUnsupportedByMinVersion(
       'Manifest key not supported by the specified minimum Firefox version'
     ),
     description: i18n.sprintf(
-      i18n._(oneLine`"strict_min_version" requires Firefox %(minVersion)s, which
+      i18n._(`"strict_min_version" requires Firefox %(minVersion)s, which
         was released before version %(versionAdded)s introduced support for
         "%(key)s".`),
       { key, minVersion, versionAdded }
@@ -605,7 +602,7 @@ export function permissionFirefoxUnsupportedByMinVersion(
       'Permission not supported by the specified minimum Firefox version'
     ),
     description: i18n.sprintf(
-      i18n._(oneLine`"strict_min_version" requires Firefox %(minVersion)s, which
+      i18n._(`"strict_min_version" requires Firefox %(minVersion)s, which
         was released before version %(versionAdded)s introduced support for
         "%(key)s".`),
       { key, minVersion, versionAdded }
@@ -627,7 +624,7 @@ export function keyFirefoxAndroidUnsupportedByMinVersion(
       'Manifest key not supported by the specified minimum Firefox for Android version'
     ),
     description: i18n.sprintf(
-      i18n._(oneLine`"strict_min_version" requires Firefox for Android
+      i18n._(`"strict_min_version" requires Firefox for Android
         %(minVersion)s, which was released before version %(versionAdded)s
         introduced support for "%(key)s".`),
       { key, minVersion, versionAdded }
@@ -649,7 +646,7 @@ export function permissionFirefoxAndroidUnsupportedByMinVersion(
       'Permission not supported by the specified minimum Firefox for Android version'
     ),
     description: i18n.sprintf(
-      i18n._(oneLine`"strict_min_version" requires Firefox for Android
+      i18n._(`"strict_min_version" requires Firefox for Android
         %(minVersion)s, which was released before version %(versionAdded)s
         introduced support for "%(key)s".`),
       { key, minVersion, versionAdded }
@@ -673,12 +670,12 @@ export const makeRestrictedPermission = (permission, minFirefoxVersion) => {
   return {
     code: RESTRICTED_PERMISSION,
     message: i18n.sprintf(
-      i18n._(oneLine`The "%(permission)s" permission requires
+      i18n._(`The "%(permission)s" permission requires
         "strict_min_version" to be set to "%(minFirefoxVersion)s" or above`),
       { permission, minFirefoxVersion }
     ),
     description: i18n.sprintf(
-      i18n._(oneLine`The "%(permission)s" permission requires
+      i18n._(`The "%(permission)s" permission requires
         "strict_min_version" to be set to "%(minFirefoxVersion)s" or above.
         Please update your manifest.json version to specify a minimum Firefox
         version.`),
@@ -700,7 +697,7 @@ export const EXTENSION_ID_REQUIRED = {
 export const PRIVILEGED_FEATURES_REQUIRED = 'PRIVILEGED_FEATURES_REQUIRED';
 export function privilegedFeaturesRequired(error) {
   const messageTmpl = i18n._(
-    oneLine`%(instancePath)s: Privileged extensions should declare privileged permissions.`
+    `%(instancePath)s: Privileged extensions should declare privileged permissions.`
   );
 
   const message = i18n.sprintf(messageTmpl, {
@@ -710,7 +707,7 @@ export function privilegedFeaturesRequired(error) {
   return {
     code: PRIVILEGED_FEATURES_REQUIRED,
     message,
-    description: i18n._(oneLine`
+    description: i18n._(`
       This extension does not declare any privileged permission. It does not need to be signed with the privileged certificate.
       Please upload it directly to https://addons.mozilla.org/.
     `),
@@ -724,10 +721,10 @@ export function mozillaAddonsPermissionRequired(error) {
   const messageTmpl =
     error.instancePath === '/permissions'
       ? i18n._(
-          oneLine`%(instancePath)s: The "mozillaAddons" permission is required for privileged extensions.`
+          `%(instancePath)s: The "mozillaAddons" permission is required for privileged extensions.`
         )
       : i18n._(
-          oneLine`%(instancePath)s: The "mozillaAddons" permission is required for extensions that include privileged manifest fields.`
+          `%(instancePath)s: The "mozillaAddons" permission is required for extensions that include privileged manifest fields.`
         );
 
   const message = i18n.sprintf(messageTmpl, {
@@ -740,7 +737,7 @@ export function mozillaAddonsPermissionRequired(error) {
     description:
       error.instancePath === '/permissions'
         ? i18n._(
-            oneLine`This extension does not include the "mozillaAddons" permission, which is required for privileged extensions.`
+            `This extension does not include the "mozillaAddons" permission, which is required for privileged extensions.`
           )
         : message,
     file: MANIFEST_JSON,
@@ -750,7 +747,7 @@ export function mozillaAddonsPermissionRequired(error) {
 export const HIDDEN_NO_ACTION = {
   code: 'HIDDEN_NO_ACTION',
   message: i18n._('Cannot use actions in hidden add-ons.'),
-  description: i18n._(oneLine`The hidden and browser_action/page_action (or
+  description: i18n._(`The hidden and browser_action/page_action (or
     action in Manifest Version 3 and above) properties are mutually
     exclusive.`),
   file: MANIFEST_JSON,
@@ -759,7 +756,7 @@ export const HIDDEN_NO_ACTION = {
 export const APPLICATIONS_DEPRECATED = {
   code: 'APPLICATIONS_DEPRECATED',
   message: i18n._('Use "browser_specific_settings" instead of "applications".'),
-  description: i18n._(oneLine`The "applications" property in the manifest is
+  description: i18n._(`The "applications" property in the manifest is
     deprecated and will no longer be accepted in Manifest Version 3 and
     above.`),
   file: MANIFEST_JSON,
@@ -767,9 +764,9 @@ export const APPLICATIONS_DEPRECATED = {
 
 export const APPLICATIONS_INVALID = {
   code: 'APPLICATIONS_INVALID',
-  message: i18n._(oneLine`"applications" is no longer allowed in Manifest
+  message: i18n._(`"applications" is no longer allowed in Manifest
     Version 3 and above.`),
-  description: i18n._(oneLine`The "applications" property in the manifest is
+  description: i18n._(`The "applications" property in the manifest is
     no longer allowed in Manifest Version 3 and above. Use
     "browser_specific_settings" instead.`),
   file: MANIFEST_JSON,
@@ -777,9 +774,9 @@ export const APPLICATIONS_INVALID = {
 
 export const VERSION_FORMAT_DEPRECATED = {
   code: 'VERSION_FORMAT_DEPRECATED',
-  message: i18n._(oneLine`The version string should be simplified because it
+  message: i18n._(`The version string should be simplified because it
     won't be compatible with Manifest Version 3 and above.`),
-  description: i18n._(oneLine`The version should be a string with 1 to 4
+  description: i18n._(`The version should be a string with 1 to 4
     numbers separated with dots. Each number should have up to 9 digits and
     leading zeros will no longer be allowed. Letters will no longer be allowed
     either. See https://mzl.la/3h3mCRu (MDN Docs) for more information.`),
@@ -789,7 +786,7 @@ export const VERSION_FORMAT_DEPRECATED = {
 export const VERSION_FORMAT_INVALID = {
   code: 'VERSION_FORMAT_INVALID',
   message: i18n._('The version string should be simplified.'),
-  description: i18n._(oneLine`The version should be a string with 1 to 4
+  description: i18n._(`The version should be a string with 1 to 4
     numbers separated with dots. Each number should have up to 9 digits and
     leading zeros are not allowed. Letters are no longer allowed. See
     https://mzl.la/3h3mCRu (MDN Docs) for more information.`),

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -27,10 +27,14 @@ export const MANIFEST_FIELD_PRIVILEGEDONLY = 'MANIFEST_FIELD_PRIVILEGEDONLY';
 export function manifestFieldPrivilegedOnly(fieldName) {
   return {
     code: MANIFEST_FIELD_PRIVILEGEDONLY,
-    message: i18n._(`"${fieldName}" is ignored for non-privileged add-ons.`),
-    description: i18n._(
-      `"${fieldName} manifest field is only used for privileged
-             and temporarily installed extensions.`
+    message: i18n.sprintf(
+      i18n._(`"%(fieldName)s" is ignored for non-privileged add-ons.`),
+      { fieldName }
+    ),
+    description: i18n.sprintf(
+      i18n._(`"%(fieldName)s" manifest field is only used for privileged and
+        temporarily installed extensions.`),
+      { fieldName }
     ),
     file: MANIFEST_JSON,
   };
@@ -191,9 +195,14 @@ export function manifestCsp(property) {
     // Note: don't change this 'code' without updating addons-server first, as
     // it depends on it to detect add-ons with a custom content security policy.
     code: MANIFEST_CSP,
-    message: i18n._(`
-      "${property}" allows remote code execution in manifest.json`),
-    description: i18n._(`A custom ${property} needs additional review.`),
+    message: i18n.sprintf(
+      i18n._(`"%(property)s" allows remote code execution in manifest.json`),
+      { property }
+    ),
+    description: i18n.sprintf(
+      i18n._(`A custom "%(property)s" needs additional review.`),
+      { property }
+    ),
     file: MANIFEST_JSON,
   };
 }
@@ -202,11 +211,13 @@ export const MANIFEST_CSP_UNSAFE_EVAL = 'MANIFEST_CSP_UNSAFE_EVAL';
 export function manifestCspUnsafeEval(property) {
   return {
     code: MANIFEST_CSP_UNSAFE_EVAL,
-    message: i18n._(`
-      ${property} allows 'eval', which has strong security and performance implications.`),
-    description: i18n._(`
-      In most cases the same result can be achieved differently,
-      therefore it is generally prohibited`),
+    message: i18n.sprintf(
+      i18n._(`"%(property)s" allows 'eval', which has strong security and
+        performance implications.`),
+      { property }
+    ),
+    description: i18n._(`In most cases the same result can be achieved
+      differently, therefore it is generally prohibited`),
     file: MANIFEST_JSON,
   };
 }
@@ -250,8 +261,13 @@ export const STRICT_MAX_VERSION = {
 export function manifestPropMissing(property) {
   return {
     code: `PROP_${property.toUpperCase()}_MISSING`,
-    message: i18n._(`No "${property}" property found in manifest.json`),
-    description: i18n._(`"${property}" is required`),
+    message: i18n.sprintf(
+      i18n._(`No "%(property)s" property found in manifest.json`),
+      { property }
+    ),
+    description: i18n.sprintf(i18n._(`"%(property)s" is required`), {
+      property,
+    }),
     file: MANIFEST_JSON,
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,7 +151,7 @@ export function getI18Data(locale) {
   return i18ndata;
 }
 
-// Functionality based on oneLine form declandewet/common-tags, copied from
+// Functionality based on oneLine from declandewet/common-tags, copied from
 // mozilla/addons-frontend.
 function oneLineTranslationString(translationKey) {
   if (translationKey && translationKey.replace && translationKey.trim) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,6 +151,15 @@ export function getI18Data(locale) {
   return i18ndata;
 }
 
+// Functionality based on oneLine form declandewet/common-tags, copied from
+// mozilla/addons-frontend.
+function oneLineTranslationString(translationKey) {
+  if (translationKey && translationKey.replace && translationKey.trim) {
+    return translationKey.replace(/(?:\n(?:\s*))+/g, ' ').trim();
+  }
+  return translationKey;
+}
+
 /*
  * Gettext utils. Used for translating strings.
  */
@@ -161,10 +170,10 @@ export function buildI18nObject(i18nData) {
     jed: _jed,
     getI18Data,
     _: (str) => {
-      return _jed.gettext(str);
+      return _jed.gettext(oneLineTranslationString(str));
     },
     gettext: (str) => {
-      return _jed.gettext(str);
+      return _jed.gettext(oneLineTranslationString(str));
     },
     sprintf: (fmt, args) => {
       return _jed.sprintf(fmt, args);

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -62,6 +62,19 @@ describe('getRootExpression()', () => {
   });
 });
 
+describe('i18n._()', () => {
+  it('should return one-line strings', () => {
+    expect(
+      i18n._(
+        `This
+         is
+         a
+         test`
+      )
+    ).toEqual('This is a test');
+  });
+});
+
 describe('gettext()', () => {
   it('should return localizable message', () => {
     expect(i18n.gettext('This is a test')).toEqual('This is a test');
@@ -84,6 +97,17 @@ describe('gettext()', () => {
     );
 
     jest.resetModules();
+  });
+
+  it('should return one-line strings', () => {
+    expect(
+      i18n.gettext(
+        `This
+         is
+         a
+         test`
+      )
+    ).toEqual('This is a test');
   });
 
   it('should support unicode messages', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/4825

---

We shouldn't use `oneLine` in localized strings. That breaks extraction.
This PR fixes the existing localized strings (similar to how it is done
in mozilla/addons-frontend).

I'll submit another patch to configure the AMO ESLint plugin (which
should catch those issues).