### PR TITLE
docs: Add backticks to FLUENT_INVALID

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -262,7 +262,7 @@
 </thead>
 <tbody>
 <tr>
-<td>FLUENT_INVALID</td>
+<td><code>FLUENT_INVALID</code></td>
 <td>warning</td>
 <td>Invalid fluent template file.</td>
 </tr>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -65,9 +65,9 @@ Rules are sorted by severity.
 
 ## Language packs
 
-| Message code   | Severity | Description                   |
-| -------------- | -------- | ----------------------------- |
-| FLUENT_INVALID | warning  | Invalid fluent template file. |
+| Message code     | Severity | Description                   |
+| ---------------- | -------- | ----------------------------- |
+| `FLUENT_INVALID` | warning  | Invalid fluent template file. |
 
 ## Web Extensions / manifest.json
 


### PR DESCRIPTION
Add backticks to message code `FLUENT_INVALID` in [_Linter Rules_ documentation](https://mozilla.github.io/addons-linter/#language-packs).