### PR TITLE
feat: Imported Firefox 113 schema

### DIFF
--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -372,8 +372,7 @@
           "type": "string",
           "enum": [
             "declarativeNetRequest"
-          ],
-          "min_manifest_version": 3
+          ]
         }
       ]
     },
@@ -383,8 +382,7 @@
           "type": "string",
           "enum": [
             "declarativeNetRequestFeedback"
-          ],
-          "min_manifest_version": 3
+          ]
         }
       ]
     },
@@ -394,8 +392,7 @@
           "type": "string",
           "enum": [
             "declarativeNetRequestWithHostAccess"
-          ],
-          "min_manifest_version": 3
+          ]
         }
       ]
     },
@@ -403,7 +400,6 @@
       "properties": {
         "declarative_net_request": {
           "type": "object",
-          "min_manifest_version": 3,
           "properties": {
             "rule_resources": {
               "type": "array",


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1782685](https://bugzilla.mozilla.org/show_bug.cgi?id=1782685) - Removed `min_manifest_version: 3` from the `declarativeNetRequest` JSONSchema.

Fixes #4865