### PR TITLE
feat: Imported Firefox 131 and 132 API schema data

### DIFF
--- a/src/schema/imported/cookies.json
+++ b/src/schema/imported/cookies.json
@@ -431,6 +431,10 @@
         "topLevelSite": {
           "type": "string",
           "description": "The first-party URL of the cookie, if the cookie is in storage partitioned by the top-level site."
+        },
+        "hasCrossSiteAncestor": {
+          "type": "boolean",
+          "description": "Whether or not the cookie is in a third-party context, respecting ancestor chains."
         }
       }
     },

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -462,9 +462,6 @@
           "$ref": "sidebarAction#/definitions/WebExtensionManifest"
         },
         {
-          "$ref": "telemetry#/definitions/WebExtensionManifest"
-        },
-        {
           "$ref": "theme#/definitions/WebExtensionManifest"
         },
         {

--- a/src/schema/imported/storage.json
+++ b/src/schema/imported/storage.json
@@ -38,7 +38,7 @@
     "sync": {
       "allOf": [
         {
-          "$ref": "#/types/StorageAreaSync"
+          "$ref": "#/types/StorageAreaWithUsage"
         },
         {
           "description": "Items in the <code>sync</code> storage area are synced by the browser.",
@@ -121,13 +121,21 @@
     "session": {
       "allOf": [
         {
-          "$ref": "#/types/StorageArea"
+          "$ref": "#/types/StorageAreaWithUsage"
         },
         {
           "allowedContexts": [
             "devtools"
           ],
-          "description": "Items in the <code>session</code> storage area are kept in memory, and only until the either browser or extension is closed or reloaded."
+          "description": "Items in the <code>session</code> storage area are kept in memory, and only until the either browser or extension is closed or reloaded.",
+          "properties": {
+            "QUOTA_BYTES": {
+              "description": "The maximum amount of data (in bytes, currently at 10MB) that can be stored in session storage, as measured by the StructuredCloneHolder of every value plus every key's length."
+            }
+          },
+          "required": [
+            "QUOTA_BYTES"
+          ]
         }
       ]
     }
@@ -313,7 +321,7 @@
         }
       ]
     },
-    "StorageAreaSync": {
+    "StorageAreaWithUsage": {
       "type": "object",
       "functions": [
         {

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -173,7 +173,7 @@
             },
             "openerTabId": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": -1,
               "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab."
             },
             "cookieStoreId": {
@@ -385,7 +385,7 @@
             },
             "openerTabId": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": -1,
               "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab."
             },
             "screen": {
@@ -532,7 +532,7 @@
             },
             "openerTabId": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": -1,
               "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab."
             },
             "loadReplace": {
@@ -1767,7 +1767,7 @@
         },
         "openerTabId": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": -1,
           "description": "The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists."
         },
         "highlighted": {

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -54,39 +54,6 @@
       ]
     },
     {
-      "name": "submitEncryptedPing",
-      "type": "function",
-      "description": "Submits a custom ping to the Telemetry back-end, with an encrypted payload. Requires a telemetry entry in the manifest to be used.",
-      "parameters": [
-        {
-          "name": "message",
-          "type": "object",
-          "additionalProperties": {},
-          "description": "The data payload for the ping, which will be encrypted."
-        },
-        {
-          "description": "Options object.",
-          "name": "options",
-          "type": "object",
-          "properties": {
-            "schemaName": {
-              "type": "string",
-              "description": "Schema name used for payload."
-            },
-            "schemaVersion": {
-              "type": "integer",
-              "description": "Schema version used for payload."
-            }
-          },
-          "required": [
-            "schemaName",
-            "schemaVersion"
-          ]
-        }
-      ],
-      "async": true
-    },
-    {
       "name": "canUpload",
       "type": "function",
       "description": "Checks if Telemetry upload is enabled.",
@@ -250,6 +217,7 @@
     },
     {
       "name": "recordEvent",
+      "deprecated": "`recordEvent` has been deprecated since Firefox 132 (see bug 1894533)",
       "type": "function",
       "description": "Record an event in Telemetry. Throws when trying to record an unknown event.",
       "async": true,
@@ -309,6 +277,7 @@
     },
     {
       "name": "registerEvents",
+      "deprecated": "`registerEvents` has been deprecated since Firefox 132 (see bug 1894533)",
       "type": "function",
       "description": "Register new events to record them from addons. See nsITelemetry.idl for more details.",
       "async": true,
@@ -348,62 +317,6 @@
     }
   ],
   "definitions": {
-    "WebExtensionManifest": {
-      "properties": {
-        "telemetry": {
-          "type": "object",
-          "properties": {
-            "ping_type": {
-              "type": "string"
-            },
-            "schemaNamespace": {
-              "type": "string"
-            },
-            "public_key": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "object",
-                  "properties": {
-                    "crv": {
-                      "type": "string"
-                    },
-                    "kty": {
-                      "type": "string"
-                    },
-                    "x": {
-                      "type": "string"
-                    },
-                    "y": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "required": [
-                "id",
-                "key"
-              ]
-            },
-            "study_name": {
-              "type": "string"
-            },
-            "pioneer_id": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          "required": [
-            "ping_type",
-            "schemaNamespace",
-            "public_key"
-          ]
-        }
-      }
-    },
     "PermissionPrivileged": {
       "anyOf": [
         {
@@ -416,10 +329,6 @@
     }
   },
   "refs": {
-    "telemetry#/definitions/WebExtensionManifest": {
-      "namespace": "manifest",
-      "type": "WebExtensionManifest"
-    },
     "telemetry#/definitions/PermissionPrivileged": {
       "namespace": "manifest",
       "type": "PermissionPrivileged"


### PR DESCRIPTION
The updated schema data includes the following changes:

- Firefox 131
  - [Bug 1908925 - storage.session quota is not enforced](https://bugzilla.mozilla.org/show_bug.cgi?id=1908925): `QUOTA_BYTES` property and `getBytesInUse` method to the `storage.session` API (storage.session quota only enforced on Nightly builds, while in Firefox >= 132 a warning is currently logged on beta and release channels when the storage.session quota is being exceeded)
  - [Bug 1409262 - Updated openerTabId is not notified via tabs.onUpdated if it is changed by tabs.update()](https://bugzilla.mozilla.org/show_bug.cgi?id=1409262): changed `openerTabId` minimum allowed value to `-1` (meant to be used in tabs.onUpdated API calls to clear the previously set openerTabId)
  - [Bug 1913704 - Remove Firefox Pioneer code](https://bugzilla.mozilla.org/show_bug.cgi?id=1913704): removed unused "telemetry" manifest property and submitEncryptedPing telemetry API method (privileged API only available to privileged signed extensions and builtins)

- Firefox 132
  - [Bug 1873418 - Support partitioned cookie attribute for browser extensions](https://bugzilla.mozilla.org/show_bug.cgi?id=1873418): introduced a new `hasCrossSiteAncestor` boolean property to the cookies API `PartitionKey` type

Fixes #5465 