### PR TITLE
feat: Imported Firefox 153.0b2 schema data

### DIFF
--- a/src/schema/imported/contextual_identities.json
+++ b/src/schema/imported/contextual_identities.json
@@ -38,6 +38,76 @@
       ]
     },
     {
+      "name": "getSupportedColors",
+      "type": "function",
+      "description": "Retrieves the list of colors supported by contextual identities.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "colors",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "color": {
+                    "type": "string",
+                    "description": "The color name, as accepted by the color property of create and update."
+                  },
+                  "colorCode": {
+                    "type": "string",
+                    "description": "The color hash for this color name."
+                  }
+                },
+                "required": [
+                  "color",
+                  "colorCode"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "getSupportedIcons",
+      "type": "function",
+      "description": "Retrieves the list of icons supported by contextual identities.",
+      "async": "callback",
+      "parameters": [
+        {
+          "name": "callback",
+          "type": "function",
+          "parameters": [
+            {
+              "name": "icons",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "icon": {
+                    "type": "string",
+                    "description": "The icon name, as accepted by the icon property of create and update."
+                  },
+                  "iconUrl": {
+                    "type": "string",
+                    "description": "The icon url for this icon name."
+                  }
+                },
+                "required": [
+                  "icon",
+                  "iconUrl"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "create",
       "type": "function",
       "description": "Creates a contextual identity with the given data.",

--- a/src/schema/imported/index.js
+++ b/src/schema/imported/index.js
@@ -42,6 +42,7 @@ import permissions from './permissions.json';
 import pkcs11 from './pkcs11.json';
 import privacy from './privacy.json';
 import proxy from './proxy.json';
+import publicSuffix from './public_suffix.json';
 import runtime from './runtime.json';
 import scripting from './scripting.json';
 import search from './search.json';
@@ -104,6 +105,7 @@ export default [
   pkcs11,
   privacy,
   proxy,
+  publicSuffix,
   runtime,
   scripting,
   search,

--- a/src/schema/imported/manifest.json
+++ b/src/schema/imported/manifest.json
@@ -635,6 +635,9 @@
           "$ref": "menus#/definitions/OptionalPermissionNoPrompt"
         },
         {
+          "$ref": "publicSuffix#/definitions/OptionalPermissionNoPrompt"
+        },
+        {
           "$ref": "scripting#/definitions/OptionalPermissionNoPrompt"
         },
         {

--- a/src/schema/imported/proxy.json
+++ b/src/schema/imported/proxy.json
@@ -45,6 +45,14 @@
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
             },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "incognito": {
               "type": "boolean",
               "description": "True for private browsing requests."

--- a/src/schema/imported/public_suffix.json
+++ b/src/schema/imported/public_suffix.json
@@ -1,0 +1,118 @@
+{
+  "$id": "publicSuffix",
+  "description": "API to obtain the registrable domain / eTLD+1 from a domain name.",
+  "permissions": [
+    "publicSuffix"
+  ],
+  "functions": [
+    {
+      "name": "isKnownSuffix",
+      "type": "function",
+      "description": "Checks if the given hostname is itself a known public suffix / eTLD (i.e. in the PSL).",
+      "parameters": [
+        {
+          "name": "hostname",
+          "type": "string"
+        }
+      ],
+      "returns": {
+        "type": "boolean",
+        "description": "True if the given hostname is itself a known eTLD."
+      }
+    },
+    {
+      "name": "getKnownSuffix",
+      "type": "function",
+      "description": "Gets the known public suffix / eTLD (i.e. in the PSL), if any, of a given hostname.",
+      "parameters": [
+        {
+          "name": "hostname",
+          "type": "string"
+        }
+      ],
+      "returns": {
+        "type": "string",
+        "optional": true,
+        "description": "The known eTLD of the given hostname, or null if no such known eTLD exists."
+      }
+    },
+    {
+      "name": "getDomain",
+      "type": "function",
+      "description": "Gets the eTLD+1 of a given hostname, or a variant such as IP address if the options allow.",
+      "parameters": [
+        {
+          "name": "hostname",
+          "type": "string"
+        },
+        {
+          "name": "options",
+          "type": "object",
+          "properties": {
+            "encoding": {
+              "allOf": [
+                {
+                  "$ref": "#/types/DomainEncoding"
+                },
+                {
+                  "default": "punycode",
+                  "description": "Determines how the returned domain should be encoded."
+                }
+              ]
+            },
+            "allowIPAddress": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, and the input hostname is an IP address, then this is returned as-is."
+            },
+            "allowPlainSuffix": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, and the input hostname is itself a known eTLD (without a preceding label) then this is returned as-is."
+            },
+            "allowUnknownSuffix": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, and the input hostname lacks a known eTLD, and is neither itself a known eTLD nor an IP address, then the returned domain consists of the penultimate two domain labels of the input."
+            }
+          },
+          "optional": true,
+          "default": {}
+        }
+      ],
+      "returns": {
+        "type": "string",
+        "optional": true,
+        "description": "The eTLD+1 (or a variant such as IP address if allowed) of the given hostname, or null if no such eTLD+1 (variant) exists."
+      }
+    }
+  ],
+  "definitions": {
+    "OptionalPermissionNoPrompt": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "publicSuffix"
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "publicSuffix#/definitions/OptionalPermissionNoPrompt": {
+      "namespace": "manifest",
+      "type": "OptionalPermissionNoPrompt"
+    }
+  },
+  "types": {
+    "DomainEncoding": {
+      "type": "string",
+      "description": "The available encoding types for the returned domain.",
+      "enum": [
+        "punycode",
+        "display"
+      ]
+    }
+  }
+}

--- a/src/schema/imported/runtime.json
+++ b/src/schema/imported/runtime.json
@@ -138,6 +138,26 @@
       }
     },
     {
+      "name": "getDocumentId",
+      "type": "function",
+      "allowedContexts": [
+        "content",
+        "devtools"
+      ],
+      "description": "Get the documentId of any window global or frame element. Throws for invalid targets, such as unloaded frames.",
+      "parameters": [
+        {
+          "name": "target",
+          "description": "A WindowProxy or a browsing context container Element (iframe, frame, embed, or object) for the target frame."
+        }
+      ],
+      "allowCrossOriginArguments": true,
+      "returns": {
+        "type": "string",
+        "description": "The documentId of the target document."
+      }
+    },
+    {
       "name": "getFrameId",
       "type": "function",
       "allowedContexts": [
@@ -148,7 +168,7 @@
       "parameters": [
         {
           "name": "target",
-          "description": "A WindowProxy or a Browsing Context container element (IFrame, Frame, Embed, Object) for the target frame."
+          "description": "A WindowProxy or a browsing context container Element (iframe, frame, embed, or object) for the target frame."
         }
       ],
       "allowCrossOriginArguments": true,
@@ -876,7 +896,6 @@
         },
         "documentId": {
           "type": "string",
-          "unsupported": true,
           "description": "An UUID for the document associated with this context, or undefined if it is not hosted in a document"
         },
         "documentOrigin": {
@@ -977,6 +996,10 @@
         "frameId": {
           "type": "integer",
           "description": "The $(topic:frame_ids)[frame] that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when <code>tab</code> is set."
+        },
+        "documentId": {
+          "type": "string",
+          "description": "A UUID of the document that opened the connection."
         },
         "id": {
           "type": "string",

--- a/src/schema/imported/scripting.json
+++ b/src/schema/imported/scripting.json
@@ -272,6 +272,10 @@
       "type": "object",
       "description": "Result of a script injection.",
       "properties": {
+        "documentId": {
+          "type": "string",
+          "description": "The document associated with the injection."
+        },
         "frameId": {
           "type": "integer",
           "description": "The frame ID associated with the injection."
@@ -284,6 +288,7 @@
         }
       },
       "required": [
+        "documentId",
         "frameId"
       ]
     },
@@ -304,6 +309,13 @@
         "tabId": {
           "type": "number",
           "description": "The ID of the tab into which to inject."
+        },
+        "documentIds": {
+          "type": "array",
+          "description": "The IDs of specific documents to inject into. This must not be set if <code>frameIds</code> or <code>allFrames</code> is set.",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/src/schema/imported/tabs.json
+++ b/src/schema/imported/tabs.json
@@ -88,6 +88,10 @@
               "type": "integer",
               "minimum": 0,
               "description": "Open a port to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "Open a port to a specific document identified by <code>documentId</code> instead of all frames in the tab."
             }
           },
           "optional": true
@@ -126,6 +130,10 @@
               "type": "integer",
               "minimum": 0,
               "description": "Send a message to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "Send a message to a specific document identified by <code>documentId</code> instead of all frames in the tab."
             }
           },
           "optional": true

