### PR TITLE
feat: Imported Firefox 148 schema data

### DIFF
--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -11,8 +11,7 @@
         "manifest_version": {
           "type": "integer",
           "minimum": 2,
-          "maximum": 3,
-          "postprocess": "manifestVersionCheck"
+          "maximum": 3
         },
         "applications": {
           "allOf": [


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 148.0b5:

- [Bug 1804921](https://bugzilla.mozilla.org/show_bug.cgi?id=1804921): removed `postprocess` property from the `manifest_version` manifest property schema definition (which the addons-linter isn't defining nor using, and so this schema change should not trigger any change in behavior on the addons-linter side)

No behaviors are expected to change due to this schema update, for the reasons described above.

Fixes #5903 