### PR TITLE
feat: Imported Firefox 140 schema data

### DIFF
--- a/src/schema/imported/cookies.json
+++ b/src/schema/imported/cookies.json
@@ -185,7 +185,7 @@
                 },
                 {
                   "description": "The cookie's same-site status.",
-                  "default": "no_restriction"
+                  "default": "unspecified"
                 }
               ]
             },
@@ -418,6 +418,7 @@
     "SameSiteStatus": {
       "type": "string",
       "enum": [
+        "unspecified",
         "no_restriction",
         "lax",
         "strict"

--- a/src/schema/imported/declarative_net_request.json
+++ b/src/schema/imported/declarative_net_request.json
@@ -571,7 +571,7 @@
   "types": {
     "ResourceType": {
       "type": "string",
-      "description": "How the requested resource will be used. Comparable to the webRequest.ResourceType type.",
+      "description": "How the requested resource will be used. Comparable to the webRequest.ResourceType type. object_subrequest is unsupported.",
       "enum": [
         "main_frame",
         "sub_frame",

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -761,12 +761,13 @@
           "enum": [
             "authenticationInfo",
             "bookmarksInfo",
-            "browsingHistory",
+            "browsingActivity",
             "financialAndPaymentInfo",
             "healthInfo",
             "locationInfo",
             "personalCommunications",
             "personallyIdentifyingInfo",
+            "searchTerms",
             "websiteActivity",
             "websiteContent"
           ]

--- a/src/schema/imported/tabGroups.json
+++ b/src/schema/imported/tabGroups.json
@@ -95,7 +95,6 @@
         {
           "type": "object",
           "name": "queryInfo",
-          "optional": true,
           "properties": {
             "collapsed": {
               "type": "boolean"

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -1412,7 +1412,6 @@
         "script",
         "image",
         "object",
-        "object_subrequest",
         "xmlhttprequest",
         "xslt",
         "ping",


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 139 API JSONSchema data:

- [Bug 1964754](https://bugzilla.mozilla.org/show_bug.cgi?id=1964754): deprecated support for object_subrequest in webrequest API resource types
- [Bug 1550032](https://bugzilla.mozilla.org/show_bug.cgi?id=1550032): added SameSite unspecified to cookies API SameSiteStatus
- [Bug 1965714](https://bugzilla.mozilla.org/show_bug.cgi?id=1965714): fixed JSONSchema definition for tabGroups.query's queryInfo parameter wrongly marked as optional
- [Bug 1964349](https://bugzilla.mozilla.org/show_bug.cgi?id=1964349): sync data collection permissions with the new taxonomy

Fixes #5694 