### PR TITLE
feat: Imported Firefox 118 schema

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -183,7 +183,8 @@
         "unregisteredthreads",
         "processcpu",
         "power",
-        "responsiveness"
+        "responsiveness",
+        "cpufreq"
       ]
     },
     "supports": {


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1838497 - Add a profiler feature to record the clock frequency of every core while sampling](https://bugzilla.mozilla.org/show_bug.cgi?id=1838497): added the new `cpufreq` feature in the geckoProfiler schema

The geckoProfiler API is a privileged API not exposed to regular extensions and so we don't expect any particular change behavior from the changes to the schema data introduced in this PR.

Fixes #5028  