### PR TITLE
fix: Introduce additional validation on the static themes CSS gradients properties

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -641,6 +641,11 @@
 <td>Theme CSS gradient must have valid parameters</td>
 </tr>
 <tr>
+<td><code>MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED</code></td>
+<td>error</td>
+<td>Theme CSS gradient function must be one of the supported gradient functions</td>
+</tr>
+<tr>
 <td><code>MANIFEST_THEME_IMAGE_MIME_MISMATCH</code></td>
 <td>warning</td>
 <td>Theme image file extension should match its mime type</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -641,6 +641,11 @@
 <td>Theme CSS gradient must have valid parameters</td>
 </tr>
 <tr>
+<td><code>MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION</code></td>
+<td>error</td>
+<td>Theme CSS gradients require strict_min_version &gt;= 153</td>
+</tr>
+<tr>
 <td><code>MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED</code></td>
 <td>error</td>
 <td>Theme CSS gradient function must be one of the supported gradient functions</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -636,6 +636,11 @@
 </thead>
 <tbody>
 <tr>
+<td><code>MANIFEST_THEME_CSS_GRADIENT_INVALID</code></td>
+<td>error</td>
+<td>Theme CSS gradient must have valid parameters</td>
+</tr>
+<tr>
 <td><code>MANIFEST_THEME_IMAGE_MIME_MISMATCH</code></td>
 <td>warning</td>
 <td>Theme image file extension should match its mime type</td>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -145,11 +145,12 @@ Rules are sorted by severity.
 
 ### Static Theme / manifest.json
 
-| Message code                         | Severity | Description                                                 |
-| ------------------------------------ | -------- | ----------------------------------------------------------- |
-| `MANIFEST_THEME_IMAGE_MIME_MISMATCH` | warning  | Theme image file extension should match its mime type       |
-| `MANIFEST_THEME_IMAGE_NOT_FOUND`     | error    | Theme images must not be missing                            |
-| `MANIFEST_THEME_IMAGE_CORRUPTED`     | error    | Theme images must not be corrupted                          |
-| `MANIFEST_THEME_IMAGE_WRONG_EXT`     | error    | Theme images must have one of the supported file extensions |
-| `MANIFEST_THEME_IMAGE_WRONG_MIME`    | error    | Theme images mime type must be a supported format           |
-| `MANIFEST_THEME_LWT_ALIAS`           | error    | Theme LWT aliases are deprecated                            |
+| Message code                          | Severity | Description                                                 |
+| ------------------------------------- | -------- | ----------------------------------------------------------- |
+| `MANIFEST_THEME_CSS_GRADIENT_INVALID` | error    | Theme CSS gradient must have valid parameters               |
+| `MANIFEST_THEME_IMAGE_MIME_MISMATCH`  | warning  | Theme image file extension should match its mime type       |
+| `MANIFEST_THEME_IMAGE_NOT_FOUND`      | error    | Theme images must not be missing                            |
+| `MANIFEST_THEME_IMAGE_CORRUPTED`      | error    | Theme images must not be corrupted                          |
+| `MANIFEST_THEME_IMAGE_WRONG_EXT`      | error    | Theme images must have one of the supported file extensions |
+| `MANIFEST_THEME_IMAGE_WRONG_MIME`     | error    | Theme images mime type must be a supported format           |
+| `MANIFEST_THEME_LWT_ALIAS`            | error    | Theme LWT aliases are deprecated                            |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -145,12 +145,13 @@ Rules are sorted by severity.
 
 ### Static Theme / manifest.json
 
-| Message code                          | Severity | Description                                                 |
-| ------------------------------------- | -------- | ----------------------------------------------------------- |
-| `MANIFEST_THEME_CSS_GRADIENT_INVALID` | error    | Theme CSS gradient must have valid parameters               |
-| `MANIFEST_THEME_IMAGE_MIME_MISMATCH`  | warning  | Theme image file extension should match its mime type       |
-| `MANIFEST_THEME_IMAGE_NOT_FOUND`      | error    | Theme images must not be missing                            |
-| `MANIFEST_THEME_IMAGE_CORRUPTED`      | error    | Theme images must not be corrupted                          |
-| `MANIFEST_THEME_IMAGE_WRONG_EXT`      | error    | Theme images must have one of the supported file extensions |
-| `MANIFEST_THEME_IMAGE_WRONG_MIME`     | error    | Theme images mime type must be a supported format           |
-| `MANIFEST_THEME_LWT_ALIAS`            | error    | Theme LWT aliases are deprecated                            |
+| Message code                              | Severity | Description                                                                 |
+| ----------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `MANIFEST_THEME_CSS_GRADIENT_INVALID`     | error    | Theme CSS gradient must have valid parameters                               |
+| `MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED` | error    | Theme CSS gradient function must be one of the supported gradient functions |
+| `MANIFEST_THEME_IMAGE_MIME_MISMATCH`      | warning  | Theme image file extension should match its mime type                       |
+| `MANIFEST_THEME_IMAGE_NOT_FOUND`          | error    | Theme images must not be missing                                            |
+| `MANIFEST_THEME_IMAGE_CORRUPTED`          | error    | Theme images must not be corrupted                                          |
+| `MANIFEST_THEME_IMAGE_WRONG_EXT`          | error    | Theme images must have one of the supported file extensions                 |
+| `MANIFEST_THEME_IMAGE_WRONG_MIME`         | error    | Theme images mime type must be a supported format                           |
+| `MANIFEST_THEME_LWT_ALIAS`                | error    | Theme LWT aliases are deprecated                                            |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -148,6 +148,7 @@ Rules are sorted by severity.
 | Message code                              | Severity | Description                                                                 |
 | ----------------------------------------- | -------- | --------------------------------------------------------------------------- |
 | `MANIFEST_THEME_CSS_GRADIENT_INVALID`     | error    | Theme CSS gradient must have valid parameters                               |
+| `MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION` | error    | Theme CSS gradients require strict_min_version >= 153                       |
 | `MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED` | error    | Theme CSS gradient function must be one of the supported gradient functions |
 | `MANIFEST_THEME_IMAGE_MIME_MISMATCH`      | warning  | Theme image file extension should match its mime type                       |
 | `MANIFEST_THEME_IMAGE_NOT_FOUND`          | error    | Theme images must not be missing                                            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cheerio": "1.2.0",
         "columnify": "1.6.0",
         "common-tags": "1.8.2",
