### PR TITLE
feat: Imported Firefox 133 schema data

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -186,7 +186,8 @@
         "responsiveness",
         "cpufreq",
         "bandwidth",
-        "memory"
+        "memory",
+        "tracing"
       ]
     },
     "supports": {

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -217,7 +217,7 @@
     },
     {
       "name": "recordEvent",
-      "deprecated": "`recordEvent` has been deprecated since Firefox 132 (see bug 1894533)",
+      "deprecated": "`recordEvent` is a no-op since Firefox 132 (see bug 1894533)",
       "type": "function",
       "description": "Record an event in Telemetry. Throws when trying to record an unknown event.",
       "async": true,
@@ -277,7 +277,7 @@
     },
     {
       "name": "registerEvents",
-      "deprecated": "`registerEvents` has been deprecated since Firefox 132 (see bug 1894533)",
+      "deprecated": "`registerEvents` is a no-op since Firefox 132 (see bug 1894533)",
       "type": "function",
       "description": "Register new events to record them from addons. See nsITelemetry.idl for more details.",
       "async": true,
@@ -299,8 +299,9 @@
     },
     {
       "name": "setEventRecordingEnabled",
+      "deprecated": "`setEventRecordingEnabled` is a no-op since Firefox 133 (see bug 1920562)",
       "type": "function",
-      "description": "Enable recording of events in a category. Events default to recording disabled. This allows to toggle recording for all events in the specified category.",
+      "description": "Enable recording of events in a category. Events default to recording enabled. This allows to toggle recording for all events in the specified category.",
       "async": true,
       "parameters": [
         {


### PR DESCRIPTION
The updated schema data includes the following changes:
- [Bug 1911021 - Integrate native tracer output directly into the profiler](https://bugzilla.mozilla.org/show_bug.cgi?id=1911021): added tracking to the geckoProfiler ProfilerFeature enum
- [Bug 1923953 - Clarify deprecation notices of now no-op'd browser.telemetry APIs in docs and schema](https://bugzilla.mozilla.org/show_bug.cgi?id=1923953): updated telemetry API description to more explicitly state that the deprecated API methods are expected to be no-op in Firefox versions >= 132

NOTE: Both of these API are not available to non privileged extensions and so there isn't going to be any expected changes in behavior for non privileged extensions submitted to AMO.

Fixes #5498