### PR TITLE
Don't break when non-integer manifest versions are specified

### DIFF
--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -369,6 +369,27 @@ describe('ManifestJSONParser', () => {
     expect(manifestJSONParser.isValid).toEqual(true);
   });
 
+  it('emits an error when a non-integer manifest version is set', () => {
+    const addonLinter = new Linter({ _: ['bar'] });
+    const json = validManifestJSON({ manifest_version: 2.1 });
+    const manifestJSONParser = new ManifestJSONParser(
+      json,
+      addonLinter.collector
+    );
+
+    expect(manifestJSONParser.isValid).toEqual(false);
+    expect(manifestJSONParser.collector.errors).toEqual([
+      expect.objectContaining({
+        code: 'MANIFEST_FIELD_INVALID',
+        description:
+          'See https://mzl.la/1ZOhoEN (MDN Docs) for more information.',
+        file: 'manifest.json',
+        instancePath: '/manifest_version',
+        message: '"/manifest_version" must be integer',
+      }),
+    ]);
+  });
+
   describe('browser_style', () => {
     function parseManifest(manifestVersion, manifestKey, browserStyleValue) {
       const manifest = {


### PR DESCRIPTION
Fixes #5910

---

The reason why everything breaks miserably is because `2.1` is higher
than our current min version (`2`) and lower than our max version (`3`).
This breaks assumptions that a manifest version will either be `2` or
`3`, or `<= 2` or `>= 3`, which doesn't leave much room for a manifest
version between `2` and `3`.

The easiest fix for now seems to be catching a non-integer value and
not call the rest of the schema validation logic (which depends on this
value).

That's what is proposed in this patch.