+        "css-tree": "3.2.1",
         "deepmerge": "4.3.1",
         "eslint": "9.39.4",
         "eslint-plugin-no-unsanitized": "4.1.5",
@@ -5278,6 +5279,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -9250,6 +9264,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -11144,6 +11164,15 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cheerio": "1.2.0",
     "columnify": "1.6.0",
     "common-tags": "1.8.2",
+    "css-tree": "3.2.1",
     "deepmerge": "4.3.1",
     "eslint": "9.39.4",
     "eslint-plugin-no-unsanitized": "4.1.5",

--- a/src/const.js
+++ b/src/const.js
@@ -250,6 +250,7 @@ export const SCHEMA_KEYWORDS_CUSTOM = {
   // schema data as part of the schema data inmport and used by the linter to hook up
   // custom validation logic for privileged permissions.
   VALIDATE_PRIVILEGED_PERMISSIONS: 'validatePrivilegedPermissions',
+  VALIDATE_CSS_GRADIENT: 'validCSSGradient',
 };
 
 export const SCHEMA_KEYWORDS = {

--- a/src/const.js
+++ b/src/const.js
@@ -1,3 +1,5 @@
+import themeSchemaObject from 'schema/imported/theme';
+
 export const ESLINT_ERROR = 2;
 export const ESLINT_WARNING = 1;
 
@@ -149,6 +151,18 @@ export const FILE_EXTENSIONS_TO_MIME = {
 export const STATIC_THEME_IMAGE_MIMES = [
   ...new Set(Object.values(FILE_EXTENSIONS_TO_MIME)),
 ];
+
+export const SUPPORTED_CSS_GRADIENT_FUNCTIONS = new Set(
+  themeSchemaObject.types.ThemeCSSGradient.anyOf.map(
+    (variant) => Object.keys(variant.properties)[0]
+  )
+);
+
+// Matches only the instancePaths where ThemeBackground (and therefore
+// ThemeCSSGradient) is valid: additional_backgrounds array items and
+// theme_frame under theme or dark_theme.
+export const THEME_BACKGROUND_PATH_RE =
+  /^\/(theme|dark_theme)\/images\/(additional_backgrounds\/\d+|theme_frame)$/;
 
 // Mapping of "schema data paths" of the deprecated properties that we
 // issue warnings for.

--- a/src/const.js
+++ b/src/const.js
@@ -264,6 +264,8 @@ export const SCHEMA_KEYWORDS = {
   ...SCHEMA_KEYWORDS_CUSTOM,
 };
 
+export const CSS_GRADIENT_MIN_FIREFOX_VERSION = 153;
+
 // Default configuration values for the linter.
 export const DEFAULT_CONFIG = {
   logLevel: 'fatal',

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -534,10 +534,7 @@ export function manifestThemeImageMimeMismatch({ path, mime }) {
 
 export const MANIFEST_THEME_CSS_GRADIENT_INVALID =
   'MANIFEST_THEME_CSS_GRADIENT_INVALID';
-export function manifestThemeCSSGradientInvalid({
-  functionName,
-  params,
-}) {
+export function manifestThemeCSSGradientInvalid({ functionName, params }) {
   return {
     code: MANIFEST_THEME_CSS_GRADIENT_INVALID,
     message: i18n.sprintf(

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -559,7 +559,7 @@ export function manifestThemeCSSGradientFunctionUnsupported(functionName) {
       { functionName }
     ),
     description: i18n.sprintf(
-      i18n._(`"%(functionName)s" is not a supported CSS gradient function. 
+      i18n._(`"%(functionName)s" is not a supported CSS gradient function.
         Supported functions are: linear-gradient, radial-gradient, conic-gradient,
         repeating-linear-gradient, repeating-radial-gradient, repeating-conic-gradient`),
       { functionName }

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -549,6 +549,25 @@ export function manifestThemeCSSGradientInvalid({ gradientFn, gradientParams }) 
   };
 }
 
+export const MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED =
+  'MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED';
+export function manifestThemeCSSGradientFunctionUnsupported(gradientFn) {
+  return {
+    code: MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED,
+    message: i18n.sprintf(
+      i18n._('Theme CSS gradient function "%(gradientFn)s" is not supported'),
+      { gradientFn }
+    ),
+    description: i18n.sprintf(
+      i18n._(
+        '"%(gradientFn)s" is not a supported CSS gradient function. Supported functions are: linear-gradient, radial-gradient, conic-gradient, repeating-linear-gradient, repeating-radial-gradient, repeating-conic-gradient'
+      ),
+      { gradientFn }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
 export const PROP_NAME_MISSING = manifestPropMissing('name');
 
 export const NO_MESSAGES_FILE = {

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -532,6 +532,23 @@ export function manifestThemeImageMimeMismatch({ path, mime }) {
   };
 }
 
+export const MANIFEST_THEME_CSS_GRADIENT_INVALID =
+  'MANIFEST_THEME_CSS_GRADIENT_INVALID';
+export function manifestThemeCSSGradientInvalid({ gradientFn, gradientParams }) {
+  return {
+    code: MANIFEST_THEME_CSS_GRADIENT_INVALID,
+    message: i18n.sprintf(
+      i18n._('Theme CSS gradient "%(gradientFn)s" has invalid parameters'),
+      { gradientFn }
+    ),
+    description: i18n.sprintf(
+      i18n._('"%(gradientFn)s": "%(gradientParams)s" is not valid CSS'),
+      { gradientFn, gradientParams }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
 export const PROP_NAME_MISSING = manifestPropMissing('name');
 
 export const NO_MESSAGES_FILE = {

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -534,7 +534,10 @@ export function manifestThemeImageMimeMismatch({ path, mime }) {
 
 export const MANIFEST_THEME_CSS_GRADIENT_INVALID =
   'MANIFEST_THEME_CSS_GRADIENT_INVALID';
-export function manifestThemeCSSGradientInvalid({ gradientFn, gradientParams }) {
+export function manifestThemeCSSGradientInvalid({
+  gradientFn,
+  gradientParams,
+}) {
   return {
     code: MANIFEST_THEME_CSS_GRADIENT_INVALID,
     message: i18n.sprintf(

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -535,18 +535,18 @@ export function manifestThemeImageMimeMismatch({ path, mime }) {
 export const MANIFEST_THEME_CSS_GRADIENT_INVALID =
   'MANIFEST_THEME_CSS_GRADIENT_INVALID';
 export function manifestThemeCSSGradientInvalid({
-  gradientFn,
-  gradientParams,
+  functionName,
+  params,
 }) {
   return {
     code: MANIFEST_THEME_CSS_GRADIENT_INVALID,
     message: i18n.sprintf(
-      i18n._('Theme CSS gradient "%(gradientFn)s" has invalid parameters'),
-      { gradientFn }
+      i18n._('Theme CSS gradient "%(functionName)s" has invalid parameters'),
+      { functionName }
     ),
     description: i18n.sprintf(
-      i18n._('"%(gradientFn)s": "%(gradientParams)s" is not valid CSS'),
-      { gradientFn, gradientParams }
+      i18n._('"%(functionName)s": "%(params)s" is not valid CSS'),
+      { functionName, params }
     ),
     file: MANIFEST_JSON,
   };
@@ -554,18 +554,18 @@ export function manifestThemeCSSGradientInvalid({
 
 export const MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED =
   'MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED';
-export function manifestThemeCSSGradientFunctionUnsupported(gradientFn) {
+export function manifestThemeCSSGradientFunctionUnsupported(functionName) {
   return {
     code: MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED,
     message: i18n.sprintf(
-      i18n._('Theme CSS gradient function "%(gradientFn)s" is not supported'),
-      { gradientFn }
+      i18n._('Theme CSS gradient function "%(functionName)s" is not supported'),
+      { functionName }
     ),
     description: i18n.sprintf(
-      i18n._(
-        '"%(gradientFn)s" is not a supported CSS gradient function. Supported functions are: linear-gradient, radial-gradient, conic-gradient, repeating-linear-gradient, repeating-radial-gradient, repeating-conic-gradient'
-      ),
-      { gradientFn }
+      i18n._(`"%(functionName)s" is not a supported CSS gradient function. 
+        Supported functions are: linear-gradient, radial-gradient, conic-gradient,
+        repeating-linear-gradient, repeating-radial-gradient, repeating-conic-gradient`),
+      { functionName }
     ),
     file: MANIFEST_JSON,
   };
@@ -577,15 +577,14 @@ export function manifestThemeCSSGradientMinVersion(minVersion) {
   return {
     code: MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION,
     message: i18n.sprintf(
-      i18n._(
-        'Theme CSS gradients require "strict_min_version" to be set to "%(minVersion)s" or above'
-      ),
+      i18n._(`Theme CSS gradients require "strict_min_version" to be set to "%(minVersion)s"
+        or above`),
       { minVersion }
     ),
     description: i18n.sprintf(
-      i18n._(
-        'CSS gradients in theme images are only supported in Firefox %(minVersion)s and above. Please set "browser_specific_settings.gecko.strict_min_version" to "%(minVersion)s" or higher in your manifest.json.'
-      ),
+      i18n._(`CSS gradients in theme images are only supported in Firefox %(minVersion)s and
+        above. Please set "browser_specific_settings.gecko.strict_min_version" to "%(minVersion)s"
+        or higher in your manifest.json`),
       { minVersion }
     ),
     file: MANIFEST_JSON,

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -568,6 +568,27 @@ export function manifestThemeCSSGradientFunctionUnsupported(gradientFn) {
   };
 }
 
+export const MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION =
+  'MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION';
+export function manifestThemeCSSGradientMinVersion(minVersion) {
+  return {
+    code: MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION,
+    message: i18n.sprintf(
+      i18n._(
+        'Theme CSS gradients require "strict_min_version" to be set to "%(minVersion)s" or above'
+      ),
+      { minVersion }
+    ),
+    description: i18n.sprintf(
+      i18n._(
+        'CSS gradients in theme images are only supported in Firefox %(minVersion)s and above. Please set "browser_specific_settings.gecko.strict_min_version" to "%(minVersion)s" or higher in your manifest.json.'
+      ),
+      { minVersion }
+    ),
+    file: MANIFEST_JSON,
+  };
+}
+
 export const PROP_NAME_MISSING = manifestPropMissing('name');
 
 export const NO_MESSAGES_FILE = {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -90,10 +90,15 @@ function getNormalizedExtension(_path) {
 // ThemeBackground position, `data` looks like a ThemeCSSGradient object, and
 // its key is not one of the supported gradient functions; returns null otherwise.
 function getUnknownCSSGradientFn(instancePath, data) {
-  if (!THEME_BACKGROUND_PATH_RE.test(instancePath)) {
-    return null;
-  }
-  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+  if (
+    // instancePath isn't one CSS gradients are supported (static themes
+    // additional_backgrounds or theme_frame properties).
+    !THEME_BACKGROUND_PATH_RE.test(instancePath) ||
+    // data isn't in the expected "JS object literal" form.
+    data === null ||
+    typeof data !== 'object' ||
+    Array.isArray(data)
+  ) {
     return null;
   }
   const keys = Object.keys(data);

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -15,6 +15,7 @@ import {
   validateLangPack,
   validateStaticTheme,
 } from 'schema/validator';
+import themeSchemaObject from 'schema/imported/theme';
 import {
   CSP_KEYWORD_RE,
   DEPRECATED_MANIFEST_PROPERTIES,
@@ -81,6 +82,39 @@ async function getImageMetadata(io, iconPath) {
 
 function getNormalizedExtension(_path) {
   return path.extname(_path).substring(1).toLowerCase();
+}
+
+export const SUPPORTED_CSS_GRADIENT_FUNCTIONS = new Set(
+  themeSchemaObject.types.ThemeCSSGradient.anyOf.map(
+    (variant) => Object.keys(variant.properties)[0]
+  )
+);
+
+// Matches only the instancePaths where ThemeBackground (and therefore
+// ThemeCSSGradient) is valid: additional_backgrounds array items and
+// theme_frame under theme or dark_theme.
+const THEME_BACKGROUND_PATH_RE =
+  /^\/(theme|dark_theme)\/images\/(additional_backgrounds\/\d+|theme_frame)$/;
+
+// Returns the unsupported gradient function name if `instancePath` is a
+// ThemeBackground position, `data` looks like a ThemeCSSGradient object, and
+// its key is not one of the supported gradient functions; returns null otherwise.
+function getUnknownCSSGradientFn(instancePath, data) {
+  if (!THEME_BACKGROUND_PATH_RE.test(instancePath)) {
+    return null;
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+  const keys = Object.keys(data);
+  if (
+    keys.length === 1 &&
+    typeof data[keys[0]] === 'string' &&
+    !SUPPORTED_CSS_GRADIENT_FUNCTIONS.has(keys[0])
+  ) {
+    return keys[0];
+  }
+  return null;
 }
 
 export default class ManifestJSONParser extends JSONParser {
@@ -376,6 +410,14 @@ export default class ManifestJSONParser extends JSONParser {
       baseObject = messages.manifestThemeCSSGradientInvalid(error.params);
       overrides.message = baseObject.message;
       overrides.description = baseObject.description;
+    } else if (error.keyword === SCHEMA_KEYWORDS.ANY_OF) {
+      const unknownFn = getUnknownCSSGradientFn(error.instancePath, error.data);
+      if (unknownFn) {
+        baseObject =
+          messages.manifestThemeCSSGradientFunctionUnsupported(unknownFn);
+        overrides.message = baseObject.message;
+        overrides.description = baseObject.description;
+      }
     }
 
     // Arrays can be extremely verbose, this tries to make them a little
@@ -490,18 +532,22 @@ export default class ManifestJSONParser extends JSONParser {
         JSON.stringify(validate.errors, null, 2)
       );
 
+      const isCSSGradientError = (e) =>
+        e.keyword === SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT ||
+        (e.keyword === SCHEMA_KEYWORDS.ANY_OF &&
+          getUnknownCSSGradientFn(e.instancePath, e.data) !== null);
+
       const cssGradientErrorPaths = new Set(
-        validate.errors
-          .filter((e) => e.keyword === SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT)
-          .map((e) => e.instancePath)
+        validate.errors.filter(isCSSGradientError).map((e) => e.instancePath)
       );
 
       validate.errors.forEach((error) => {
-        // Omit other validation errors hit by the same instancePath for which we are
-        // already reporting MANIFEST_THEME_CSS_GRADIENT_INVALID linting error (otherwise
-        // the resulting validation errors are going to be potentially confusing).
+        // Omit other validation errors at the same instancePath for which we are
+        // already reporting a CSS gradient linting error (either
+        // MANIFEST_THEME_CSS_GRADIENT_INVALID or MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED),
+        // otherwise the resulting validation errors are going to be potentially confusing.
         if (
-          error.keyword !== SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT &&
+          !isCSSGradientError(error) &&
           cssGradientErrorPaths.has(error.instancePath)
         ) {
           return;

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -15,7 +15,6 @@ import {
   validateLangPack,
   validateStaticTheme,
 } from 'schema/validator';
-import themeSchemaObject from 'schema/imported/theme';
 import {
   CSS_GRADIENT_MIN_FIREFOX_VERSION,
   CSP_KEYWORD_RE,
@@ -31,7 +30,9 @@ import {
   RESTRICTED_HOMEPAGE_URLS,
   RESTRICTED_PERMISSIONS,
   SCHEMA_KEYWORDS,
+  SUPPORTED_CSS_GRADIENT_FUNCTIONS,
   STATIC_THEME_IMAGE_MIMES,
+  THEME_BACKGROUND_PATH_RE,
 } from 'const';
 import log from 'logger';
 import * as messages from 'messages';
@@ -84,18 +85,6 @@ async function getImageMetadata(io, iconPath) {
 function getNormalizedExtension(_path) {
   return path.extname(_path).substring(1).toLowerCase();
 }
-
-export const SUPPORTED_CSS_GRADIENT_FUNCTIONS = new Set(
-  themeSchemaObject.types.ThemeCSSGradient.anyOf.map(
-    (variant) => Object.keys(variant.properties)[0]
-  )
-);
-
-// Matches only the instancePaths where ThemeBackground (and therefore
-// ThemeCSSGradient) is valid: additional_backgrounds array items and
-// theme_frame under theme or dark_theme.
-const THEME_BACKGROUND_PATH_RE =
-  /^\/(theme|dark_theme)\/images\/(additional_backgrounds\/\d+|theme_frame)$/;
 
 // Returns the unsupported gradient function name if `instancePath` is a
 // ThemeBackground position, `data` looks like a ThemeCSSGradient object, and

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -372,6 +372,10 @@ export default class ManifestJSONParser extends JSONParser {
         : messages.manifestFieldPrivileged(error);
       overrides.message = baseObject.message;
       overrides.description = baseObject.description;
+    } else if (error.keyword === SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT) {
+      baseObject = messages.manifestThemeCSSGradientInvalid(error.params);
+      overrides.message = baseObject.message;
+      overrides.description = baseObject.description;
     }
 
     // Arrays can be extremely verbose, this tries to make them a little

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -490,7 +490,23 @@ export default class ManifestJSONParser extends JSONParser {
         JSON.stringify(validate.errors, null, 2)
       );
 
+      const cssGradientErrorPaths = new Set(
+        validate.errors
+          .filter((e) => e.keyword === SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT)
+          .map((e) => e.instancePath)
+      );
+
       validate.errors.forEach((error) => {
+        // Omit other validation errors hit by the same instancePath for which we are
+        // already reporting MANIFEST_THEME_CSS_GRADIENT_INVALID linting error (otherwise
+        // the resulting validation errors are going to be potentially confusing).
+        if (
+          error.keyword !== SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT &&
+          cssGradientErrorPaths.has(error.instancePath)
+        ) {
+          return;
+        }
+
         const message = this.errorLookup(error);
 
         // errorLookup call returned a null or undefined message,

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -17,6 +17,7 @@ import {
 } from 'schema/validator';
 import themeSchemaObject from 'schema/imported/theme';
 import {
+  CSS_GRADIENT_MIN_FIREFOX_VERSION,
   CSP_KEYWORD_RE,
   DEPRECATED_MANIFEST_PROPERTIES,
   FILE_EXTENSIONS_TO_MIME,
@@ -603,6 +604,8 @@ export default class ManifestJSONParser extends JSONParser {
         ...this.parsedJSON.browser_specific_settings,
       };
     }
+
+    this.validateStaticThemeCSSGradientMinVersion();
 
     // We only want `admin_install_only` to be set in `bss` when `--enterprise`
     // is set, otherwise we don't want the flag _at all_, which includes both
@@ -1236,6 +1239,42 @@ export default class ManifestJSONParser extends JSONParser {
     }
 
     return Promise.all(promises);
+  }
+
+  validateStaticThemeCSSGradientMinVersion() {
+    if (!this.isStaticTheme) return;
+
+    const hasCSSGradient = ['theme', 'dark_theme'].some((themeKey) => {
+      const themeImages = this.parsedJSON[themeKey]?.images;
+      if (!themeImages) return false;
+      if (
+        Array.isArray(themeImages.additional_backgrounds) &&
+        themeImages.additional_backgrounds.some(
+          (item) => typeof item !== 'string'
+        )
+      ) {
+        return true;
+      }
+      if (
+        themeImages.theme_frame != null &&
+        typeof themeImages.theme_frame !== 'string'
+      ) {
+        return true;
+      }
+      return false;
+    });
+
+    if (!hasCSSGradient) return;
+
+    const minVersion = firefoxStrictMinVersion(this.parsedJSON);
+    if (minVersion === null || minVersion < CSS_GRADIENT_MIN_FIREFOX_VERSION) {
+      this.collector.addError(
+        messages.manifestThemeCSSGradientMinVersion(
+          CSS_GRADIENT_MIN_FIREFOX_VERSION
+        )
+      );
+      this.isValid = false;
+    }
   }
 
   validateFileExistsInPackage(

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1156,6 +1156,11 @@ export default class ManifestJSONParser extends JSONParser {
       for (const prop of Object.keys(themeImages)) {
         if (Array.isArray(themeImages[prop])) {
           themeImages[prop].forEach((imagePath) => {
+            // CSS gradient objects (ThemeCSSGradient) are not image files and
+            // so they should not be checked for file existence or valid mime-type.
+            if (typeof imagePath !== 'string') {
+              return;
+            }
             promises.push(this.validateThemeImage(imagePath, prop));
           });
         } else {

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1236,11 +1236,15 @@ export default class ManifestJSONParser extends JSONParser {
   }
 
   validateStaticThemeCSSGradientMinVersion() {
-    if (!this.isStaticTheme) return;
+    if (!this.isStaticTheme) {
+      return;
+    }
 
     const hasCSSGradient = ['theme', 'dark_theme'].some((themeKey) => {
       const themeImages = this.parsedJSON[themeKey]?.images;
-      if (!themeImages) return false;
+      if (!themeImages) {
+        return false;
+      }
       if (
         Array.isArray(themeImages.additional_backgrounds) &&
         themeImages.additional_backgrounds.some(
@@ -1258,7 +1262,9 @@ export default class ManifestJSONParser extends JSONParser {
       return false;
     });
 
-    if (!hasCSSGradient) return;
+    if (!hasCSSGradient) {
+      return;
+    }
 
     const minVersion = firefoxStrictMinVersion(this.parsedJSON);
     if (minVersion === null || minVersion < CSS_GRADIENT_MIN_FIREFOX_VERSION) {

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -695,7 +695,7 @@ export class SchemaValidator {
     ) => {
       if (keywordSchemaValue === 'validCSSGradient') {
         // Gather the CSS gradient's function name and params from the theme
-        // properties and use csstree.parse to validate it. 
+        // properties and use csstree.parse to validate it.
         const [functionName, params] = Object.entries(propValue)[0];
         let hasParseError = false;
         let parsed;

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -694,11 +694,13 @@ export class SchemaValidator {
       { rootData /* instancePath, parentData, parentDataProperty, */ }
     ) => {
       if (keywordSchemaValue === 'validCSSGradient') {
-        const [gradientFn, gradientParams] = Object.entries(propValue)[0];
+        // Gather the CSS gradient's function name and params from the theme
+        // properties and use csstree.parse to validate it. 
+        const [functionName, params] = Object.entries(propValue)[0];
         let hasParseError = false;
         let parsed;
         try {
-          parsed = csstree.parse(`${gradientFn}(${gradientParams})`, {
+          parsed = csstree.parse(`${functionName}(${params})`, {
             context: 'value',
             onParseError: () => {
               hasParseError = true;
@@ -706,7 +708,7 @@ export class SchemaValidator {
           });
         } catch (err) {
           log.error(
-            `Unexpected error while parsing CSS gradient "${gradientFn}(${gradientParams})"`,
+            `Unexpected error while parsing CSS gradient "${functionName}(${params})"`,
             err.message
           );
           hasParseError = true;
@@ -725,8 +727,8 @@ export class SchemaValidator {
           validateRequiredManifestBackgroundKeys.errors = [
             {
               keyword: SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT,
-              message: `"${gradientFn}" has invalid CSS gradient parameters`,
-              params: { gradientFn, gradientParams },
+              message: `"${functionName}" has invalid CSS gradient parameters`,
+              params: { functionName, params },
             },
           ];
           return false;

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -1,4 +1,7 @@
 import Ajv from 'ajv';
+import * as csstree from 'css-tree';
+
+import log from 'logger';
 
 import ajvMergePatch from 'ajv-merge-patch';
 import { getDefaultConfigValue } from 'yargs-options';
@@ -691,6 +694,47 @@ export class SchemaValidator {
       schema,
       { rootData /* instancePath, parentData, parentDataProperty, */ }
     ) => {
+      if (keywordSchemaValue === 'validCSSGradient') {
+        const [gradientFn, gradientParams] = Object.entries(propValue)[0];
+        let hasParseError = false;
+        let parsed;
+        try {
+          parsed = csstree.parse(`${gradientFn}(${gradientParams})`, {
+            context: 'value',
+            onParseError: () => {
+              hasParseError = true;
+            },
+          });
+        } catch (err) {
+          log.error(
+            `Unexpected error while parsing CSS gradient "${gradientFn}(${gradientParams})"`,
+            err.message
+          );
+          hasParseError = true;
+        }
+        const children = parsed?.children;
+        // Require the reconstructed CSS to parse without errors as exactly one
+        // Function node. This rejects empty values, plain text, and strings
+        // with unmatched parentheses that would otherwise split into multiple
+        // top-level tokens (e.g. a CSS injection attempt).
+        if (
+          hasParseError ||
+          !parsed ||
+          children?.size !== 1 ||
+          children?.first?.type !== 'Function'
+        ) {
+          validateRequiredManifestBackgroundKeys.errors = [
+            {
+              keyword: SCHEMA_KEYWORDS.VALIDATE_CSS_GRADIENT,
+              message: `"${gradientFn}" has invalid CSS gradient parameters`,
+              params: { gradientFn, gradientParams },
+            },
+          ];
+          return false;
+        }
+        return true;
+      }
+
       if (keywordSchemaValue !== 'checkRequiredManifestBackgroundKeys') {
         return true;
       }

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -2,7 +2,6 @@ import Ajv from 'ajv';
 import * as csstree from 'css-tree';
 
 import log from 'logger';
-
 import ajvMergePatch from 'ajv-merge-patch';
 import { getDefaultConfigValue } from 'yargs-options';
 import { deepPatch } from 'schema/deepmerge';

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4233,7 +4233,10 @@ describe('ManifestJSONParser', () => {
         theme: {
           images: {
             additional_backgrounds: [
-              { 'linear-gradient': 'red), url(chrome://path/to/image.png), linear-gradient(transparent,' },
+              {
+                'linear-gradient':
+                  'red), url(chrome://path/to/image.png), linear-gradient(transparent,',
+              },
             ],
           },
         },
@@ -4251,8 +4254,7 @@ describe('ManifestJSONParser', () => {
       expect(manifestJSONParser.isValid).toEqual(false);
       assertHasMatchingError(linter.collector.errors, {
         code: messages.MANIFEST_THEME_CSS_GRADIENT_INVALID,
-        message:
-          'Theme CSS gradient "linear-gradient" has invalid parameters',
+        message: 'Theme CSS gradient "linear-gradient" has invalid parameters',
         description:
           '"linear-gradient": "red), url(chrome://path/to/image.png), linear-gradient(transparent," is not valid CSS',
       });
@@ -4380,6 +4382,7 @@ describe('ManifestJSONParser', () => {
           linter.collector,
           { io: { files: {} } }
         );
+        expect(manifestJSONParser.isValid).toEqual(true);
         expect(
           linter.collector.errors.some(
             (e) => e.code === messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4261,6 +4261,38 @@ describe('ManifestJSONParser', () => {
       ).toEqual([]);
     });
 
+    it('reports an error for an unsupported CSS gradient function in additional_backgrounds', () => {
+      const linter = new Linter({ _: ['bar'] });
+      const manifest = validStaticThemeManifestJSON({
+        theme: {
+          images: {
+            additional_backgrounds: [
+              { 'unknown-gradient': '90deg, #FCFBFF 0%, #EFEDF2 100%' },
+            ],
+          },
+        },
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        manifest,
+        linter.collector,
+        { io: { files: {} } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(false);
+      assertHasMatchingError(linter.collector.errors, {
+        code: messages.MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED,
+        message:
+          'Theme CSS gradient function "unknown-gradient" is not supported',
+      });
+      // No anyOf/branch noise should be emitted for the same entry.
+      expect(
+        linter.collector.errors.filter(
+          (e) => e.code !== messages.MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED
+        )
+      ).toEqual([]);
+    });
+
     it('validates image files while skipping CSS gradient objects in additional_backgrounds', async () => {
       const linter = new Linter({ _: ['bar'] });
       const imageFiles = ['bg1.svg', 'bg2.png'];

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4237,6 +4237,9 @@ describe('ManifestJSONParser', () => {
             ],
           },
         },
+        browser_specific_settings: {
+          gecko: { id: '@static-theme', strict_min_version: '153.0' },
+        },
       });
 
       const manifestJSONParser = new ManifestJSONParser(
@@ -4271,6 +4274,9 @@ describe('ManifestJSONParser', () => {
             ],
           },
         },
+        browser_specific_settings: {
+          gecko: { id: '@static-theme', strict_min_version: '153.0' },
+        },
       });
 
       const manifestJSONParser = new ManifestJSONParser(
@@ -4293,6 +4299,118 @@ describe('ManifestJSONParser', () => {
       ).toEqual([]);
     });
 
+    describe('CSS gradient min version', () => {
+      const GRADIENT_THEME = {
+        theme: {
+          images: {
+            additional_backgrounds: [
+              { 'linear-gradient': 'to bottom, #FF6BBA 0%, #FFC999 100%' },
+            ],
+          },
+        },
+      };
+
+      it('reports an error when strict_min_version is not set', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const manifest = validStaticThemeManifestJSON({
+          ...GRADIENT_THEME,
+          browser_specific_settings: { gecko: { id: '@test' } },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          manifest,
+          linter.collector,
+          { io: { files: {} } }
+        );
+        expect(manifestJSONParser.isValid).toEqual(false);
+        assertHasMatchingError(linter.collector.errors, {
+          code: messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION,
+        });
+      });
+
+      it('reports an error when strict_min_version is below 153', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const manifest = validStaticThemeManifestJSON({
+          ...GRADIENT_THEME,
+          browser_specific_settings: {
+            gecko: { id: '@test', strict_min_version: '109.0' },
+          },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          manifest,
+          linter.collector,
+          { io: { files: {} } }
+        );
+        expect(manifestJSONParser.isValid).toEqual(false);
+        assertHasMatchingError(linter.collector.errors, {
+          code: messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION,
+        });
+      });
+
+      it('does not report an error when strict_min_version is 153', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const manifest = validStaticThemeManifestJSON({
+          ...GRADIENT_THEME,
+          browser_specific_settings: {
+            gecko: { id: '@test', strict_min_version: '153.0' },
+          },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          manifest,
+          linter.collector,
+          { io: { files: {} } }
+        );
+        expect(manifestJSONParser.isValid).toEqual(true);
+        expect(
+          linter.collector.errors.some(
+            (e) => e.code === messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION
+          )
+        ).toBe(false);
+      });
+
+      it('does not report an error when additional_backgrounds has only image paths', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const manifest = validStaticThemeManifestJSON({
+          theme: {
+            images: { additional_backgrounds: ['bg.png'] },
+          },
+          browser_specific_settings: { gecko: { id: '@test' } },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          manifest,
+          linter.collector,
+          { io: { files: {} } }
+        );
+        expect(
+          linter.collector.errors.some(
+            (e) => e.code === messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION
+          )
+        ).toBe(false);
+      });
+
+      it('reports an error when dark_theme uses a CSS gradient without strict_min_version', () => {
+        const linter = new Linter({ _: ['bar'] });
+        const manifest = validStaticThemeManifestJSON({
+          dark_theme: {
+            images: {
+              additional_backgrounds: [
+                { 'linear-gradient': 'to bottom, #20123A 0%, #291D4F 50%' },
+              ],
+            },
+          },
+          browser_specific_settings: { gecko: { id: '@test' } },
+        });
+        const manifestJSONParser = new ManifestJSONParser(
+          manifest,
+          linter.collector,
+          { io: { files: {} } }
+        );
+        expect(manifestJSONParser.isValid).toEqual(false);
+        assertHasMatchingError(linter.collector.errors, {
+          code: messages.MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION,
+        });
+      });
+    });
+
     it('validates image files while skipping CSS gradient objects in additional_backgrounds', async () => {
       const linter = new Linter({ _: ['bar'] });
       const imageFiles = ['bg1.svg', 'bg2.png'];
@@ -4305,6 +4423,9 @@ describe('ManifestJSONParser', () => {
               imageFiles[1],
             ],
           },
+        },
+        browser_specific_settings: {
+          gecko: { id: '@static-theme', strict_min_version: '153.0' },
         },
       });
 

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4253,6 +4253,12 @@ describe('ManifestJSONParser', () => {
         description:
           '"linear-gradient": "red), url(chrome://path/to/image.png), linear-gradient(transparent," is not valid CSS',
       });
+      // No anyOf/branch noise should be emitted for the same entry.
+      expect(
+        linter.collector.errors.filter(
+          (e) => e.code !== messages.MANIFEST_THEME_CSS_GRADIENT_INVALID
+        )
+      ).toEqual([]);
     });
 
     it('validates image files while skipping CSS gradient objects in additional_backgrounds', async () => {

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4227,6 +4227,47 @@ describe('ManifestJSONParser', () => {
       expect(manifestJSONParser.isValid).toEqual(true);
     });
 
+    it('validates image files while skipping CSS gradient objects in additional_backgrounds', async () => {
+      const linter = new Linter({ _: ['bar'] });
+      const imageFiles = ['bg1.svg', 'bg2.png'];
+      const manifest = validStaticThemeManifestJSON({
+        theme: {
+          images: {
+            additional_backgrounds: [
+              imageFiles[0],
+              { 'linear-gradient': 'to bottom, #FF6BBA -18.096%, #FFC999 50%' },
+              imageFiles[1],
+            ],
+          },
+        },
+      });
+
+      const files = {
+        'bg1.svg': EMPTY_SVG,
+        'bg2.png': EMPTY_PNG,
+      };
+      const fakeIO = getStreamableIO(files);
+      fakeIO.getFileAsStream = jest.fn(fakeIO.getFileAsStream);
+
+      const manifestJSONParser = new ManifestJSONParser(
+        manifest,
+        linter.collector,
+        { io: fakeIO }
+      );
+
+      await manifestJSONParser.validateStaticThemeImages();
+
+      // Only the two image files should be read and the gradient skipped.
+      expect(fakeIO.getFileAsStream.mock.calls.length).toBe(imageFiles.length);
+      expect(fakeIO.getFileAsStream.mock.calls.map((call) => call[0])).toEqual(
+        imageFiles
+      );
+
+      const { errors, warnings } = linter.collector;
+      expect({ errors, warnings }).toEqual({ errors: [], warnings: [] });
+      expect(manifestJSONParser.isValid).toEqual(true);
+    });
+
     it('considers theme.images as optional', async () => {
       const linter = new Linter({ _: ['bar'] });
       const manifest = validStaticThemeManifestJSON({

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -4227,6 +4227,34 @@ describe('ManifestJSONParser', () => {
       expect(manifestJSONParser.isValid).toEqual(true);
     });
 
+    it('reports an error for invalid CSS gradient parameters in additional_backgrounds', () => {
+      const linter = new Linter({ _: ['bar'] });
+      const manifest = validStaticThemeManifestJSON({
+        theme: {
+          images: {
+            additional_backgrounds: [
+              { 'linear-gradient': 'red), url(chrome://path/to/image.png), linear-gradient(transparent,' },
+            ],
+          },
+        },
+      });
+
+      const manifestJSONParser = new ManifestJSONParser(
+        manifest,
+        linter.collector,
+        { io: { files: {} } }
+      );
+
+      expect(manifestJSONParser.isValid).toEqual(false);
+      assertHasMatchingError(linter.collector.errors, {
+        code: messages.MANIFEST_THEME_CSS_GRADIENT_INVALID,
+        message:
+          'Theme CSS gradient "linear-gradient" has invalid parameters',
+        description:
+          '"linear-gradient": "red), url(chrome://path/to/image.png), linear-gradient(transparent," is not valid CSS',
+      });
+    });
+
     it('validates image files while skipping CSS gradient objects in additional_backgrounds', async () => {
       const linter = new Linter({ _: ['bar'] });
       const imageFiles = ['bg1.svg', 'bg2.png'];

--- a/tests/unit/schema/test.static_theme.js
+++ b/tests/unit/schema/test.static_theme.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 
 import { validateStaticTheme } from 'schema/validator';
-import { SUPPORTED_CSS_GRADIENT_FUNCTIONS } from 'parsers/manifestjson';
+import { SUPPORTED_CSS_GRADIENT_FUNCTIONS } from 'const';
 
 import { validStaticThemeManifestJSON } from '../helpers';
 

--- a/tests/unit/schema/test.static_theme.js
+++ b/tests/unit/schema/test.static_theme.js
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 
 import { validateStaticTheme } from 'schema/validator';
+import { SUPPORTED_CSS_GRADIENT_FUNCTIONS } from 'parsers/manifestjson';
 
 import { validStaticThemeManifestJSON } from '../helpers';
 
@@ -122,5 +123,16 @@ describe('static theme', () => {
         ).toBe(true);
       }
     );
+
+    it('SUPPORTED_CSS_GRADIENT_FUNCTIONS matches the ThemeCSSGradient schema', () => {
+      expect([...SUPPORTED_CSS_GRADIENT_FUNCTIONS]).toEqual([
+        'linear-gradient',
+        'radial-gradient',
+        'conic-gradient',
+        'repeating-linear-gradient',
+        'repeating-radial-gradient',
+        'repeating-conic-gradient',
+      ]);
+    });
   });
 });

--- a/tests/unit/schema/test.static_theme.js
+++ b/tests/unit/schema/test.static_theme.js
@@ -42,4 +42,46 @@ describe('static theme', () => {
       'must NOT have additional properties'
     );
   });
+
+  it('should accept additional_backgrounds with a CSS gradient object', () => {
+    const manifest = cloneDeep(JSON.parse(validStaticThemeManifestJSON()));
+    manifest.theme.images = {
+      additional_backgrounds: [
+        { 'linear-gradient': 'to bottom, #FF6BBA -18.096%, #FFC999 50%' },
+      ],
+    };
+    validateStaticTheme(manifest);
+    expect(validateStaticTheme.errors).toBeNull();
+  });
+
+  it('should accept additional_backgrounds mixing image paths and CSS gradient objects', () => {
+    const manifest = cloneDeep(JSON.parse(validStaticThemeManifestJSON()));
+    manifest.theme.images = {
+      additional_backgrounds: [
+        'bg1.svg',
+        { 'linear-gradient': 'to bottom, #FF6BBA -18.096%, #FFC999 50%' },
+        'bg2.png',
+      ],
+    };
+    validateStaticTheme(manifest);
+    expect(validateStaticTheme.errors).toBeNull();
+  });
+
+  it('should fail on additional_backgrounds with an invalid CSS gradient object', () => {
+    const manifest = cloneDeep(JSON.parse(validStaticThemeManifestJSON()));
+    manifest.theme.images = {
+      additional_backgrounds: [
+        { 'invalid-gradient': 'to bottom, #FF6BBA, #FFC999' },
+      ],
+    };
+    validateStaticTheme(manifest);
+    expect(validateStaticTheme.errors).not.toBeNull();
+    expect(
+      validateStaticTheme.errors.some(
+        (err) =>
+          err.instancePath === '/theme/images/additional_backgrounds/0' &&
+          err.message === 'must match a schema in anyOf'
+      )
+    ).toBe(true);
+  });
 });

--- a/tests/unit/schema/test.static_theme.js
+++ b/tests/unit/schema/test.static_theme.js
@@ -84,4 +84,43 @@ describe('static theme', () => {
       )
     ).toBe(true);
   });
+
+  describe('CSS gradient parameter validation', () => {
+    it.each([
+      ['linear-gradient', 'to bottom, #FF6BBA -18.096%, #FFC999 50%'],
+      ['linear-gradient', '90deg, #9059FF 0%, #FF4AA2 52.08%, #FFBD4F 100%'],
+      ['radial-gradient', 'circle, red, blue'],
+      ['conic-gradient', 'from 90deg, red, blue'],
+      ['repeating-linear-gradient', 'red 0%, blue 20%, red 40%'],
+      ['repeating-radial-gradient', 'circle, red 0%, blue 50%'],
+      ['repeating-conic-gradient', 'from 45deg, red, blue'],
+    ])('should accept valid %s parameters', (gradientFn, params) => {
+      const manifest = cloneDeep(JSON.parse(validStaticThemeManifestJSON()));
+      manifest.theme.images = {
+        additional_backgrounds: [{ [gradientFn]: params }],
+      };
+      validateStaticTheme(manifest);
+      expect(validateStaticTheme.errors).toBeNull();
+    });
+
+    it.each([
+      ['linear-gradient', 'red), url(chrome://path/to/image.png), linear-gradient(transparent,'],
+      ['linear-gradient', '<script>alert(1)</script>'],
+    ])(
+      'should fail on %s with invalid CSS parameters',
+      (gradientFn, params) => {
+        const manifest = cloneDeep(JSON.parse(validStaticThemeManifestJSON()));
+        manifest.theme.images = {
+          additional_backgrounds: [{ [gradientFn]: params }],
+        };
+        validateStaticTheme(manifest);
+        expect(validateStaticTheme.errors).not.toBeNull();
+        expect(
+          validateStaticTheme.errors.some(
+            (err) => err.keyword === 'validCSSGradient'
+          )
+        ).toBe(true);
+      }
+    );
+  });
 });

--- a/tests/unit/schema/test.static_theme.js
+++ b/tests/unit/schema/test.static_theme.js
@@ -105,7 +105,10 @@ describe('static theme', () => {
     });
 
     it.each([
-      ['linear-gradient', 'red), url(chrome://path/to/image.png), linear-gradient(transparent,'],
+      [
+        'linear-gradient',
+        'red), url(chrome://path/to/image.png), linear-gradient(transparent,',
+      ],
       ['linear-gradient', '<script>alert(1)</script>'],
     ])(
       'should fail on %s with invalid CSS parameters',


### PR DESCRIPTION
This pull request introduce the following 3 new rules:

- `MANIFEST_THEME_CSS_GRADIENT_INVALID` (**error**): This rule uses [css-tree](https://github.com/csstree/csstree) npm dependency (same dependency used by [stylelint](https://stylelint.io/) internally) internally to parse the CSS gradient params (by hooking up the `validCSSGradient` postprocessor function already part of the JSONSchema definition for the ThemeCSSGradient type) and reports CSS gradients that hits a parsing error. This rule also suppresses other secondary JSON schema validation errors hit by the same theme property (reported along with linting error coming from this rule as a side-effect of the anyOf schema) to keep the reported linting error less noisy (and avoid for the multiple linting errors to become potentially confusing by reporting conflicting guidance to the theme author)

- `MANIFEST_THEME_CSS_GRADIENT_UNSUPPORTED` (**error**): This rule is meant to report a better error when the CSS gradient function name is not one of explicitly listed as supported by Firefox JSONSchema (the valid CSS gradient function names are derived from the imported schema, and a unit test is meant to let us catch if the list of derived CSS gradient function is changing as a side effect of a future Firefox schema import).

- `MANIFEST_THEME_CSS_GRADIENT_MIN_VERSION` (**error**): This rule is meant to report to the theme author that static themes using CSS gradients nees to also include a manifest's strict_min_version equal or higher than 153.

Fixes #6076 