### PR TITLE
Add a test case to verify that with attributes are supported

### DIFF
--- a/tests/unit/scanners/test.javascript.js
+++ b/tests/unit/scanners/test.javascript.js
@@ -183,6 +183,17 @@ describe('JavaScript Scanner', () => {
     }
   );
 
+  it('should support the "with" import attributes', async () => {
+    const code = `(async () => {
+      const data = await import("./module.json", { with: { type: "json" } });
+    })();`;
+
+    const jsScanner = new JavaScriptScanner(code, 'code.js');
+
+    const { linterMessages } = await jsScanner.scan();
+    expect(linterMessages).toEqual([]);
+  });
+
   it('should support numeric separators', async () => {
     const code = 'const num = 1_0;';
 


### PR DESCRIPTION
Closes https://github.com/mozilla/addons-linter/issues/5896

---

Thanks to https://github.com/mozilla/addons-linter/commit/23d910400830cb6f9496ce83e8c43140f9f38159, we support the `with` attributes. This PR adds a test case for it.