### PR TITLE
feat: Imported Firefox 139 schema data

### DIFF
--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -48,6 +48,7 @@ import search from './search.json';
 import sessions from './sessions.json';
 import sidebarAction from './sidebar_action.json';
 import storage from './storage.json';
+import tabGroups from './tabGroups.json';
 import tabs from './tabs.json';
 import telemetry from './telemetry.json';
 import test from './test.json';
@@ -109,6 +110,7 @@ export default [
   sessions,
   sidebarAction,
   storage,
+  tabGroups,
   tabs,
   telemetry,
   test,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -642,6 +642,9 @@
           "$ref": "search#/definitions/OptionalPermissionNoPrompt"
         },
         {
+          "$ref": "tabGroups#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
           "$ref": "tabs#/definitions/OptionalPermissionNoPrompt"
         },
         {
@@ -748,6 +751,51 @@
         },
         {
           "$ref": "telemetry#/definitions/PermissionPrivileged"
+        }
+      ]
+    },
+    "CommonDataCollectionPermission": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "authenticationInfo",
+            "bookmarksInfo",
+            "browsingHistory",
+            "financialAndPaymentInfo",
+            "healthInfo",
+            "locationInfo",
+            "personalCommunications",
+            "personallyIdentifyingInfo",
+            "websiteActivity",
+            "websiteContent"
+          ]
+        }
+      ]
+    },
+    "DataCollectionPermission": {
+      "anyOf": [
+        {
+          "$ref": "#/types/CommonDataCollectionPermission"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        }
+      ]
+    },
+    "OptionalDataCollectionPermission": {
+      "anyOf": [
+        {
+          "$ref": "#/types/CommonDataCollectionPermission"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "technicalAndInteraction"
+          ]
         }
       ]
     },
@@ -878,6 +926,25 @@
         },
         "admin_install_only": {
           "type": "boolean"
+        },
+        "data_collection_permissions": {
+          "type": "object",
+          "properties": {
+            "optional": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/types/OptionalDataCollectionPermission"
+                  },
+                  {
+                    "onError": "warn"
+                  }
+                ]
+              },
+              "default": []
+            }
+          }
         }
       }
     },

--- a/src/schema/imported/permissions.json
+++ b/src/schema/imported/permissions.json
@@ -171,6 +171,13 @@
             "$ref": "manifest#/types/MatchPattern"
           },
           "default": []
+        },
+        "data_collection": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/OptionalDataCollectionPermission"
+          },
+          "default": []
         }
       }
     },
@@ -195,6 +202,13 @@
           "type": "array",
           "items": {
             "$ref": "manifest#/types/MatchPattern"
+          },
+          "default": []
+        },
+        "data_collection": {
+          "type": "array",
+          "items": {
+            "$ref": "manifest#/types/OptionalDataCollectionPermission"
           },
           "default": []
         }

