### PR TITLE
feat: Imported Firefox 137 schema data

### DIFF
--- a/src/schema/imported/commands.json
+++ b/src/schema/imported/commands.json
@@ -125,6 +125,13 @@
           "description": "Called to return the registered commands."
         }
       ]
+    },
+    {
+      "name": "openShortcutSettings",
+      "type": "function",
+      "async": true,
+      "description": "Open extension shortcuts configuration page.",
+      "parameters": []
     }
   ],
   "definitions": {

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -31,7 +31,7 @@
         },
         "name": {
           "type": "string",
-          "description": "Name must be at least 2, at should be at most 75 characters",
+          "description": "Name must be at least 2, and should be at most 75 characters",
           "preprocess": "localize",
           "maxLength": 45,
           "minLength": 2


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 137 API JSONSchema data:
- [Bug 1538451 - Make extension shortcut management page accessible by a link/URL for a WebExtension](https://bugzilla.mozilla.org/show_bug.cgi?id=1538451): added JSONSchema data for the new API method `browser.commands.openShortcutsSettings`.
- [Bug 1950334 - Typo in manifest schema](https://bugzilla.mozilla.org/show_bug.cgi?id=1950334): fixed a type in the `description` property associated to the manifest.json's `name` property.

Fixes #5606 