### PR TITLE
Do not warn about nesting css selectors when firefoxStrictMinVersion is >= 117 

### DIFF
--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -11,5 +11,7 @@ export const CSS_SYNTAX_ERROR = {
 export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   message: i18n._('Invalid nesting of selectors found'),
-  description: i18n._(`Selector nesting is supported from firefox version 117.0 and above`),
+  description: i18n._(
+    `Selector nesting is supported from firefox version 117.0 and above`
+  ),
 };

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -11,5 +11,7 @@ export const CSS_SYNTAX_ERROR = {
 export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   message: i18n._('Invalid nesting of selectors found'),
-  description: i18n._(`Selectors should not be nested`),
+  description: i18n._(
+    `Selector nesting is supported from firefox version 117.0 and above`
+  ),
 };

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -11,7 +11,5 @@ export const CSS_SYNTAX_ERROR = {
 export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   message: i18n._('Invalid nesting of selectors found'),
-  description: i18n._(
-    `Selector nesting is supported from firefox version 117.0 and above`
-  ),
+  description: i18n._(`Selector nesting is supported from firefox version 117.0 and above`),
 };

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -11,7 +11,6 @@ export const CSS_SYNTAX_ERROR = {
 export const INVALID_SELECTOR_NESTING = {
   code: 'INVALID_SELECTOR_NESTING',
   message: i18n._('Invalid nesting of selectors found'),
-  description: i18n._(
-    `Selector nesting is supported from firefox version 117.0 and above`
-  ),
+  description: i18n._(`Selector nesting is supported from firefox version 117.0
+  and above`),
 };

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -47,17 +47,6 @@ import {
 } from 'utils';
 import BLOCKED_CONTENT_SCRIPT_HOSTS from 'blocked_content_script_hosts.txt';
 
-/**
- * @typedef {Object} Metadata
- * @property {string} id
- * @property {number} manifestVersion
- * @property {string} name
- * @property {number} type
- * @property {string} version
- * @property {string} firefoxMinVersion
- * @property {Set<string>} experimentApiPaths
- */
-
 async function getStreamImageSize(stream) {
   const chunks = [];
   for await (const chunk of stream) {
@@ -1297,6 +1286,15 @@ export default class ManifestJSONParser extends JSONParser {
   }
 
   /**
+   * @typedef {Object} Metadata
+   * @property {string} id
+   * @property {number} manifestVersion
+   * @property {string} name
+   * @property {number} type
+   * @property {string} version
+   * @property {string} firefoxMinVersion
+   * @property {Set<string>} experimentApiPaths
+   *
    * @returns {Metadata}
    */
   getMetadata() {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1293,6 +1293,7 @@ export default class ManifestJSONParser extends JSONParser {
    * @property {number} type
    * @property {string} version
    * @property {string} firefoxMinVersion
+   * @property {string} firefoxStrictMinVersion
    * @property {Set<string>} experimentApiPaths
    *
    * @returns {Metadata}
@@ -1304,10 +1305,14 @@ export default class ManifestJSONParser extends JSONParser {
       name: this.parsedJSON.name,
       type: PACKAGE_EXTENSION,
       version: this.parsedJSON.version,
+      // This is the `strict_min_version` value set in the `manifest.json` file
+      // for Firefox for desktop.
       firefoxMinVersion:
         this.parsedJSON.applications &&
         this.parsedJSON.applications.gecko &&
         this.parsedJSON.applications.gecko.strict_min_version,
+      // This is the strict min *major* version for Firefox for desktop.
+      firefoxStrictMinVersion: firefoxStrictMinVersion(this.parsedJSON),
       experimentApiPaths: this.getExperimentApiPaths(),
     };
   }

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -47,6 +47,17 @@ import {
 } from 'utils';
 import BLOCKED_CONTENT_SCRIPT_HOSTS from 'blocked_content_script_hosts.txt';
 
+/**
+ * @typedef {Object} Metadata
+ * @property {string} id
+ * @property {number} manifestVersion
+ * @property {string} name
+ * @property {number} type
+ * @property {string} version
+ * @property {string} firefoxMinVersion
+ * @property {Set<string>} experimentApiPaths
+ */
+
 async function getStreamImageSize(stream) {
   const chunks = [];
   for await (const chunk of stream) {
@@ -1285,6 +1296,9 @@ export default class ManifestJSONParser extends JSONParser {
     return apiPaths;
   }
 
+  /**
+   * @returns {Metadata}
+   */
   getMetadata() {
     return {
       id: this.getAddonId(),

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -1,8 +1,9 @@
 import * as messages from 'messages';
 
-import { basicCompatVersionComparisonGEQ } from '../../utils';
+import { basicCompatVersionComparison } from '../../utils';
 
-const CSS_NESTING_MIN_VERSION = 117;
+// Allowed version is 117.0 and above
+const CSS_NESTING_MIN_VERSION = 116;
 
 export function invalidNesting(
   cssNode,
@@ -10,7 +11,7 @@ export function invalidNesting(
   { startLine, startColumn, addonMetadata } = {}
 ) {
   if (
-    basicCompatVersionComparisonGEQ(
+    basicCompatVersionComparison(
       addonMetadata?.firefoxMinVersion,
       CSS_NESTING_MIN_VERSION
     )

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -2,7 +2,6 @@ import * as messages from 'messages';
 
 import { basicCompatVersionComparison } from '../../utils';
 
-// Allowed version is 117.0 and above
 const CSS_NESTING_MIN_VERSION = 117;
 
 export function invalidNesting(
@@ -11,10 +10,10 @@ export function invalidNesting(
   { startLine, startColumn, addonMetadata } = {}
 ) {
   if (
-    addonMetadata?.firefoxMinVersion &&
+    addonMetadata?.firefoxStrictMinVersion &&
     !basicCompatVersionComparison(
       CSS_NESTING_MIN_VERSION,
-      addonMetadata?.firefoxMinVersion
+      addonMetadata?.firefoxStrictMinVersion
     )
   ) {
     return [];

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -1,10 +1,22 @@
 import * as messages from 'messages';
 
+import { basicCompatVersionComparisonGEQ } from '../../utils';
+
+const CSS_NESTING_MIN_VERSION = 117;
+
 export function invalidNesting(
   cssNode,
   filename,
-  { startLine, startColumn } = {}
+  { startLine, startColumn, addonMetadata } = {}
 ) {
+  if (
+    basicCompatVersionComparisonGEQ(
+      addonMetadata?.firefoxMinVersion,
+      CSS_NESTING_MIN_VERSION
+    )
+  ) {
+    return [];
+  }
   const messageList = [];
   if (cssNode.type === 'rule') {
     for (let i = 0; i < cssNode.nodes.length; i++) {

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -18,6 +18,7 @@ export function invalidNesting(
   ) {
     return [];
   }
+
   const messageList = [];
   if (cssNode.type === 'rule') {
     for (let i = 0; i < cssNode.nodes.length; i++) {

--- a/src/rules/css/invalidNesting.js
+++ b/src/rules/css/invalidNesting.js
@@ -3,7 +3,7 @@ import * as messages from 'messages';
 import { basicCompatVersionComparison } from '../../utils';
 
 // Allowed version is 117.0 and above
-const CSS_NESTING_MIN_VERSION = 116;
+const CSS_NESTING_MIN_VERSION = 117;
 
 export function invalidNesting(
   cssNode,
@@ -11,9 +11,10 @@ export function invalidNesting(
   { startLine, startColumn, addonMetadata } = {}
 ) {
   if (
-    basicCompatVersionComparison(
-      addonMetadata?.firefoxMinVersion,
-      CSS_NESTING_MIN_VERSION
+    addonMetadata?.firefoxMinVersion &&
+    !basicCompatVersionComparison(
+      CSS_NESTING_MIN_VERSION,
+      addonMetadata?.firefoxMinVersion
     )
   ) {
     return [];

--- a/src/scanners/base.js
+++ b/src/scanners/base.js
@@ -27,6 +27,18 @@ export default class BaseScanner {
     throw new Error('scannerName is not implemented');
   }
 
+  /**
+   * @typedef {Object} ScannerOptions
+   * @property {import('../parsers/manifestjson').Metadata} addonMetadata
+   * @property {import('../collector').default} collector
+   * @property {string[]} disabledRules
+   * @property {string[]} existingFiles
+   * @property {boolean} privileged
+   *
+   * @param {string|Buffer|import('stream').Readable} contents
+   * @param {string} filename
+   * @param {ScannerOptions} options
+   */
   constructor(contents, filename, options = {}) {
     this.contents = contents;
     this.filename = filename;

--- a/src/utils.js
+++ b/src/utils.js
@@ -426,16 +426,6 @@ export function basicCompatVersionComparison(versionAdded, minVersion) {
 }
 
 /**
- * @param {*} versionAdded
- * @param {number} minVersion
- * @returns {boolean} true if versionAdded has a greater or equal major version than minVersion
- */
-export function basicCompatVersionComparisonGEQ(versionAdded, minVersion) {
-  const asNumber = parseInt(versionAdded, 10);
-  return !Number.isNaN(asNumber) && asNumber >= minVersion;
-}
-
-/**
  * @param {*} supportInfo - bcd support info of a feature
  * @returns {string|boolean} The first version number to support the feature
  *          or a boolean indicating if the feature is supported at all. We do

--- a/src/utils.js
+++ b/src/utils.js
@@ -415,9 +415,24 @@ export function androidStrictMinVersion(manifestJson) {
   return version;
 }
 
+/**
+ * @param {*} versionAdded
+ * @param {number} minVersion
+ * @returns {boolean} true if versionAdded has a strictly greater major version than minVersion
+ */
 export function basicCompatVersionComparison(versionAdded, minVersion) {
   const asNumber = parseInt(versionAdded, 10);
   return !Number.isNaN(asNumber) && asNumber > minVersion;
+}
+
+/**
+ * @param {*} versionAdded
+ * @param {number} minVersion
+ * @returns {boolean} true if versionAdded has a greater or equal major version than minVersion
+ */
+export function basicCompatVersionComparisonGEQ(versionAdded, minVersion) {
+  const asNumber = parseInt(versionAdded, 10);
+  return !Number.isNaN(asNumber) && asNumber >= minVersion;
 }
 
 /**

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -43,6 +43,23 @@ describe('CSS Rule InvalidNesting', () => {
     expect(linterMessages.length).toEqual(0);
   });
 
+  it('should not report invalid nesting on minimal allowed version', async () => {
+    const code = oneLine`/* I'm a comment */
+      #something {
+        .bar {
+          height: 100px;
+        }
+      }`;
+    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
+      addonMetadata: {
+        firefoxMinVersion: '117.0.0',
+      },
+    });
+
+    const { linterMessages } = await cssScanner.scan();
+    expect(linterMessages.length).toEqual(0);
+  });
+
   it('should not detect invalid nesting', async () => {
     const code = oneLine`/* I'm a comment */
       @media only screen and (max-width: 959px) {

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -26,39 +26,24 @@ describe('CSS Rule InvalidNesting', () => {
     expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
   });
 
-  it('should not report invalid nesting on sufficient version', async () => {
-    const code = oneLine`/* I'm a comment */
+  it.each(['117.0.0', '117.0.1'])(
+    'should not report invalid nesting when firefoxMinVersion=%s',
+    async (firefoxMinVersion) => {
+      const code = oneLine`/* I'm a comment */
       #something {
         .bar {
           height: 100px;
         }
       }`;
-    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
-      addonMetadata: {
-        firefoxMinVersion: '117.0.1',
-      },
-    });
-
-    const { linterMessages } = await cssScanner.scan();
-    expect(linterMessages.length).toEqual(0);
-  });
-
-  it('should not report invalid nesting on minimal allowed version', async () => {
-    const code = oneLine`/* I'm a comment */
-      #something {
-        .bar {
-          height: 100px;
-        }
-      }`;
-    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
-      addonMetadata: {
-        firefoxMinVersion: '117.0.0',
-      },
-    });
-
-    const { linterMessages } = await cssScanner.scan();
-    expect(linterMessages.length).toEqual(0);
-  });
+      const cssScanner = new CSSScanner(code, 'fakeFile.css', {
+        addonMetadata: {
+          firefoxMinVersion,
+        },
+      });
+      const { linterMessages } = await cssScanner.scan();
+      expect(linterMessages.length).toEqual(0);
+    }
+  );
 
   it('should not detect invalid nesting', async () => {
     const code = oneLine`/* I'm a comment */

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -12,7 +12,11 @@ describe('CSS Rule InvalidNesting', () => {
           height: 100px;
         }
       }`;
-    const cssScanner = new CSSScanner(code, 'fakeFile.css');
+    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
+      addonMetadata: {
+        firefoxStrictMinVersion: '60.5',
+      },
+    });
 
     const { linterMessages } = await cssScanner.scan();
     expect(linterMessages.length).toEqual(1);
@@ -20,6 +24,23 @@ describe('CSS Rule InvalidNesting', () => {
       messages.INVALID_SELECTOR_NESTING.code
     );
     expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
+  });
+
+  it('should not report invalid nesting on sufficient version', async () => {
+    const code = oneLine`/* I'm a comment */
+      #something {
+        .bar {
+          height: 100px;
+        }
+      }`;
+    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
+      addonMetadata: {
+        firefoxMinVersion: '117.0.1',
+      },
+    });
+
+    const { linterMessages } = await cssScanner.scan();
+    expect(linterMessages.length).toEqual(0);
   });
 
   it('should not detect invalid nesting', async () => {

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -5,9 +5,9 @@ import { VALIDATION_WARNING } from 'const';
 import CSSScanner from 'scanners/css';
 
 describe('CSS Rule InvalidNesting', () => {
-  it.each(['60.5', '116.0', '116', '116.1', '116.0.1', '116.0.0'])(
-    'should detect invalid nesting when firefoxMinVersion=%s',
-    async (firefoxMinVersion) => {
+  it.each([60, 116])(
+    'should detect invalid nesting when firefoxStrictMinVersion=%s',
+    async (firefoxStrictMinVersion) => {
       const code = oneLine`/* I'm a comment */
       #something {
         .bar {
@@ -16,7 +16,7 @@ describe('CSS Rule InvalidNesting', () => {
       }`;
       const cssScanner = new CSSScanner(code, 'fakeFile.css', {
         addonMetadata: {
-          firefoxMinVersion,
+          firefoxStrictMinVersion,
         },
       });
 
@@ -29,9 +29,9 @@ describe('CSS Rule InvalidNesting', () => {
     }
   );
 
-  it.each(['117', '117.0', '117.1', '117.0.0', '117.0.1'])(
-    'should not report invalid nesting when firefoxMinVersion=%s',
-    async (firefoxMinVersion) => {
+  it.each([117, 118])(
+    'should not report invalid nesting when firefoxStrictMinVersion=%s',
+    async (firefoxStrictMinVersion) => {
       const code = oneLine`/* I'm a comment */
       #something {
         .bar {
@@ -40,7 +40,7 @@ describe('CSS Rule InvalidNesting', () => {
       }`;
       const cssScanner = new CSSScanner(code, 'fakeFile.css', {
         addonMetadata: {
-          firefoxMinVersion,
+          firefoxStrictMinVersion,
         },
       });
       const { linterMessages } = await cssScanner.scan();

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -5,7 +5,7 @@ import { VALIDATION_WARNING } from 'const';
 import CSSScanner from 'scanners/css';
 
 describe('CSS Rule InvalidNesting', () => {
-  it.each(['60.5', '116.0', '116'])(
+  it.each(['60.5', '116.0', '116', '116.1', '116.0.1', '116.0.0'])(
     'should detect invalid nesting when firefoxMinVersion=%s',
     async (firefoxMinVersion) => {
       const code = oneLine`/* I'm a comment */

--- a/tests/unit/rules/css/test.invalidNesting.js
+++ b/tests/unit/rules/css/test.invalidNesting.js
@@ -5,28 +5,31 @@ import { VALIDATION_WARNING } from 'const';
 import CSSScanner from 'scanners/css';
 
 describe('CSS Rule InvalidNesting', () => {
-  it('should detect invalid nesting', async () => {
-    const code = oneLine`/* I'm a comment */
+  it.each(['60.5', '116.0', '116'])(
+    'should detect invalid nesting when firefoxMinVersion=%s',
+    async (firefoxMinVersion) => {
+      const code = oneLine`/* I'm a comment */
       #something {
         .bar {
           height: 100px;
         }
       }`;
-    const cssScanner = new CSSScanner(code, 'fakeFile.css', {
-      addonMetadata: {
-        firefoxStrictMinVersion: '60.5',
-      },
-    });
+      const cssScanner = new CSSScanner(code, 'fakeFile.css', {
+        addonMetadata: {
+          firefoxMinVersion,
+        },
+      });
 
-    const { linterMessages } = await cssScanner.scan();
-    expect(linterMessages.length).toEqual(1);
-    expect(linterMessages[0].code).toEqual(
-      messages.INVALID_SELECTOR_NESTING.code
-    );
-    expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
-  });
+      const { linterMessages } = await cssScanner.scan();
+      expect(linterMessages.length).toEqual(1);
+      expect(linterMessages[0].code).toEqual(
+        messages.INVALID_SELECTOR_NESTING.code
+      );
+      expect(linterMessages[0].type).toEqual(VALIDATION_WARNING);
+    }
+  );
 
-  it.each(['117.0.0', '117.0.1'])(
+  it.each(['117', '117.0', '117.1', '117.0.0', '117.0.1'])(
     'should not report invalid nesting when firefoxMinVersion=%s',
     async (firefoxMinVersion) => {
       const code = oneLine`/* I'm a comment */

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -5,7 +5,6 @@ import {
   AddonsLinterUserError,
   androidStrictMinVersion,
   basicCompatVersionComparison,
-  basicCompatVersionComparisonGEQ,
   buildI18nObject,
   checkMinNodeVersion,
   ensureFilenameExists,
@@ -603,34 +602,12 @@ describe('basicCompatVersionComparison', () => {
     expect(basicCompatVersionComparison('61', 60)).toBe(true);
   });
 
-  it('should return false when version added is equals than min version', () => {
+  it('should return false when version added is equal to min version', () => {
     expect(basicCompatVersionComparison('61.5.2', 61)).toBe(false);
   });
 
   it('should return false when version added is smaller than min version', () => {
     expect(basicCompatVersionComparison('59', 60)).toBe(false);
-  });
-});
-
-describe('basicCompatVersionComparisonEQ', () => {
-  it('should return false when version added is a boolean', () => {
-    expect(basicCompatVersionComparisonGEQ(false, 60)).toBe(false);
-  });
-
-  it('should return false when version added is undefined', () => {
-    expect(basicCompatVersionComparisonGEQ(undefined, 60)).toBe(false);
-  });
-
-  it('should return true when version added is bigger than min version', () => {
-    expect(basicCompatVersionComparisonGEQ('61', 60)).toBe(true);
-  });
-
-  it('should return true when version added is equals than min version', () => {
-    expect(basicCompatVersionComparisonGEQ('61.5.2', 61)).toBe(true);
-  });
-
-  it('should return false when version added is smaller than min version', () => {
-    expect(basicCompatVersionComparisonGEQ('59', 60)).toBe(false);
   });
 });
 

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -5,6 +5,7 @@ import {
   AddonsLinterUserError,
   androidStrictMinVersion,
   basicCompatVersionComparison,
+  basicCompatVersionComparisonGEQ,
   buildI18nObject,
   checkMinNodeVersion,
   ensureFilenameExists,
@@ -602,8 +603,34 @@ describe('basicCompatVersionComparison', () => {
     expect(basicCompatVersionComparison('61', 60)).toBe(true);
   });
 
+  it('should return false when version added is equals than min version', () => {
+    expect(basicCompatVersionComparison('61.5.2', 61)).toBe(false);
+  });
+
   it('should return false when version added is smaller than min version', () => {
     expect(basicCompatVersionComparison('59', 60)).toBe(false);
+  });
+});
+
+describe('basicCompatVersionComparisonEQ', () => {
+  it('should return false when version added is a boolean', () => {
+    expect(basicCompatVersionComparisonGEQ(false, 60)).toBe(false);
+  });
+
+  it('should return false when version added is undefined', () => {
+    expect(basicCompatVersionComparisonGEQ(undefined, 60)).toBe(false);
+  });
+
+  it('should return true when version added is bigger than min version', () => {
+    expect(basicCompatVersionComparisonGEQ('61', 60)).toBe(true);
+  });
+
+  it('should return true when version added is equals than min version', () => {
+    expect(basicCompatVersionComparisonGEQ('61.5.2', 61)).toBe(true);
+  });
+
+  it('should return false when version added is smaller than min version', () => {
+    expect(basicCompatVersionComparisonGEQ('59', 60)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #5102

Since Firefox Version 117 CSS selector nesting is supported.
This is not reflected in the `rules/css/invalidNestingSelectors.js` of the addons-linter.
In this changeset I introduced a check against the `firefoxMinStrictVersion`, or `strict_min_version` which is specified in the `manifest.json`.

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-431)
