### PR TITLE
chore(circleci): bump nodejs version to from v16 to v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ references:
     working_directory: ~/addons-linter
     docker:
       # This is the NodeJS version we run in production.
-      - image: cimg/node:16.19
+      - image: cimg/node:18.20
 
   defaults-next: &defaults-next
     <<: *defaults
     docker:
       # This is the next NodeJS version we will support.
-      - image: cimg/node:18.15
+      - image: cimg/node:20.17
 
   defaults-alternate: &defaults-alternate
     <<: *defaults
@@ -25,7 +25,7 @@ references:
       # This is an alternate Node version we support or want to support in the
       # (far) future. It can either be lower or higher than the current Node
       # version we run in production.
-      - image: cimg/node:19.6
+      - image: cimg/node:22.7
 
   restore_build_cache: &restore_build_cache
     restore_cache:

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "addons-linter": "bin/addons-linter"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "browserslist": [
-    "node >=16.0.0"
+    "node >=18.0.0"
   ],
   "scripts": {
     "build": "node scripts/build-locales && webpack --bail --stats-error-details true --color --config webpack.config.js",


### PR DESCRIPTION
This PR bumps the nodejs versions used by the circleci jobs:

- test: to v18 (from v16)
- test-next: to v20 (from v18)
- test-alternate: to v22 (from v19)

Fixes test job issue while running recent web-ext tests on a recent unreleased web-ext version where nodejs >= 18 is required (e.g. see [example failure here](https://app.circleci.com/pipelines/github/rpl/addons-linter/39/workflows/463e9605-ba9a-46ee-bb48-0e73fc76f8e8/jobs/129)), introduced as a side effect of the changes from mozilla/web-ext#3217. 