### PR TITLE
Use same default config from CLI and API.

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -266,3 +266,22 @@ export const SCHEMA_KEYWORDS = {
   // Non-standard JSONSchema keywords (defined and used by the Firefox and/or addons-linter).
   ...SCHEMA_KEYWORDS_CUSTOM,
 };
+
+// Default configuration values for the linter.
+export const DEFAULT_CONFIG = {
+  logLevel: 'fatal',
+  warningsAsErrors: false,
+  output: 'text',
+  metadata: false,
+  pretty: false,
+  stack: false,
+  boring: false,
+  enterprise: false,
+  privileged: false,
+  selfHosted: false,
+  enableBackgroundServiceWorker: false,
+  minManifestVersion: 2,
+  maxManifestVersion: 3,
+  disableXpiAutoclose: false,
+  enableDataCollectionPermissions: true,
+};

--- a/src/linter.js
+++ b/src/linter.js
@@ -35,11 +35,11 @@ import Dispensary from 'dispensary';
 
 export default class Linter {
   constructor(config) {
-    this.config = config;
-    [this.packagePath] = config._;
+    this.config = { ...constants.DEFAULT_CONFIG, ...config };
+    [this.packagePath] = this.config._;
     this.io = null;
     this.chalk = new chalk.Instance({ enabled: !this.config.boring });
-    this.collector = new Collector(config);
+    this.collector = new Collector(this.config);
     this.addonMetadata = null;
     this.shouldScanFile = this.shouldScanFile.bind(this);
   }

--- a/src/yargs-options.js
+++ b/src/yargs-options.js
@@ -1,75 +1,77 @@
+import { DEFAULT_CONFIG } from './const';
+
 const options = {
   'log-level': {
     describe: 'The log-level to generate',
     type: 'string',
-    default: 'fatal',
+    default: DEFAULT_CONFIG.logLevel,
     choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
   },
   'warnings-as-errors': {
     describe: 'Treat warnings as errors',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.warningsAsErrors,
   },
   output: {
     alias: 'o',
     describe: 'The type of output to generate',
     type: 'string',
-    default: 'text',
+    default: DEFAULT_CONFIG.output,
     choices: ['json', 'text'],
   },
   metadata: {
     describe: 'Output only metadata as JSON',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.metadata,
   },
   pretty: {
     describe: 'Prettify JSON output',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.pretty,
   },
   stack: {
     describe: 'Show stacktraces when errors are thrown',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.stack,
   },
   boring: {
     describe: 'Disable colorful shell output',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.boring,
   },
   enterprise: {
     describe:
       'Treat the input file (or directory) as an enterprise extension (implies --self-hosted)',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.enterprise,
   },
   privileged: {
     describe: 'Treat the input file (or directory) as a privileged extension',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.privileged,
   },
   'self-hosted': {
     describe: 'Disable messages related to hosting on addons.mozilla.org',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.selfHosted,
   },
   'enable-background-service-worker': {
     describe: 'Enable MV3 background service worker support',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.enableBackgroundServiceWorker,
   },
   'min-manifest-version': {
     describe:
       'Set a custom minimum allowed value for the manifest_version property',
     type: 'number',
-    default: 2,
+    default: DEFAULT_CONFIG.minManifestVersion,
     requiresArg: true,
   },
   'max-manifest-version': {
     describe:
       'Set a custom maximum allowed value for the manifest_version property',
     type: 'number',
-    default: 3,
+    default: DEFAULT_CONFIG.maxManifestVersion,
     requiresArg: true,
   },
   'disable-linter-rules': {
@@ -80,12 +82,12 @@ const options = {
   'disable-xpi-autoclose': {
     describe: 'Disable the auto-close feature when linting XPI files',
     type: 'boolean',
-    default: false,
+    default: DEFAULT_CONFIG.disableXpiAutoclose,
   },
   'enable-data-collection-permissions': {
     describe: 'Enable data collection permissions support',
     type: 'boolean',
-    default: true,
+    default: DEFAULT_CONFIG.enableDataCollectionPermissions,
   },
 };
 


### PR DESCRIPTION
Fixes #5845

- Create an object containing the default values.
- Use this object in the CLI options.
- Use this object in the Linter instantiation (in case addons-linter is used by the API).