### PR TITLE
Always build locales when we build the linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,7 @@ references:
   make_production_build: &make_production_build
     run:
       name: build project
-      command: |
-        node scripts/build-locales
-        NODE_ENV=production npm run build
+      command: NODE_ENV=production npm run build
 
   restore_next_build_cache: &restore_next_build_cache
     restore_cache:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node >=16.0.0"
   ],
   "scripts": {
-    "build": "webpack --bail --stats-error-details true --color --config webpack.config.js",
+    "build": "node scripts/build-locales && webpack --bail --stats-error-details true --color --config webpack.config.js",
     "eslint": "eslint bin/* scripts/* .",
     "extract-locales": "webpack --bail --stats-error-details true --color --config webpack.l10n.config.babel.js",
     "test": "jest --runInBand --watch 'tests/.*'",


### PR DESCRIPTION
In general, we shouldn't have multiple commands for the same step in the
CI config. In this case, it makes sense to build the locales when we
build the linter since it is part of it.