### PR TITLE
fix: Detect module in second child

### DIFF
--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -248,8 +248,11 @@ export default class JavaScriptScanner {
               return 'module';
             }
           }
-        } else if (child) {
-          return this._getSourceType(child, stayTopLevel);
+        } else if (
+          child &&
+          this._getSourceType(child, stayTopLevel) === 'module'
+        ) {
+          return 'module';
         }
       }
     }

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -544,6 +544,24 @@ describe('JavaScript Scanner', () => {
       expect(jsScanner.sourceType).toEqual('module');
     });
 
+    it('should detect module in if', async () => {
+      const code = 'if (await Promise.resolve(true)) { }';
+
+      const jsScanner = new JavaScriptScanner(code, 'code.js');
+      await runJsScanner(jsScanner);
+
+      expect(jsScanner.sourceType).toEqual('module');
+    });
+
+    it('should detect module in ternary', async () => {
+      const code = 'const foo = true ? (1 && await Promise.resolve()) : 0;';
+
+      const jsScanner = new JavaScriptScanner(code, 'code.js');
+      await runJsScanner(jsScanner);
+
+      expect(jsScanner.sourceType).toEqual('module');
+    });
+
     it('should detect script', async () => {
       const code = oneLine`
         eval('foo');

--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -535,6 +535,15 @@ describe('JavaScript Scanner', () => {
       expect(jsScanner.sourceType).toEqual('script');
     });
 
+    it('should detect module in second child', async () => {
+      const code = 'const foo = await Promise.resolve();';
+
+      const jsScanner = new JavaScriptScanner(code, 'code.js');
+      await runJsScanner(jsScanner);
+
+      expect(jsScanner.sourceType).toEqual('module');
+    });
+
     it('should detect script', async () => {
       const code = oneLine`
         eval('foo');


### PR DESCRIPTION
Fixes again https://github.com/mozilla/addons-linter/issues/4020#issuecomment-1527820431

In the detection of the type of a JavaScript file, the program walked only in the first child of a node (if the child was not an array).