### PR TITLE
feat: Imported Firefox 126 API schema data

### DIFF
--- a/src/schema/imported/commands.json
+++ b/src/schema/imported/commands.json
@@ -13,6 +13,18 @@
         {
           "name": "command",
           "type": "string"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "tags#/types/Tab"
+            },
+            {
+              "name": "tab",
+              "optional": true,
+              "description": "Details of the $(ref:tabs.Tab) where the command was activated."
+            }
+          ]
         }
       ]
     },

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -189,6 +189,16 @@
                     }
                   ]
                 },
+                "options_page": {
+                  "allOf": [
+                    {
+                      "$ref": "manifest#/types/ExtensionURL"
+                    },
+                    {
+                      "description": "Alias property for options_ui.page, ignored when options_ui.page is set. When using this property the options page is always opened in a new tab."
+                    }
+                  ]
+                },
                 "options_ui": {
                   "type": "object",
                   "properties": {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -809,9 +809,10 @@
     {
       "name": "captureVisibleTab",
       "type": "function",
-      "description": "Captures an area of the currently active tab in the specified window. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
+      "description": "Captures an area of the currently active tab in the specified window. You must have &lt;all_urls&gt; or activeTab permission to use this method.",
       "permissions": [
-        "<all_urls>"
+        "<all_urls>",
+        "activeTab"
       ],
       "async": "callback",
       "parameters": [

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1386,6 +1386,7 @@
           "type": "string",
           "enum": [
             "webRequest",
+            "webRequestAuthProvider",
             "webRequestBlocking",
             "webRequestFilterResponse",
             "webRequestFilterResponse.serviceWorkerScript"
@@ -1463,7 +1464,7 @@
         "blocking",
         "asyncBlocking"
       ],
-      "postprocess": "webRequestBlockingPermissionRequired"
+      "postprocess": "webRequestBlockingOrAuthProviderPermissionRequired"
     },
     "OnResponseStartedOptions": {
       "type": "string",


### PR DESCRIPTION
The updated schema data includes the following changes:

- [Bug 1843866 - Add tab parameter to commands.onCommand](https://bugzilla.mozilla.org/show_bug.cgi?id=1843866): the commands.onCommand listeners are now expected to receive a new `tab` parameter
- [Bug 1816960 - Consider aliasing options_page to options_ui.page](https://bugzilla.mozilla.org/show_bug.cgi?id=1816960): `optiona_page` manifest property is now supported as an alias for the existing `options_ui.page` manifest property
- [Bug 1784920 - Add `activeTab` as permission for `tabs.captureVisibleTab` API](https://bugzilla.mozilla.org/show_bug.cgi?id=1784920): a granted `activeTab` permission is now also allowing extensions to use `tabs.captureVisibleTab`
- [Bug 1820569 - Implement webRequestAuthProvider permission for webRequest.onAuthRequired](https://bugzilla.mozilla.org/show_bug.cgi?id=1820569): a granted `webRequestAuthProvider` permission allows extension sto register a blocking listener for the `webRequest.onAuthRequired` API event.

Fixes #5280

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDLINT-547)