--- a/src/schema/imported/theme.json
+++ b/src/schema/imported/theme.json
@@ -180,6 +180,99 @@
         }
       }
     },
+    "ThemeCSSGradient": {
+      "description": "A CSS gradient that can be used as a theme background, in addition to image assets. The single property name selects the gradient function, and its value holds the gradient's arguments, e.g. `{ \"linear-gradient\": \"to bottom, #FF6BBA, #FFC999\" }`.",
+      "anyOf": [
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "linear-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "linear-gradient"
+          ]
+        },
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "radial-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "radial-gradient"
+          ]
+        },
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "conic-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "conic-gradient"
+          ]
+        },
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "repeating-linear-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "repeating-linear-gradient"
+          ]
+        },
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "repeating-radial-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "repeating-radial-gradient"
+          ]
+        },
+        {
+          "type": "object",
+          "postprocess": "validCSSGradient",
+          "properties": {
+            "repeating-conic-gradient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "repeating-conic-gradient"
+          ]
+        }
+      ]
+    },
+    "ThemeBackground": {
+      "anyOf": [
+        {
+          "$ref": "manifest#/types/ImageDataOrExtensionURL"
+        },
+        {
+          "$ref": "#/types/ThemeCSSGradient"
+        }
+      ]
+    },
     "ThemeType": {
       "type": "object",
       "properties": {
@@ -189,7 +282,7 @@
             "additional_backgrounds": {
               "type": "array",
               "items": {
-                "$ref": "manifest#/types/ImageDataOrExtensionURL"
+                "$ref": "#/types/ThemeBackground"
               },
               "maxItems": 15
             },
@@ -204,7 +297,7 @@
               ]
             },
             "theme_frame": {
-              "$ref": "manifest#/types/ImageDataOrExtensionURL"
+              "$ref": "#/types/ThemeBackground"
             }
           },
           "additionalProperties": {
@@ -409,6 +502,13 @@
                   "repeat-x",
                   "repeat-y"
                 ]
