### PR TITLE
fix(linter): only lint JSON files relevant to extensions

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -378,7 +378,15 @@ export default class Linter {
       case '.mjs':
         return JavaScriptScanner;
       case '.json':
-        return JSONScanner;
+        if (
+          (filename.startsWith(constants.LOCALES_DIRECTORY) &&
+            filename.endsWith(constants.MESSAGES_JSON)) ||
+          filenameWithoutPath === constants.MANIFEST_JSON ||
+          (this.addonMetadata?.dnrRuleFiles ?? []).includes(filename)
+        ) {
+          return JSONScanner;
+        }
+        return BinaryScanner;
       case '.properties':
       case '.ftl':
       case '.dtd':

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1410,6 +1410,11 @@ export default class ManifestJSONParser extends JSONParser {
       // This is the strict min *major* version for Firefox for desktop.
       firefoxStrictMinVersion: firefoxStrictMinVersion(this.parsedJSON),
       experimentApiPaths: this.getExperimentApiPaths(),
+      dnrRuleFiles: (
+        this.parsedJSON.declarative_net_request?.rule_resources ?? []
+      )
+        .map((r) => r.path)
+        .filter(Boolean),
     };
   }
 }

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -5464,6 +5464,41 @@ describe('ManifestJSONParser', () => {
     );
   });
 
+  describe('dnrRuleFiles', () => {
+    it('should return rule file paths from declarative_net_request.rule_resources', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({
+        manifest_version: 3,
+        declarative_net_request: {
+          rule_resources: [
+            { id: 'ruleset-1', enabled: true, path: 'rules/ruleset1.json' },
+            { id: 'ruleset-2', enabled: false, path: 'rules/ruleset2.json' },
+          ],
+        },
+      });
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      const { dnrRuleFiles } = manifestJSONParser.getMetadata();
+      expect(dnrRuleFiles).toEqual([
+        'rules/ruleset1.json',
+        'rules/ruleset2.json',
+      ]);
+    });
+
+    it('should return empty array when no declarative_net_request is defined', () => {
+      const addonLinter = new Linter({ _: ['bar'] });
+      const json = validManifestJSON({});
+      const manifestJSONParser = new ManifestJSONParser(
+        json,
+        addonLinter.collector
+      );
+      const { dnrRuleFiles } = manifestJSONParser.getMetadata();
+      expect(dnrRuleFiles).toEqual([]);
+    });
+  });
+
   describe('applications property - MV2', () => {
     it('does not emit any warning or error when a MV2 extension does not use applications or browser_specific_settings', () => {
       const linter = new Linter({ _: ['bar'] });

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -345,9 +345,9 @@ describe('Linter.getScanner()', () => {
   it('should return JSONScanner for manifest.json and locale messages', () => {
     const addonLinter = new Linter({ _: ['foo'] });
     expect(addonLinter.getScanner('manifest.json')).toEqual(JSONScanner);
-    expect(
-      addonLinter.getScanner('_locales/en/messages.json')
-    ).toEqual(JSONScanner);
+    expect(addonLinter.getScanner('_locales/en/messages.json')).toEqual(
+      JSONScanner
+    );
   });
 
   it('should return BinaryScanner for arbitrary JSON files', () => {

--- a/tests/unit/test.linter.js
+++ b/tests/unit/test.linter.js
@@ -342,10 +342,19 @@ describe('Linter.getScanner()', () => {
     }
   );
 
-  it('should return JSONScanner', () => {
+  it('should return JSONScanner for manifest.json and locale messages', () => {
     const addonLinter = new Linter({ _: ['foo'] });
-    const Scanner = addonLinter.getScanner('locales/en.json');
-    expect(Scanner).toEqual(JSONScanner);
+    expect(addonLinter.getScanner('manifest.json')).toEqual(JSONScanner);
+    expect(
+      addonLinter.getScanner('_locales/en/messages.json')
+    ).toEqual(JSONScanner);
+  });
+
+  it('should return BinaryScanner for arbitrary JSON files', () => {
+    const addonLinter = new Linter({ _: ['foo'] });
+    expect(addonLinter.getScanner('data/cards.json')).toEqual(BinaryScanner);
+    expect(addonLinter.getScanner('locales/en.json')).toEqual(BinaryScanner);
+    expect(addonLinter.getScanner('package.json')).toEqual(BinaryScanner);
   });
 
   it('should return LangpackScanner', () => {
@@ -1408,7 +1417,7 @@ describe('Linter.extractMetadata()', () => {
     addonLinter.print = sinon.stub();
 
     await addonLinter.scan({ _console: fakeConsole });
-    expect(addonLinter.output.metadata.totalScannedFileSize).toEqual(2929);
+    expect(addonLinter.output.metadata.totalScannedFileSize).toEqual(2652);
   });
 
   it('should flag coin miners', async () => {
@@ -1446,11 +1455,11 @@ describe('Linter.extractMetadata()', () => {
       }
     }
     await addonLinter.scan({ _Xpi: FakeXpi, _console: fakeConsole });
-    // Only manifest and js files, binary files like the .png are ignored
-    sinon.assert.callCount(markCoinMinerUsageSpy, 4);
+    // Only js files are scanned for coin miners; arbitrary JSON files are skipped
+    sinon.assert.callCount(markCoinMinerUsageSpy, 3);
     const { warnings } = addonLinter.collector;
 
-    expect(warnings.length).toEqual(5);
+    expect(warnings.length).toEqual(4);
 
     assertHasMatchingError(warnings, {
       code: 'COINMINER_USAGE_DETECTED',
@@ -1466,13 +1475,6 @@ describe('Linter.extractMetadata()', () => {
       line: 26,
       instancePath: 'CryptonightWASMWrapper',
       file: 'coinhive_disguised_as_preferences.js',
-    });
-
-    assertHasMatchingError(warnings, {
-      code: 'COINMINER_USAGE_DETECTED',
-      column: 30,
-      line: 12,
-      file: 'included_in_manifest.json',
     });
 
     assertHasMatchingError(warnings, {


### PR DESCRIPTION
Fixes #5685

## Changes

- Skip arbitrary JSON files by routing only `manifest.json`, `_locales/*/messages.json`, and `declarative_net_request` rule files to `JSONScanner`
- All other `.json` files are treated as binary and skipped, removing the `FILE_TOO_LARGE` error for legitimate large JSON data files
- Extracts `dnrRuleFiles` from `declarative_net_request.rule_resources` in the manifest parser so those paths are still linted

## Tests

- Updated `getScanner` test to verify `manifest.json` and `_locales/*/messages.json` route to `JSONScanner`
- Added test to verify arbitrary JSON files (e.g. `data/cards.json`, `package.json`) route to `BinaryScanner`
- Updated `totalScannedFileSize` test to reflect that `package.json` is no longer counted
- Updated coin miner test to reflect that arbitrary JSON files are no longer scanned
