### PR TITLE
feat: Imported Firefox 122 API schema data

### DIFF
--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -129,6 +129,7 @@
                   "description": "Sets the default engine to a built-in engine only."
                 },
                 "params": {
+                  "max_manifest_version": 2,
                   "type": "array",
                   "items": {
                     "type": "object",


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1868114 - Drop schema support for chrome_settings_overrides.searchProvider.params in Manifest v3](https://bugzilla.mozilla.org/show_bug.cgi?id=1868114)

The deprecated chrome_settings_overrides.search_provider.params manifest property was only available to builtin search engines and already ignored for third party add-ons, and so we don't expect any particular change behavior from the changes to the schema data introduced in this PR.

Fixes #5138

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-424)
