### PR TITLE
Avoid re-scanning replacement values in l10n strings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -139,14 +139,12 @@ function oneLineTranslationString(translationKey) {
 // re-enable localization of the project in the future.
 export const i18n = Object.freeze({
   _: (str) => oneLineTranslationString(str),
-  sprintf: (fmt, args) => {
-    let str = fmt;
-    // Replace every `%(key)s` or `%(key)d` placeholder with the actual value.
-    for (const key of Object.keys(args)) {
-      str = str.replaceAll(new RegExp(`%\\(${key}\\)(d|s)`, 'g'), args[key]);
-    }
-    return str;
-  },
+  sprintf: (fmt, args) =>
+    // Replace every `%(key)s` or `%(key)d` placeholder with the actual value
+    // in a single pass so replacement values are never re-scanned.
+    fmt.replace(/%\((\w+)\)(d|s)/g, (full, key) =>
+      Object.hasOwn(args, key) ? args[key] : full
+    ),
 });
 
 /*

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -100,6 +100,20 @@ describe('sprintf()', () => {
       '1 + 1'
     );
   });
+
+  it('should not re-scan replacement values for placeholders', () => {
+    expect(i18n.sprintf(i18n._('%(a)s'), { a: '%(b)s', b: 'X' })).toEqual(
+      '%(b)s'
+    );
+  });
+
+  it('should leave unknown placeholders untouched', () => {
+    expect(i18n.sprintf(i18n._('%(unknown)s'), {})).toEqual('%(unknown)s');
+  });
+
+  it('should not resolve inherited properties', () => {
+    expect(i18n.sprintf(i18n._('%(__proto__)s'), {})).toEqual('%(__proto__)s');
+  });
 });
 
 describe('getVariable()', () => {


### PR DESCRIPTION
See: https://github.com/mozilla/addons-linter/pull/6106#discussion_r3559005244