### PR TITLE
fix: Node.js v26 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "semver": "7.8.5",
         "source-map-support": "0.5.21",
         "upath": "3.0.7",
-        "yargs": "17.7.2",
+        "yargs": "17.7.3",
         "yauzl": "3.4.0"
       },
       "bin": {
@@ -14711,9 +14711,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "semver": "7.8.5",
     "source-map-support": "0.5.21",
     "upath": "3.0.7",
-    "yargs": "17.7.2",
+    "yargs": "17.7.3",
     "yauzl": "3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`yargs` has been updated from v17.7.2 to v17.7.3, which includes a fix for a compatibility issue with Node.js v26

Details: https://github.com/yargs/yargs/issues/2509
Changelog: https://github.com/yargs/yargs/releases/tag/v17.7.3

Fixes #6103
