### PR TITLE
feat: Imported Firefox 134 and Firefox 135 schema data

### DIFF
--- a/src/schema/imported/chrome_settings_overrides.json
+++ b/src/schema/imported/chrome_settings_overrides.json
@@ -128,52 +128,6 @@
                 "is_default": {
                   "type": "boolean",
                   "description": "Sets the default engine to a built-in engine only."
-                },
-                "params": {
-                  "max_manifest_version": 2,
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "A url parameter name"
-                      },
-                      "condition": {
-                        "type": "string",
-                        "enum": [
-                          "purpose",
-                          "pref"
-                        ],
-                        "description": "The type of param can be either \"purpose\" or \"pref\"."
-                      },
-                      "pref": {
-                        "type": "string",
-                        "description": "The preference to retrieve the value from.",
-                        "preprocess": "localize"
-                      },
-                      "purpose": {
-                        "type": "string",
-                        "enum": [
-                          "contextmenu",
-                          "searchbar",
-                          "homepage",
-                          "keyword",
-                          "newtab"
-                        ],
-                        "description": "The context that initiates a search, required if condition is \"purpose\"."
-                      },
-                      "value": {
-                        "type": "string",
-                        "description": "A url parameter value.",
-                        "preprocess": "localize"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ]
-                  },
-                  "description": "A list of optional search url parameters. This allows the additon of search url parameters based on how the search is performed in Firefox."
                 }
               },
               "required": [

--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -592,6 +592,7 @@
         "imageset",
         "web_manifest",
         "speculative",
+        "json",
         "other"
       ]
     },

--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -187,7 +187,9 @@
         "cpufreq",
         "bandwidth",
         "memory",