+              },
+              "maxItems": 15
+            },
+            "additional_backgrounds_size": {
+              "type": "array",
+              "items": {
+                "type": "string"
               },
               "maxItems": 15
             },

--- a/src/schema/imported/userScripts.json
+++ b/src/schema/imported/userScripts.json
@@ -209,6 +209,40 @@
           ]
         }
       ]
+    },
+    {
+      "name": "execute",
+      "min_manifest_version": 3,
+      "type": "function",
+      "description": "Executes one or more ephemeral user scripts into a specific tab.",
+      "async": "callback",
+      "parameters": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/types/UserScriptInjection"
+            },
+            {
+              "name": "injection",
+              "description": "The details of the user script which to inject."
+            }
+          ]
+        },
+        {
+          "name": "callback",
+          "type": "function",
+          "description": "Invoked upon completion of the injection. The resulting array contains the result of execution for each frame where the injection succeeded.",
+          "parameters": [
+            {
+              "name": "results",
+              "type": "array",
+              "items": {
+                "$ref": "#/types/InjectionResult"
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
   "definitions": {
@@ -486,6 +520,109 @@
           "description": "Whether the runtime.sendMessage and runtime.connect methods are exposed. Defaults to not exposing these messaging APIs."
         }
       }
+    },
+    "UserScriptInjection": {
+      "min_manifest_version": 3,
+      "type": "object",
+      "description": "Details of a user script injection",
+      "properties": {
+        "injectImmediately": {
+          "type": "boolean",
+          "description": "Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target."
+        },
+        "js": {
+          "type": "array",
+          "description": "The list of ScriptSource objects defining sources of scripts to be injected into matching pages.",
+          "items": {
+            "$ref": "#/types/ScriptSource"
+          }
+        },
+        "target": {
+          "allOf": [
+            {
+              "$ref": "#/types/InjectionTarget"
+            },
+            {
+              "description": "Details specifying the target into which to inject the script."
+            }
+          ]
+        },
+        "world": {
+          "allOf": [
+            {
+              "$ref": "#/types/ExecutionWorld"
+            },
+            {
+              "description": "The JavaScript \"world\" to run the script in. The default is `USER_SCRIPT`."
+            }
+          ]
+        },
+        "worldId": {
+          "type": "string",
+          "description": "A specific user script world ID to execute in. Only valid if `world` is omitted or is `USER_SCRIPT`. If `worldId` is omitted, the default value is an empty string (\"\") and the script will execute in the default world."
+        }
+      },
+      "required": [
+        "js",
+        "target"
+      ]
+    },
+    "InjectionTarget": {
+      "min_manifest_version": 3,
+      "type": "object",
+      "description": "Details specifying the target into which to inject the script.",
+      "properties": {
+        "allFrames": {
+          "type": "boolean",
+          "description": "Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` is specified."
+        },
+        "documentIds": {
+          "type": "array",
+          "description": "The IDs of specific documentIds to inject into. This must not be set if frameIds is set.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "frameIds": {
+          "type": "array",
+          "description": "The IDs of specific frames to inject into.",
+          "items": {
+            "type": "number"
+          }
+        },
+        "tabId": {
+          "type": "number",
+          "description": "The ID of the tab into which to inject."
+        }
+      },
+      "required": [
+        "tabId"
+      ]
+    },
+    "InjectionResult": {
+      "min_manifest_version": 3,
+      "type": "object",
+      "description": "Result of a user script injection.",
+      "properties": {
+        "documentId": {
+          "type": "string",
+          "description": "Document ID associated with the injection."
+        },
+        "frameId": {
+          "type": "integer",
+          "description": "Frame ID associated with the injection."
+        },
+        "result": {
+          "description": "Result of the script injection if any. This is mutually exclusive with error."
+        },
+        "error": {
+          "description": "Error message if any. This is mutually exclusive with result. The value is typically an (Error) object with a message property, but could be any value (including primitives and undefined) if the user script threw or rejected with such a value."
+        }
+      },
+      "required": [
+        "documentId",
+        "frameId"
+      ]
     }
   },
   "allowedContexts": [

--- a/src/schema/imported/web_navigation.json
+++ b/src/schema/imported/web_navigation.json
@@ -8,7 +8,7 @@
     {
       "name": "getFrame",
       "type": "function",
-      "description": "Retrieves information about the given frame. A frame refers to an &lt;iframe&gt; or a &lt;frame&gt; of a web page and is identified by a tab ID and a frame ID.",
+      "description": "Retrieves information about the given frame. A frame refers to an &lt;iframe&gt; or a &lt;frame&gt; of a web page and is identified by a tab ID and a frame ID, or by its document ID.",
       "async": "callback",
       "parameters": [
         {
@@ -19,7 +19,7 @@
             "tabId": {
               "type": "integer",
               "minimum": 0,
-              "description": "The ID of the tab in which the frame is."
+              "description": "The ID of the tab in which the frame is. Must be specified if documentId is not set."
             },
             "processId": {
               "type": "integer",
@@ -28,13 +28,13 @@
             "frameId": {
               "type": "integer",
               "minimum": 0,
-              "description": "The ID of the frame in the given tab."
+              "description": "The ID of the frame in the given tab. Must be specified if documentId is not set."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document. If provided, tabId and frameId are optional. If all are provided, the frame is only returned if all properties match."
             }
-          },
-          "required": [
-            "tabId",
-            "frameId"
-          ]
+          }
         },
         {
           "type": "function",
@@ -65,13 +65,22 @@
                 "parentFrameId": {
                   "type": "integer",
                   "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists."
+                },
+                "documentId": {
+                  "type": "string",
+                  "description": "A UUID of the document loaded."
+                },
+                "parentDocumentId": {
+                  "type": "string",
+                  "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
                 }
               },
               "required": [
                 "url",
                 "tabId",
                 "frameId",
-                "parentFrameId"
+                "parentFrameId",
+                "documentId"
               ]
             }
           ]
@@ -132,6 +141,14 @@
                     "type": "integer",
                     "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists."
                   },
