### PR TITLE
fix: Report a warning on manifest_version 3 extensions targeting Firefox for Android

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -605,6 +605,11 @@
 <td>error</td>
 <td>The version string is not valid because its format is too complex.</td>
 </tr>
+<tr>
+<td><code>MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS</code></td>
+<td>warning</td>
+<td>The extension is marked as compatible with a Firefox for Android version that doesn't fully support Manifest Version 3</td>
+</tr>
 </tbody>
 </table>
 <h3 id="static-theme-%2F-manifest.json" tabindex="-1">Static Theme / manifest.json <a class="header-anchor" href="#static-theme-%2F-manifest.json">¶</a></h3>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -141,6 +141,7 @@ Rules are sorted by severity.
 | `APPLICATIONS_INVALID`                                  | error    | The `applications` property is no longer accepted in Manifest Version 3 and above.                                                                                                 |
 | `VERSION_FORMAT_DEPRECATED`                             | warning  | The version string should be simplified.                                                                                                                                           |
 | `VERSION_FORMAT_INVALID`                                | error    | The version string is not valid because its format is too complex.                                                                                                                 |
+| `MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS`               | warning  | The extension is marked compatible with a Firefox for Android version with a limited Manifest Version 3 support                                                                    |
 
 ### Static Theme / manifest.json
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -141,7 +141,7 @@ Rules are sorted by severity.
 | `APPLICATIONS_INVALID`                                  | error    | The `applications` property is no longer accepted in Manifest Version 3 and above.                                                                                                 |
 | `VERSION_FORMAT_DEPRECATED`                             | warning  | The version string should be simplified.                                                                                                                                           |
 | `VERSION_FORMAT_INVALID`                                | error    | The version string is not valid because its format is too complex.                                                                                                                 |
-| `MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS`               | warning  | The extension is marked compatible with a Firefox for Android version with a limited Manifest Version 3 support                                                                    |
+| `MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS`               | warning  | The extension is marked as compatible with a Firefox for Android version that doesn't fully support Manifest Version 3                                                             |
 
 ### Static Theme / manifest.json
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -23,6 +23,13 @@ export const MANIFEST_FIELD_INVALID = {
   file: MANIFEST_JSON,
 };
 
+export const MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS = {
+  code: 'MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS',
+  message: i18n._('Limited Manifest Version 3 support on Firefox for Android.'),
+  description: i18n._('See https://mzl.la/TODO for more information.'),
+  file: MANIFEST_JSON,
+};
+
 export const MANIFEST_FIELD_PRIVILEGEDONLY = 'MANIFEST_FIELD_PRIVILEGEDONLY';
 export function manifestFieldPrivilegedOnly(fieldName) {
   return {

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -28,7 +28,11 @@ export const MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS = {
   message: i18n._(
     'Manifest Version 3 is not fully supported on Firefox for Android.'
   ),
-  description: i18n._('See https://mzl.la/TODO for more information.'),
+  // TODO(#5110): replace description with a message including a shorted
+  // link to a documentation page.
+  description: i18n._(
+    'Manifest Version 3 is not fully supported on Firefox for Android.'
+  ),
   file: MANIFEST_JSON,
 };
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -25,7 +25,9 @@ export const MANIFEST_FIELD_INVALID = {
 
 export const MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS = {
   code: 'MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS',
-  message: i18n._('Limited Manifest Version 3 support on Firefox for Android.'),
+  message: i18n._(
+    'Manifest Version 3 is not fully supported on Firefox for Android.'
+  ),
   description: i18n._('See https://mzl.la/TODO for more information.'),
   file: MANIFEST_JSON,
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -519,6 +519,15 @@ export default class ManifestJSONParser extends JSONParser {
       };
     }
 
+    if (
+      this.parsedJSON.manifest_version >= 3 &&
+      this.parsedJSON.browser_specific_settings?.gecko_android
+    ) {
+      this.collector.addWarning(
+        messages.MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS
+      );
+    }
+
     if (this.parsedJSON.content_security_policy != null) {
       this.validateCspPolicy(this.parsedJSON.content_security_policy);
     }

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -365,6 +365,28 @@ describe('ManifestJSONParser', () => {
     expect(manifestJSONParser.isValid).toEqual(true);
   });
 
+  it('should warn when gecko_android is set along with manifest_version 3', () => {
+    const addonLinter = new Linter({ _: ['bar'] });
+    const json = validManifestJSON({
+      browser_specific_settings: {
+        gecko: { id: 'test@ext' },
+        gecko_android: {},
+      },
+      manifest_version: 3,
+    });
+
+    const manifestJSONParser = new ManifestJSONParser(
+      json,
+      addonLinter.collector
+    );
+
+    const { warnings } = addonLinter.collector;
+    expect(warnings).toEqual([
+      expect.objectContaining(messages.MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS),
+    ]);
+    expect(manifestJSONParser.isValid).toEqual(true);
+  });
+
   describe('browser_style', () => {
     function parseManifest(manifestVersion, manifestKey, browserStyleValue) {
       const manifest = {


### PR DESCRIPTION
Fixes #5104

## TODO List

- [x] replace the placeholder for the shortened url to a more detailed doc page with a real moz.la link (moved to separate followup: #5110)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-373)