-        "tracing"
+        "tracing",
+        "sandbox",
+        "flows"
       ]
     },
     "supports": {

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -53,6 +53,7 @@ import telemetry from './telemetry.json';
 import test from './test.json';
 import theme from './theme.json';
 import topSites from './top_sites.json';
+import trial from './trial_ml.json';
 import types from './types.json';
 import url_overrides from './url_overrides.json';
 import userScripts from './userScripts.json';
@@ -113,6 +114,7 @@ export default [
   test,
   theme,
   topSites,
+  trial,
   types,
   url_overrides,
   userScripts,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -617,7 +617,9 @@
       "anyOf": [
         {
           "type": "string",
-          "enum": []
+          "enum": [
+            "userScripts"
+          ]
         },
         {
           "$ref": "trial#/definitions/OptionalOnlyPermission"

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -613,6 +613,20 @@
         "size"
       ]
     },
+    "OptionalOnlyPermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": []
+        },
+        {
+          "$ref": "trial#/definitions/OptionalOnlyPermission"
+        },
+        {
+          "$ref": "userScripts#/definitions/OptionalOnlyPermission"
+        }
+      ]
+    },
     "OptionalPermissionNoPrompt": {
       "anyOf": [
         {
@@ -715,6 +729,9 @@
       "anyOf": [
         {
           "$ref": "#/types/OptionalPermission"
+        },
+        {
+          "$ref": "#/types/OptionalOnlyPermission"
         },
         {
           "$ref": "#/types/MatchPattern"

--- a/src/schema/imported/network_status.json
+++ b/src/schema/imported/network_status.json
@@ -8,7 +8,7 @@
     {
       "name": "getLinkInfo",
       "type": "function",
-      "description": "Returns the $(ref:NetworkLinkInfo} of the current network connection.",
+      "description": "Returns the $(ref:NetworkLinkInfo) of the current network connection.",
       "async": true,
       "parameters": []
     }

--- a/src/schema/imported/permissions.json
+++ b/src/schema/imported/permissions.json
@@ -154,7 +154,14 @@
         "permissions": {
           "type": "array",
           "items": {
-            "$ref": "manifest#/types/OptionalPermission"
+            "anyOf": [
+              {
+                "$ref": "manifest#/types/OptionalPermission"
+              },
+              {
+                "$ref": "manifest#/types/OptionalOnlyPermission"
+              }
+            ]
           },
           "default": []
         },
@@ -173,7 +180,14 @@
         "permissions": {
           "type": "array",
           "items": {
-            "$ref": "manifest#/types/Permission"
+            "anyOf": [
+              {
+                "$ref": "manifest#/types/Permission"
+              },
+              {
+                "$ref": "manifest#/types/OptionalOnlyPermission"
+              }
+            ]
           },
           "default": []
         },

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -564,6 +564,26 @@
       ]
     },
     {
+      "name": "onUserScriptConnect",
+      "type": "function",
+      "description": "Fired when a connection is made from a USER_SCRIPT world registered through the userScripts API.",
+      "permissions": [
+        "userScripts"
+      ],
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/Port"
+            },
+            {
+              "name": "port"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "onConnectExternal",
       "type": "function",
       "description": "Fired when a connection is made from another extension.",
@@ -620,6 +640,41 @@
       "name": "onMessageExternal",
       "type": "function",
       "description": "Fired when a message is sent from another extension/app. Cannot be used in a content script.",
+      "parameters": [
+        {
+          "name": "message",
+          "optional": true,
+          "description": "The message sent by the calling script."
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/MessageSender"
+            },
+            {
+              "name": "sender"
+            }
+          ]
+        },
+        {
+          "name": "sendResponse",
+          "type": "function",
+          "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code> listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code> is called)."
+        }
+      ],
+      "returns": {
+        "type": "boolean",
+        "optional": true,
+        "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns."
+      }
+    },
+    {
+      "name": "onUserScriptMessage",
+      "type": "function",
+      "description": "Fired when a message is sent from a USER_SCRIPT world registered through the userScripts API.",
+      "permissions": [
+        "userScripts"
+      ],
       "parameters": [
         {
           "name": "message",
@@ -935,6 +990,10 @@
           "unsupported": true,
           "type": "string",
           "description": "The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available."
+        },
+        "userScriptWorldId": {
+          "type": "string",
+          "description": "The worldId of the USER_SCRIPT world that sent the message. Only present on onUserScriptMessage and onUserScriptConnect (in port.sender) events."
         }
       }
     },

--- a/src/schema/imported/telemetry.json
+++ b/src/schema/imported/telemetry.json
@@ -62,6 +62,7 @@
     },
     {
       "name": "scalarAdd",
+      "deprecated": "`scalarAdd` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Adds the value to the given scalar.",
       "async": true,
@@ -81,6 +82,7 @@
     },
     {
       "name": "scalarSet",
+      "deprecated": "`scalarSet` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Sets the named scalar to the given value. Throws if the value type doesn't match the scalar type.",
       "async": true,
@@ -113,6 +115,7 @@
     },
     {
       "name": "scalarSetMaximum",
+      "deprecated": "`scalarSetMaximum` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Sets the scalar to the maximum of the current and the passed value",
       "async": true,
@@ -132,6 +135,7 @@
     },
     {
       "name": "keyedScalarAdd",
+      "deprecated": "`keyedScalarAdd` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Adds the value to the given keyed scalar.",
       "async": true,
@@ -156,6 +160,7 @@
     },
     {
       "name": "keyedScalarSet",
+      "deprecated": "`keyedScalarSet` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Sets the keyed scalar to the given value. Throws if the value type doesn't match the scalar type.",
       "async": true,
@@ -193,6 +198,7 @@
     },
     {
       "name": "keyedScalarSetMaximum",
+      "deprecated": "`keyedScalarSetMaximum` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Sets the keyed scalar to the maximum of the current and the passed value",
       "async": true,
@@ -256,6 +262,7 @@
     },
     {
       "name": "registerScalars",
+      "deprecated": "`registerScalars` is a no-op since Firefox 134 (see bug 1930196)",
       "type": "function",
       "description": "Register new scalars to record them from addons. See nsITelemetry.idl for more details.",
       "async": true,

--- a/src/schema/imported/trial_ml.json
+++ b/src/schema/imported/trial_ml.json
@@ -1,0 +1,115 @@
+{
+  "$id": "trial",
+  "allowedContexts": [
+    "content"
+  ],
+  "permissions": [
+    "trialML"
+  ],
+  "properties": {
+    "ml": {
+      "description": "Use the trial ML API to run Machine Learning models requests from extensions pages or content scripts.",
+      "allowedContexts": [
+        "content"
+      ],
+      "permissions": [
+        "trialML"
+      ],
+      "events": [
+        {
+          "name": "onProgress",
+          "type": "function",
+          "allowedContexts": [
+            "content"
+          ],
+          "description": "Events from the inference engine.",
+          "parameters": [
+            {
+              "name": "progressData",
+              "description": "Object containing the data, see https://firefox-source-docs.mozilla.org/toolkit/components/ml/notifications.html",
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "functions": [
+        {
+          "name": "createEngine",
+          "type": "function",
+          "description": "Prepare the inference engine",
+          "async": true,
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/CreateEngineRequest"
+                },
+                {
+                  "name": "CreateEngineRequest"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "runEngine",
+          "type": "function",
+          "allowedContexts": [
+            "content"
+          ],
+          "description": "Call the inference engine",
+          "async": true,
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/RunEngineRequest"
+                },
+                {
+                  "name": "RunEngineRequest"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "deleteCachedModels",
+          "type": "function",
+          "allowedContexts": [
+            "content"
+          ],
+          "description": "Delete the models the extension downloaded.",
+          "async": true
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "OptionalOnlyPermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "trialML"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "trial#/definitions/OptionalOnlyPermission": {
+      "namespace": "manifest",
+      "type": "OptionalOnlyPermission"
+    }
+  },
+  "types": {
+    "CreateEngineRequest": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "RunEngineRequest": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/schema/imported/userScripts.json
+++ b/src/schema/imported/userScripts.json
@@ -1,15 +1,16 @@
 {
   "$id": "userScripts",
-  "max_manifest_version": 2,
   "permissions": [
-    "manifest:user_scripts"
+    "manifest:user_scripts",
+    "userScripts"
   ],
   "functions": [
     {
       "name": "register",
+      "max_manifest_version": 2,
       "type": "function",
-      "description": "Register a user script programmatically given its $(ref:userScripts.UserScriptOptions), and resolves to a $(ref:userScripts.RegisteredUserScript) instance",
-      "async": true,
+      "description": "Register a user script programmatically given its $(ref:userScripts.UserScriptOptions), and resolves to an object with the unregister() function",
+      "async": "callback",
       "parameters": [
         {
           "allOf": [
@@ -20,11 +21,207 @@
               "name": "userScriptOptions"
             }
           ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "legacyRegisteredUserScript",
+              "type": "object",
+              "description": "An object that represents a user script registered programmatically",
+              "properties": {
+                "unregister": {
+                  "type": "function",
+                  "description": "Unregister a user script registered programmatically",
+                  "async": true,
+                  "parameters": []
+                }
+              },
+              "required": [
+                "unregister"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "register",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Registers one or more user scripts for this extension.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "scripts",
+          "type": "array",
+          "items": {
+            "$ref": "#/types/RegisteredUserScript"
+          },
+          "description": "List of user scripts to be registered."
+        }
+      ]
+    },
+    {
+      "name": "update",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Updates one or more user scripts for this extension.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "scripts",
+          "type": "array",
+          "items": {
+            "$merge": {
+              "source": {
+                "$ref": "userScripts#/types/RegisteredUserScript"
+              },
+              "with": {
+                "type": "object",
+                "properties": {
+                  "js": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/types/ScriptSource"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "List of user scripts to be updated."
+        }
+      ]
+    },
+    {
+      "name": "unregister",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Unregisters all dynamically-registered user scripts for this extension.",
+      "async": true,
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/UserScriptFilter"
+            },
+            {
+              "name": "filter",
+              "optional": true,
+              "description": "If specified, this method unregisters only the user scripts that match it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "getScripts",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Returns all dynamically-registered user scripts for this extension.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/UserScriptFilter"
+            },
+            {
+              "name": "filter",
+              "optional": true,
+              "description": "If specified, this method returns only the user scripts that match it."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "scripts",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/RegisteredUserScript"
+              },
+              "description": "List of registered user scripts."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "configureWorld",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Configures the environment for scripts running in a USER_SCRIPT world.",
+      "async": true,
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/WorldProperties"
+            },
+            {
+              "name": "properties",
+              "description": "The desired configuration for a USER_SCRIPT world."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "resetWorldConfiguration",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Resets the configuration for a given world. That world will fall back to the default world's configuration.",
+      "async": true,
+      "parameters": [
+        {
+          "name": "worldId",
+          "type": "string",
+          "optional": true,
+          "default": "",
+          "description": "The ID of the USER_SCRIPT world to reset. If omitted or empty, resets the default world's configuration."
+        }
+      ]
+    },
+    {
+      "name": "getWorldConfigurations",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Returns all registered USER_SCRIPT world configurations.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "configurations",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/WorldProperties"
+              },
+              "description": "All configurations registered with configureWorld()."
+            }
+          ]
         }
       ]
     }
   ],
   "definitions": {
+    "OptionalOnlyPermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "userScripts"
+          ]
+        }
+      ]
+    },
     "WebExtensionManifest": {
       "properties": {
         "user_scripts": {
@@ -40,6 +237,10 @@
     }
   },
   "refs": {
+    "userScripts#/definitions/OptionalOnlyPermission": {
+      "namespace": "manifest",
+      "type": "OptionalOnlyPermission"
+    },
     "userScripts#/definitions/WebExtensionManifest": {
       "namespace": "manifest",
       "type": "WebExtensionManifest"
@@ -47,6 +248,7 @@
   },
   "types": {
     "UserScriptOptions": {
+      "max_manifest_version": 2,
       "type": "object",
       "description": "Details of a user script",
       "properties": {
@@ -137,17 +339,153 @@
       ]
     },
     "RegisteredUserScript": {
+      "min_manifest_version": 3,
       "type": "object",
       "description": "An object that represents a user script registered programmatically",
-      "functions": [
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the user script specified in the API call. This property must not start with a '_' as it's reserved as a prefix for generated script IDs."
+        },
+        "allFrames": {
+          "type": "boolean",
+          "description": "If allFrames is <code>true</code>, implies that the JavaScript should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame."
+        },
+        "js": {
+          "type": "array",
+          "description": "The list of ScriptSource objects defining sources of scripts to be injected into matching pages.",
+          "items": {
+            "$ref": "#/types/ScriptSource"
+          }
+        },
+        "matches": {
+          "type": "array",
+          "description": "At least one of matches or includeGlobs should be non-empty. The script runs in documents whose URL match either pattern.",
+          "items": {
+            "$ref": "manifest#/types/MatchPattern"
+          }
+        },
+        "excludeMatches": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/MatchPattern"
+          }
+        },
+        "includeGlobs": {
+          "type": "array",
+          "description": "At least one of matches or includeGlobs should be non-empty. The script runs in documents whose URL match either pattern.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeGlobs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runAt": {
+          "allOf": [
+            {
+              "$ref": "extensionTypes#/types/RunAt"
+            },
+            {
+              "description": "The soonest that the JavaScript will be injected into the tab. Defaults to \"document_idle\"."
+            }
+          ]
+        },
+        "world": {
+          "allOf": [
+            {
+              "$ref": "#/types/ExecutionWorld"
+            },
+            {
+              "description": "The JavaScript script for a script to execute within. Defaults to \"USER_SCRIPT\"."
+            }
+          ]
+        },
+        "worldId": {
+          "type": "string",
+          "description": "If specified, specifies a specific user script world ID to execute in. Only valid if `world` is omitted or is `USER_SCRIPT`. If `worldId` is omitted, the script will execute in the default user script world (\"\"). Values with leading underscores (`_`) are reserved. The maximum length is 256."
+        }
+      },
+      "required": [
+        "id",
+        "js"
+      ]
+    },
+    "ExecutionWorld": {
+      "min_manifest_version": 3,
+      "type": "string",
+      "enum": [
+        "MAIN",
+        "USER_SCRIPT"
+      ],
+      "description": "The JavaScript world for a script to execute within. <code>USER_SCRIPT</code> is the default execution environment of user scripts, <code>MAIN</code> is the web page's execution environment."
+    },
+    "UserScriptFilter": {
+      "min_manifest_version": 3,
+      "type": "object",
+      "description": "Optional filter to use with getScripts() and unregister().",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScriptSource": {
+      "min_manifest_version": 3,
+      "description": "Object with file xor code property. Equivalent to the ExtensionFileOrCode, except the file remains a relative URL.",
+      "anyOf": [
         {
-          "name": "unregister",
-          "type": "function",
-          "description": "Unregister a user script registered programmatically",
-          "async": true,
-          "parameters": []
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "description": "The path of the JavaScript file to inject relative to the extension's root directory.",
+              "format": "unresolvedRelativeUrl"
+            }
+          },
+          "required": [
+            "file"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code"
+          ]
         }
       ]
+    },
+    "WorldProperties": {
+      "min_manifest_version": 3,
+      "type": "object",
+      "description": "The configuration of a USER_SCRIPT world.",
+      "properties": {
+        "worldId": {
+          "type": "string",
+          "default": "",
+          "description": "The identifier of the world. Values with leading underscores (`_`) are reserved. The maximum length is 256. Defaults to the default USER_SCRIPT world (\"\")."
+        },
+        "csp": {
+          "type": "string",
+          "description": "The world's Content Security Policy. Defaults to the CSP of regular content scripts, which prohibits dynamic code execution such as eval."
+        },
+        "messaging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the runtime.sendMessage and runtime.connect methods are exposed. Defaults to not exposing these messaging APIs."
+        }
+      }
     }
   },
   "allowedContexts": [
@@ -156,6 +494,7 @@
   "events": [
     {
       "name": "onBeforeScript",
+      "max_manifest_version": 2,
       "permissions": [
         "manifest:user_scripts.api_script"
       ],

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1425,6 +1425,7 @@
         "imageset",
         "web_manifest",
         "speculative",
+        "json",
         "other"
       ]
     },

--- a/src/schema/updates/manifest.json
+++ b/src/schema/updates/manifest.json
@@ -119,6 +119,14 @@
             "maxItems": 5
           }
         }
