### PR TITLE
feat: Imported Firefox 114 schema

### DIFF
--- a/src/schema/imported/action.json
+++ b/src/schema/imported/action.json
@@ -629,7 +629,7 @@
         },
         "browser_style": {
           "type": "boolean",
-          "default": false
+          "description": "Deprecated in Manifest V3."
         },
         "default_area": {
           "description": "Defines the location the browserAction will appear by default.  The default location is navbar.",

--- a/src/schema/imported/browser_action.json
+++ b/src/schema/imported/browser_action.json
@@ -31,7 +31,7 @@
         },
         "browser_style": {
           "type": "boolean",
-          "default": false
+          "description": "Deprecated in Manifest V3."
         },
         "default_area": {
           "description": "Defines the location the browserAction will appear by default.  The default location is navbar.",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -198,17 +198,16 @@
                     },
                     "browser_style": {
                       "type": "boolean",
-                      "default": true
+                      "description": "Defaults to true in Manifest V2; Deprecated in Manifest V3."
                     },
                     "chrome_style": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "max_manifest_version": 2,
+                      "description": "chrome_style is ignored in Firefox. Its replacement (browser_style) has been deprecated."
                     },
                     "open_in_tab": {
                       "type": "boolean"
                     }
-                  },
-                  "additionalProperties": {
-                    "deprecated": "An unexpected property was found in the WebExtension manifest"
                   },
                   "required": [
                     "page"
@@ -337,20 +336,17 @@
                       "min_manifest_version": 3,
                       "type": "array",
                       "postprocess": "webAccessibleMatching",
-                      "minItems": 1,
                       "items": {
                         "type": "object",
                         "properties": {
                           "resources": {
                             "type": "array",
-                            "minItems": 1,
                             "items": {
                               "type": "string"
                             }
                           },
                           "matches": {
                             "type": "array",
-                            "minItems": 1,
                             "items": {
                               "$ref": "#/types/MatchPattern"
                             }

--- a/src/schema/imported/page_action.json
+++ b/src/schema/imported/page_action.json
@@ -314,7 +314,7 @@
             },
             "browser_style": {
               "type": "boolean",
-              "default": false
+              "description": "Deprecated in Manifest V3."
             },
             "show_matches": {
               "type": "array",

--- a/src/schema/imported/sidebar_action.json
+++ b/src/schema/imported/sidebar_action.json
@@ -239,7 +239,7 @@
             },
             "browser_style": {
               "type": "boolean",
-              "default": true
+              "description": "Defaults to true in Manifest V2; Deprecated in Manifest V3."
             },
             "default_panel": {
               "type": "string",


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1827910 - Deprecate browser_style in MV3](https://bugzilla.mozilla.org/show_bug.cgi?id=1827910)
- [Bug 1828128 - MV3 extension cannot load when an empty web_accessible_resources list is in manifest.json](https://bugzilla.mozilla.org/show_bug.cgi?id=1828128)

Fixes #4896

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-166)
