### PR TITLE
feat: Imported Firefox 123 API schema data

### DIFF
--- a/src/schema/imported/contextual_identities.json
+++ b/src/schema/imported/contextual_identities.json
@@ -102,9 +102,37 @@
       ]
     },
     {
+      "name": "move",
+      "type": "function",
+      "description": "Reorder one or more contextual identities by their cookieStoreIDs to a given position.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "cookieStoreIds",
+          "description": "The ID or list of IDs of the contextual identity cookie stores. ",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        {
+          "type": "integer",
+          "name": "position",
+          "description": "The position the contextual identity should move to."
+        }
+      ]
+    },
+    {
       "name": "remove",
       "type": "function",
-      "description": "Deletes a contetual identity by its cookie Store ID.",
+      "description": "Deletes a contextual identity by its cookie Store ID.",
       "async": true,
       "parameters": [
         {

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -184,7 +184,8 @@
         "processcpu",
         "power",
         "responsiveness",
-        "cpufreq"
+        "cpufreq",
+        "bandwidth"
       ]
     },
     "supports": {


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1333395 - Consider support for containers sort order](https://bugzilla.mozilla.org/show_bug.cgi?id=1333395): introduced a new `move` API method to the `contextualIdentities` API namespace (which allows an extension to reorder contextual identities globally, so that their order will be the same for all extensions using this API)

- [Bug 1871545 - Add bandwidth counters](https://bugzilla.mozilla.org/show_bug.cgi?id=1871545): added `bandwith` to the `ProfilerFeatures` enum part of the `geckoProfiler` privileged API namespace

Fixes #5158

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-440)
