### PR TITLE
Binary scanner should be able to check string-like buffers

### DIFF
--- a/src/scanners/binary.js
+++ b/src/scanners/binary.js
@@ -3,7 +3,7 @@ import * as messages from 'messages';
 import * as constants from 'const';
 
 export default class BinaryScanner extends BaseScanner {
-  static get fileStreamType() {
+  static get fileResultType() {
     return 'chunk';
   }
 
@@ -15,6 +15,7 @@ export default class BinaryScanner extends BaseScanner {
     if (Object.keys(values).some((v) => values[v] !== buffer[v])) {
       return;
     }
+
     this.linterMessages.push({
       ...messages.FLAGGED_FILE_TYPE,
       type: constants.VALIDATION_NOTICE,

--- a/tests/unit/scanners/test.binary.js
+++ b/tests/unit/scanners/test.binary.js
@@ -26,7 +26,7 @@ describe('Binary', () => {
   });
 
   it('should ask for a chunk', () => {
-    expect(BinaryScanner.fileStreamType).toEqual('chunk');
+    expect(BinaryScanner.fileResultType).toEqual('chunk');
   });
 
   it('should report a proper scanner name', () => {


### PR DESCRIPTION
I noticed this while trying to fix #5258. ~~It looks like - on my machine - the buffer contains characters, not numbers. Therefore, the check against the magic bytes fails.~~

```
NOTICES:

Code                Message                   Description                                                                                 File        Line   Column
FLAGGED_FILE_TYPE   Flagged file type found   Files whose names end with flagged extensions have been found in the add-on. The            win32/adb
                                              extension of these files are flagged because they usually identify binary components.
                                              Please see https://bit.ly/review-policy for more information on the binary content review
                                              process.
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-530)