+      },
+      "OptionalOnlyPermission": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": ["userScripts"]
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
The updated schema data includes the following changes

Firefox 134:
- [Bug 1924071 - Remove the purpose option from search URLs](https://bugzilla.mozilla.org/show_bug.cgi?id=1924071): removed unused API schema related to legacy application provided search engines
- [Bug 1929104 - Disable SandboxProfiler* by default when profiling](https://bugzilla.mozilla.org/show_bug.cgi?id=1929104): added `"sandbox"` to the `ProfilerFeature` strings enum
- [Bug 1919323 - Add support for optional-only permissions](https://bugzilla.mozilla.org/show_bug.cgi?id=1919323): introduced new `OptionalOnlyPermission` type
- [Bug 1917799 - Implement a WebExtension experimental API for Firefox AI Platform](https://bugzilla.mozilla.org/show_bug.cgi?id=1917799): introduced new trialML optional only permission
- [Bug 1903498 - Typo in schema file network_status.json](https://bugzilla.mozilla.org/show_bug.cgi?id=1903498): fixed typo in networkStatus API schema description property
- [Bug 1911836 - Implement runtime.onUserScriptMessage and runtime.onUserScriptConnect](https://bugzilla.mozilla.org/show_bug.cgi?id=1911836): introduced new `runtime.onUserScriptMessage` and `runtime.onUserScriptConnect` API events
- [Bug 1930196 - Deprecate browser.telemetry.registerScalars and browser.telemetry.{keyedScalar,scalar}{Set,Add} and replace them with no-ops](https://bugzilla.mozilla.org/show_bug.cgi?id=1930196): added deprecation notes on `telemetry` API method related to dynamically registered scalars
- [Bug 1911833 - Implement initial MV3 userScripts API bindings](https://bugzilla.mozilla.org/show_bug.cgi?id=1911833): added Manifest V3 userScripts API schema
- [Bug 1911835 - Implement USER_SCRIPT world](https://bugzilla.mozilla.org/show_bug.cgi?id=1911835): added `USER_SCRIPT` world to `ExecutionWorld` string enum
- [Bug 1917000 - Implement opt-in to userScripts API](https://bugzilla.mozilla.org/show_bug.cgi?id=1917000): added `"userScripts"` to the `OptionalOnlyPermission` string enum

Firefox 135:
- [Bug 1858078 - Add CSP support to JSON modules](https://bugzilla.mozilla.org/show_bug.cgi?id=1858078): added "json" resource type to DNR and webRequest API schema
- [Bug 1937636 - Add a profiler feature for recording flow markers](https://bugzilla.mozilla.org/show_bug.cgi?id=1937636): added `"flows"` to the `ProfileFeature` strings enum

In addition to that this PR also includes:
- a temporary workaround on the addons-linter `src/schema/updates/manifest.json` side to prevent the empty enum currently part of the OptionalOnlyPermission schema data as imported from Firefox from triggering errors originated from ajv (which consider an empty array associated to an enum as invalid schema data) - see b417050e9f705e819013d02172d019858bba42b8
  - [x] File bugzilla issue to remove the empty enum array from the API schema data imported from Firefox (tracked by [Bug 1942814](https://bugzilla.mozilla.org/show_bug.cgi?id=1942814))
  - [x] File github issue to remove the workaround along with the next Firefox 136 schema data import where the invalid empty enum array wouldn't be part of the data imported from Firefox anymore (tracked by #5553)
- new tests to explicitly cover the behaviors expected on optional only permissions (when invalid due to being requested as non-optional and when valid due to being requested as optional)
  - [x] File followup to consider adding a new error code to be associated specifically to the error to be reported when an optional only permission is being requested as non-optional and a better error message providing a link to docs describing how developers are expected to use optional only permissions in their extensions (tracked by #5554)

Fixes #5550