### PR TITLE
Prevent errors when non-string CSP values are defined in the manifest

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -232,6 +232,7 @@ export default class ManifestJSONParser extends JSONParser {
           );
         } else if (
           typeof manifestKeyValue === 'object' &&
+          manifestKeyValue !== null &&
           Object.prototype.hasOwnProperty.call(manifestKeyValue, subkey)
         ) {
           this.checkCompatInfo(
@@ -1149,6 +1150,10 @@ export default class ManifestJSONParser extends JSONParser {
   }
 
   validateCspPolicyString(policy, manifestPropName) {
+    if (typeof policy !== 'string') {
+      return;
+    }
+
     const directives = parseCspPolicy(policy);
 
     // The order is important here, 'default-src' needs to be before

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -2248,6 +2248,27 @@ describe('ManifestJSONParser', () => {
         expect(warningsV3.length).toEqual(6);
       }
     );
+
+    // See: https://github.com/mozilla/addons-linter/issues/5194
+    it.each([[true], { extension_pages: true }, null])(
+      'should handle non-string values - %o',
+      (content_security_policy) => {
+        const addonLinter = new Linter({ _: ['bar'] });
+        const json = validManifestJSON({ content_security_policy });
+
+        const manifestJSONParser = new ManifestJSONParser(
+          json,
+          addonLinter.collector
+        );
+
+        const { errors } = addonLinter.collector;
+        expect(errors[0]).toMatchObject({
+          code: messages.MANIFEST_FIELD_INVALID.code,
+          message: '"/content_security_policy" must be string',
+        });
+        expect(manifestJSONParser.isValid).toEqual(false);
+      }
+    );
   });
 
   describe('update_url', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/5194

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-462)