--- a/src/schema/imported/tabGroups.json
+++ b/src/schema/imported/tabGroups.json
@@ -1,0 +1,331 @@
+{
+  "$id": "tabGroups",
+  "description": "Use the browser.tabGroups API to interact with the browser's tab grouping system. You can use this API to modify, and rearrange tab groups.",
+  "permissions": [
+    "tabGroups"
+  ],
+  "properties": {
+    "TAB_GROUP_ID_NONE": {
+      "value": -1,
+      "description": "An ID that represents the absence of a group."
+    }
+  },
+  "functions": [
+    {
+      "name": "get",
+      "type": "function",
+      "description": "Retrieves details about the specified group.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "groupId",
+          "minimum": 0
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/TabGroup"
+                },
+                {
+                  "name": "group"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "move",
+      "type": "function",
+      "description": "Move a group within, or to another window.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "groupId",
+          "minimum": 0
+        },
+        {
+          "type": "object",
+          "name": "moveProperties",
+          "properties": {
+            "index": {
+              "type": "integer",
+              "minimum": -1
+            },
+            "windowId": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "index"
+          ]
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/TabGroup"
+                },
+                {
+                  "name": "group"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "query",
+      "type": "function",
+      "description": "Return all grups, or find groups with specified properties.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "object",
+          "name": "queryInfo",
+          "optional": true,
+          "properties": {
+            "collapsed": {
+              "type": "boolean"
+            },
+            "color": {
+              "$ref": "#/types/Color"
+            },
+            "title": {
+              "type": "string"
+            },
+            "windowId": {
+              "type": "integer",
+              "minimum": -2
+            }
+          }
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "name": "groups",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/TabGroup"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "update",
+      "type": "function",
+      "description": "Modifies state of a specified group.",
+      "async": "callback",
+      "parameters": [
+        {
+          "type": "integer",
+          "name": "groupId",
+          "minimum": 0
+        },
+        {
+          "type": "object",
+          "name": "updateProperties",
+          "properties": {
+            "collapsed": {
+              "type": "boolean"
+            },
+            "color": {
+              "$ref": "#/types/Color"
+            },
+            "title": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "function",
+          "name": "callback",
+          "parameters": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/types/TabGroup"
+                },
+                {
+                  "name": "group"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "onCreated",
+      "type": "function",
+      "description": "Fired when a tab group is created.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/TabGroup"
+            },
+            {
+              "name": "group"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onMoved",
+      "type": "function",
+      "description": "Fired when a tab group is moved, within a window or to another window.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/TabGroup"
+            },
+            {
+              "name": "group"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onRemoved",
+      "type": "function",
+      "description": "Fired when a tab group is removed.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/TabGroup"
+            },
+            {
+              "name": "group"
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "name": "removeInfo",
+          "properties": {
+            "isWindowClosing": {
+              "type": "boolean",
+              "description": "True when the tab group is being closed because its window is being closed."
+            }
+          },
+          "required": [
+            "isWindowClosing"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "onUpdated",
+      "type": "function",
+      "description": "Fired when a tab group is updated.",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/TabGroup"
+            },
+            {
+              "name": "group"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "OptionalPermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "tabGroups"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "tabGroups#/definitions/OptionalPermissionNoPrompt": {
+      "namespace": "manifest",
+      "type": "OptionalPermissionNoPrompt"
+    }
+  },
+  "types": {
+    "Color": {
+      "type": "string",
+      "description": "The group's color, using 'grey' spelling for compatibility with Chromium.",
+      "enum": [
+        "blue",
+        "cyan",
+        "grey",
+        "green",
+        "orange",
+        "pink",
+        "purple",
+        "red",
+        "yellow"
+      ]
+    },
+    "TabGroup": {
+      "type": "object",
+      "description": "State of a tab group inside of an open window.",
+      "properties": {
+        "collapsed": {
+          "type": "boolean",
+          "description": "Whether the tab group is collapsed or expanded in the tab strip."
+        },
+        "color": {
+          "allOf": [
+            {
+              "$ref": "#/types/Color"
+            },
+            {
+              "description": "User-selected color name for the tab group's label/icons."
+            }
+          ]
+        },
+        "id": {
+          "type": "integer",
+          "description": "Unique ID of the tab group."
+        },
+        "title": {
+          "type": "string",
+          "description": "User-defined name of the tab group."
+        },
+        "windowId": {
+          "type": "integer",
+          "description": "Window that the tab group is in."
+        }
+      },
+      "required": [
+        "collapsed",
+        "color",
+        "id",
+        "windowId"
+      ]
+    }
+  }
+}

--- a/src/schema/imported/test.json
+++ b/src/schema/imported/test.json
@@ -240,6 +240,7 @@
     {
       "name": "assertThrows",
       "type": "function",
+      "allowAmbiguousOptionalArguments": true,
       "parameters": [
         {
           "name": "func",
@@ -251,7 +252,9 @@
               "$ref": "#/types/ExpectedError"
             },
             {
-              "name": "expectedError"
+              "name": "expectedError",
+              "optional": true,
+              "description": "Required, unless running with extensions.wpt.enabled"
             }
           ]
         },
@@ -259,6 +262,21 @@
           "name": "message",
           "type": "string",
           "optional": true
+        }
+      ]
+    },
+    {
+      "name": "runTests",
+      "type": "function",
+      "async": true,
+      "parameters": [
+        {
+          "name": "tests",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "function"
+          }
         }
       ]
     }


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 139 API JSONSchema data:

- [Bug 1940631](https://bugzilla.mozilla.org/show_bug.cgi?id=1940631) / [Bug 1965007](https://bugzilla.mozilla.org/show_bug.cgi?id=1965007): Added JSONSchema definitions for the new `tabGroups` API namespace
- [Bug 1954524](https://bugzilla.mozilla.org/show_bug.cgi?id=1954524): Added JSONSchema definitions for the new `browser_specific_settings.gecko.data_collection_permissions` manifest property
- [Bug 1954522](https://bugzilla.mozilla.org/show_bug.cgi?id=1954522) / [Bug 1954525](https://bugzilla.mozilla.org/show_bug.cgi?id=1954525): Added support for the new `data_collection` to the in `browser.permissions` API

Fixes #5659 