### PR TITLE
Warn instead of error when service_worker is combined with background.scripts/page

### DIFF
--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -146,8 +146,7 @@
                       },
                       "required": [
                         "page"
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     {
                       "type": "object",

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -41,9 +41,7 @@
                 "properties": {
                   "background": {
                     "anyOf": [
-                      {
-                        "additionalProperties": false
-                      },
+                      {},
                       {},
                       {
                         "min_manifest_version": 3


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/5152

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-423)
