### PR TITLE
feat: Imported Firefox 145 and 146 schema data

### DIFF
--- a/src/schema/imported/geckoProfiler.json
+++ b/src/schema/imported/geckoProfiler.json
@@ -189,7 +189,8 @@
         "memory",
         "tracing",
         "sandbox",
-        "flows"
+        "flows",
+        "jssources"
       ]
     },
     "supports": {

--- a/src/schema/imported/management.json
+++ b/src/schema/imported/management.json
@@ -339,7 +339,7 @@
       ]
     },
     "ExtensionInstallType": {
-      "description": "How the extension was installed. One of<br><var>development</var>: The extension was loaded unpacked in developer mode,<br><var>normal</var>: The extension was installed normally via an .xpi file,<br><var>sideload</var>: The extension was installed by other software on the machine,<br><var>admin</var>: The extension was installed by policy,<br><var>other</var>: The extension was installed by other means.",
+      "description": "How the extension was installed.<dl><dt>development</dt><dd>The extension was loaded unpacked in developer mode,</dd><dt>normal</dt><dd>The extension was installed normally via an .xpi file</dd><dt>sideload</dt><dd>The extension was installed by other software on the machine</dd><dt>admin</dt><dd>The extension was installed by policy</dd><dt>other</dt><dd>The extension was installed by other means.</dd></dl>",
       "type": "string",
       "enum": [
         "development",

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -270,7 +270,7 @@
             "$ref": "#/types/Port"
           },
           {
-            "description": "Port through which messages can be sent and received. The port's $(ref:runtime.Port onDisconnect) event is fired if the extension/app does not exist. "
+            "description": "Port through which messages can be sent and received. The port's $(ref:runtime.Port.onDisconnect) event is fired if the extension/app does not exist. "
           }
         ]
       }

--- a/src/schema/imported/storage.json
+++ b/src/schema/imported/storage.json
@@ -29,7 +29,7 @@
         {
           "name": "areaName",
           "type": "string",
-          "description": "The name of the storage area (<code>\"sync\"</code>, <code>\"local\"</code> or <code>\"managed\"</code>) the changes are for."
+          "description": "The name of the storage area (<code>\"session\"</code>, <code>\"sync\"</code>, <code>\"local\"</code> or <code>\"managed\"</code>) the changes are for."
         }
       ]
     }


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 145 and 146 API JSONSchema data:

- [Bug 1991407](https://bugzilla.mozilla.org/show_bug.cgi?id=1991407): minor changes applied to a few description properties across `management.json`, `runtime.json` and `storage.json`, no addition or change of the actual APIs provided by these schema file

- [Bug 1979114](https://bugzilla.mozilla.org/show_bug.cgi?id=1979114): added "jssources" to the `geckoProfiler`'s `ProfilerFeature` type. No third party extensions actual use this API and so this schema change only matter for the GeckoProfiler integrated in Firefox itself.

No behaviors are expected to change due to this schema update, for the reasons described above.

Fixes #5851 