### PR TITLE
Binary scanner should read chunks, not strings

### DIFF
--- a/src/scanners/binary.js
+++ b/src/scanners/binary.js
@@ -3,7 +3,7 @@ import * as messages from 'messages';
 import * as constants from 'const';
 
 export default class BinaryScanner extends BaseScanner {
-  static get fileStreamType() {
+  static get fileResultType() {
     return 'chunk';
   }
 
@@ -15,6 +15,7 @@ export default class BinaryScanner extends BaseScanner {
     if (Object.keys(values).some((v) => values[v] !== buffer[v])) {
       return;
     }
+
     this.linterMessages.push({
       ...messages.FLAGGED_FILE_TYPE,
       type: constants.VALIDATION_NOTICE,

--- a/tests/unit/scanners/test.binary.js
+++ b/tests/unit/scanners/test.binary.js
@@ -26,7 +26,7 @@ describe('Binary', () => {
   });
 
   it('should ask for a chunk', () => {
-    expect(BinaryScanner.fileStreamType).toEqual('chunk');
+    expect(BinaryScanner.fileResultType).toEqual('chunk');
   });
 
   it('should report a proper scanner name', () => {


### PR DESCRIPTION
Like https://github.com/mozilla/addons-linter/pull/5263 but with the
right commit message...