### PR TITLE
Revert "chore(deps): bump espree from 10.0.1 to 10.1.0 (#5351)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "8.57.0",
         "eslint-plugin-no-unsanitized": "4.0.2",
         "eslint-visitor-keys": "4.0.0",
-        "espree": "10.1.0",
+        "espree": "10.0.1",
         "esprima": "4.0.1",
         "fast-json-patch": "3.1.1",
         "glob": "11.0.0",
@@ -3594,9 +3594,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5920,11 +5920,11 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
       "dependencies": {
-        "acorn": "^8.12.0",
+        "acorn": "^8.11.3",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "8.57.0",
     "eslint-plugin-no-unsanitized": "4.0.2",
     "eslint-visitor-keys": "4.0.0",
-    "espree": "10.1.0",
+    "espree": "10.0.1",
     "esprima": "4.0.1",
     "fast-json-patch": "3.1.1",
     "glob": "11.0.0",


### PR DESCRIPTION
This reverts commit 592958d1fdc510c12701ca6e9e87ddf6fe118037 because it
is incompatible with Node 16 (which we're using in the add-ons pipeline).