### PR TITLE
Switch to 'maintained' babel-gettext-extractor lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@babel/register": "7.23.7",
         "async": "3.2.5",
         "babel-core": "7.0.0-bridge.0",
-        "babel-gettext-extractor": "4.1.3",
+        "babel-gettext-extractor": "github:willdurand/babel-gettext-extractor#5.1.0",
         "babel-jest": "29.7.0",
         "babel-loader": "9.1.3",
         "comment-json": "4.2.3",
@@ -3943,10 +3943,10 @@
       }
     },
     "node_modules/babel-gettext-extractor": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/babel-gettext-extractor/-/babel-gettext-extractor-4.1.3.tgz",
-      "integrity": "sha512-R0IZVLMgmUtmqeADC1FVKAcJ1ssTZT0IUhH/QsSaoNdYP8u3z4o3y4N+qYNqBNlKrLnHqlN6n8/DJawTONSyIA==",
+      "version": "5.1.0",
+      "resolved": "git+ssh://git@github.com/willdurand/babel-gettext-extractor.git#6d534942510315291b3a5025b4a310ccd48c567e",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.0.0",
         "gettext-parser": "1.4.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@babel/register": "7.23.7",
     "async": "3.2.5",
     "babel-core": "7.0.0-bridge.0",
-    "babel-gettext-extractor": "4.1.3",
+    "babel-gettext-extractor": "github:willdurand/babel-gettext-extractor#5.1.0",
     "babel-jest": "29.7.0",
     "babel-loader": "9.1.3",
     "comment-json": "4.2.3",


### PR DESCRIPTION
Small dependency update to point to my maintained fork. This would allow
us to add comments on l10n strings for localizers using this syntax:

```
// L10n: a comment for localizers
i18n.gettext(`a l10n string`)
```