+                  "documentId": {
+                    "type": "string",
+                    "description": "A UUID of the document loaded."
+                  },
+                  "parentDocumentId": {
+                    "type": "string",
+                    "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+                  },
                   "url": {
                     "type": "string",
                     "description": "The URL currently associated with this frame."
@@ -142,6 +159,7 @@
                   "tabId",
                   "frameId",
                   "parentFrameId",
+                  "documentId",
                   "url"
                 ]
               }
@@ -180,6 +198,10 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "timeStamp": {
               "type": "number",
@@ -236,6 +258,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "transitionType": {
               "allOf": [
                 {
@@ -263,6 +293,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "transitionType",
             "transitionQualifiers",
             "timeStamp"
@@ -309,6 +340,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "timeStamp": {
               "type": "number",
               "description": "The time when the page's DOM was fully constructed, in milliseconds since the epoch."
@@ -319,6 +358,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "timeStamp"
           ]
         }
@@ -363,6 +403,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "timeStamp": {
               "type": "number",
               "description": "The time when the document finished loading, in milliseconds since the epoch."
@@ -373,6 +421,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "timeStamp"
           ]
         }
@@ -417,6 +466,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "error": {
               "unsupported": true,
               "type": "string",
@@ -432,6 +489,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "error",
             "timeStamp"
           ]
@@ -536,6 +594,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "transitionType": {
               "allOf": [
                 {
@@ -563,6 +629,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "transitionType",
             "transitionQualifiers",
             "timeStamp"
@@ -639,6 +706,14 @@
               "type": "integer",
               "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab."
             },
+            "documentId": {
+              "type": "string",
+              "description": "A UUID of the document loaded."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "A UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "transitionType": {
               "allOf": [
                 {
@@ -666,6 +741,7 @@
             "url",
             "processId",
             "frameId",
+            "documentId",
             "transitionType",
             "transitionQualifiers",
             "timeStamp"

--- a/src/schema/imported/web_request.json
+++ b/src/schema/imported/web_request.json
@@ -101,6 +101,14 @@
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
             },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "incognito": {
               "type": "boolean",
               "description": "True for private browsing requests."
@@ -253,6 +261,14 @@
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
             },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "incognito": {
               "type": "boolean",
               "description": "True for private browsing requests."
@@ -387,6 +403,14 @@
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
             },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "incognito": {
               "type": "boolean",
               "description": "True for private browsing requests."
@@ -509,6 +533,14 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "incognito": {
               "type": "boolean",
@@ -653,6 +685,14 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "incognito": {
               "type": "boolean",
@@ -847,6 +887,14 @@
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
             },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
+            },
             "incognito": {
               "type": "boolean",
               "description": "True for private browsing requests."
@@ -988,6 +1036,14 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "incognito": {
               "type": "boolean",
@@ -1135,6 +1191,14 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "incognito": {
               "type": "boolean",
@@ -1288,6 +1352,14 @@
             "parentFrameId": {
               "type": "integer",
               "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists."
+            },
+            "documentId": {
+              "type": "string",
+              "description": "The UUID of the document making the request. This value is not present if the request is a navigation of a frame."
+            },
+            "parentDocumentId": {
+              "type": "string",
+              "description": "The UUID of the parent document owning this frame. This is not set if there is no parent."
             },
             "incognito": {
               "type": "boolean",


### PR DESCRIPTION
The updated schema data includes the following changes from Firefox 153.0b2:

- **[Bug 2044712](https://bugzilla.mozilla.org/show_bug.cgi?id=2044712)**: Added to the `contextualIdentities` API the new `getSupportedColors()` and `getSupportedIcons()` API methods
- **[Bug 1315558](https://bugzilla.mozilla.org/show_bug.cgi?id=1315558)**: Added new `browser.publicSuffix` API and a new corresponding `"publicSuffix"` optional permission
- **[Bug 1891478](https://bugzilla.mozilla.org/show_bug.cgi?id=1891478)**: Added `documentId` support across multiple APIs (`runtime`, `proxy`, `web_request`, and `web_navigation`, `scripting.InjectionResult` and `tabs` API namespaces)
- **[Bug 2036647](https://bugzilla.mozilla.org/show_bug.cgi?id=2036647)**: Added `ThemeCSSGradient` and `ThemeBackground` types to `theme`, as part of allowing `additional_backgrounds` to accept CSS gradients in addition to image URLs, and added a new `additional_backgrounds_size` theme property
- **[Bug 1930776](https://bugzilla.mozilla.org/show_bug.cgi?id=1930776)**: Added `userScripts.execute()` API method

Fixes #6074