### PR TITLE
feat: Imported Firefox 116 schema

### DIFF
--- a/src/schema/imported/action.json
+++ b/src/schema/imported/action.json
@@ -77,6 +77,31 @@
       ]
     },
     {
+      "name": "getUserSettings",
+      "type": "function",
+      "description": "Returns the user-specified settings relating to an extension's action.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "name": "userSettings",
+              "type": "object",
+              "properties": {
+                "isOnToolbar": {
+                  "type": "boolean",
+                  "description": "Whether the extension's action icon is visible on browser windows' top-level toolbar (i.e., whether the extension has been 'pinned' by the user)."
+                }
+              },
+              "description": "The collection of user-specified settings relating to an extension's action."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "setIcon",
       "type": "function",
       "description": "Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.",

--- a/src/schema/imported/browser_action.json
+++ b/src/schema/imported/browser_action.json
@@ -117,6 +117,31 @@
       ]
     },
     {
+      "name": "getUserSettings",
+      "type": "function",
+      "description": "Returns the user-specified settings relating to an extension's action.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "name": "userSettings",
+              "type": "object",
+              "properties": {
+                "isOnToolbar": {
+                  "type": "boolean",
+                  "description": "Whether the extension's action icon is visible on browser windows' top-level toolbar (i.e., whether the extension has been 'pinned' by the user)."
+                }
+              },
+              "description": "The collection of user-specified settings relating to an extension's action."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "setIcon",
       "type": "function",
       "description": "Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.",

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -127,14 +127,14 @@
     {
       "name": "setUninstallURL",
       "type": "function",
-      "description": "Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.",
+      "description": "Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 1023 characters.",
       "async": "callback",
       "parameters": [
         {
           "type": "string",
           "name": "url",
           "optional": true,
-          "maxLength": 255,
+          "maxLength": 1023,
           "description": "URL to be opened after the extension is uninstalled. This URL must have an http: or https: scheme. Set an empty string to not open a new tab upon uninstallation."
         },
         {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -293,6 +293,10 @@
               "type": "boolean",
               "description": "Whether the tabs are audible."
             },
+            "autoDiscardable": {
+              "type": "boolean",
+              "description": "Whether the tab can be discarded automatically by the browser when resources are low."
+            },
             "muted": {
               "type": "boolean",
               "description": "Whether the tabs are muted."
@@ -509,6 +513,10 @@
             "active": {
               "type": "boolean",
               "description": "Whether the tab should be active. Does not affect whether the window is focused (see $(ref:windows.update))."
+            },
+            "autoDiscardable": {
+              "type": "boolean",
+              "description": "Whether the tab can be discarded automatically by the browser when resources are low."
             },
             "highlighted": {
               "type": "boolean",
@@ -1305,6 +1313,10 @@
               "type": "boolean",
               "description": "The tab's new audible state."
             },
+            "autoDiscardable": {
+              "type": "boolean",
+              "description": "The tab's new autoDiscardable state."
+            },
             "discarded": {
               "type": "boolean",
               "description": "True while the tab is not loaded with content."
@@ -1777,6 +1789,10 @@
           "type": "boolean",
           "description": "Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the speaker audio indicator is showing."
         },
+        "autoDiscardable": {
+          "type": "boolean",
+          "description": "Whether the tab can be discarded automatically by the browser when resources are low."
+        },
         "mutedInfo": {
           "allOf": [
             {
@@ -2060,6 +2076,7 @@
       "enum": [
         "attention",
         "audible",
+        "autoDiscardable",
         "discarded",
         "favIconUrl",
         "hidden",

--- a/src/schema/imported/web_navigation.json
+++ b/src/schema/imported/web_navigation.json
@@ -242,13 +242,11 @@
                   "$ref": "#/types/TransitionType"
                 },
                 {
-                  "unsupported": true,
                   "description": "Cause of the navigation."
                 }
               ]
             },
             "transitionQualifiers": {
-              "unsupported": true,
               "type": "array",
               "description": "A list of transition qualifiers.",
               "items": {
@@ -544,13 +542,11 @@
                   "$ref": "#/types/TransitionType"
                 },
                 {
-                  "unsupported": true,
                   "description": "Cause of the navigation."
                 }
               ]
             },
             "transitionQualifiers": {
-              "unsupported": true,
               "type": "array",
               "description": "A list of transition qualifiers.",
               "items": {
@@ -649,13 +645,11 @@
                   "$ref": "#/types/TransitionType"
                 },
                 {
-                  "unsupported": true,
                   "description": "Cause of the navigation."
                 }
               ]
             },
             "transitionQualifiers": {
-              "unsupported": true,
               "type": "array",
               "description": "A list of transition qualifiers.",
               "items": {


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1814905 - Implement chrome.action.getUserSettings](https://bugzilla.mozilla.org/show_bug.cgi?id=1814905): which has introduced a new getUserSettings in both action and browserAction API namespaces
- [Bug 1835723 - setUninstallURL should be updated to 1023](https://bugzilla.mozilla.org/show_bug.cgi?id=1835723): which has bumped the enforced url length accepted by runtime.setUninstallURL from 255 to 1023.
- [Bug 1809094 - Implement tab.autoDiscardable property](https://bugzilla.mozilla.org/show_bug.cgi?id=1809094): which has introduced a new `autoDiscardable` property to the tabs.Tab type schema (which determine if the tab is considered by the browser as discardable)
- [Bug 1837829 - webNavigation.onCommitted's `transitionType`/`transitionQualifiers` shouldn't be marked as `unsupported`](https://bugzilla.mozilla.org/show_bug.cgi?id=1837829): which removed unsupported property on the webNavigation types that were mistakenly marked as unsupported (technically doesn't change anything in the behavior, it mainly affects the browsr compatibility metadata shown on MDN API reference pages).

Fixes #4977