### PR TITLE
feat: Imported Firefox 115 schema

### DIFF
--- a/src/schema/imported/commands.json
+++ b/src/schema/imported/commands.json
@@ -15,6 +15,36 @@
           "type": "string"
         }
       ]
+    },
+    {
+      "name": "onChanged",
+      "description": "Fired when a registered command's shortcut is changed.",
+      "type": "function",
+      "parameters": [
+        {
+          "type": "object",
+          "name": "changeInfo",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the shortcut."
+            },
+            "newShortcut": {
+              "type": "string",
+              "description": "The new shortcut active for this command, or blank if not active."
+            },
+            "oldShortcut": {
+              "type": "string",
+              "description": "The old shortcut which is no longer active for this command, or blank if the shortcut was previously inactive."
+            }
+          },
+          "required": [
+            "name",
+            "newShortcut",
+            "oldShortcut"
+          ]
+        }
+      ]
     }
   ],
   "functions": [

--- a/src/schema/imported/storage.json
+++ b/src/schema/imported/storage.json
@@ -117,6 +117,19 @@
           ]
         }
       ]
+    },
+    "session": {
+      "allOf": [
+        {
+          "$ref": "#/types/StorageArea"
+        },
+        {
+          "allowedContexts": [
+            "devtools"
+          ],
+          "description": "Items in the <code>session</code> storage area are kept in memory, and only until the either browser or extension is closed or reloaded."
+        }
+      ]
     }
   },
   "definitions": {},


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1823713 - Implement storage.session in extension process](https://bugzilla.mozilla.org/show_bug.cgi?id=1823713): which introduced storage.session API namespace
- [Bug 1801531 - Implement browser.commands.onChanged](https://bugzilla.mozilla.org/show_bug.cgi?id=1801531): which introduced command.onChanged API event

Fixes #4928