### PR TITLE
Allow update_url for enterprise add-ons

### DIFF
--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -769,10 +769,7 @@ export default class ManifestJSONParser extends JSONParser {
       });
     }
 
-    if (
-      (!this.selfHosted || this.isEnterpriseAddon) &&
-      this.parsedJSON.applications?.gecko?.update_url
-    ) {
+    if (!this.selfHosted && this.parsedJSON.applications?.gecko?.update_url) {
       if (this.isPrivilegedAddon) {
         // We cannot know whether a privileged add-on will be listed or
         // unlisted so we only emit a warning for MANIFEST_UPDATE_URL (not an

--- a/tests/unit/parsers/test.manifestjson.js
+++ b/tests/unit/parsers/test.manifestjson.js
@@ -2469,7 +2469,7 @@ describe('ManifestJSONParser', () => {
       expect(addonLinter.collector.warnings.length).toBe(0);
     });
 
-    it('emits an error when the update_url is defined in an enterprise add-on', () => {
+    it('does not emit an error when the update_url is defined in an enterprise add-on', () => {
       const linter = new Linter({ _: ['bar'] });
 
       const manifestJSONParser = new ManifestJSONParser(
@@ -2489,11 +2489,9 @@ describe('ManifestJSONParser', () => {
         { isEnterprise: true }
       );
 
-      expect(manifestJSONParser.isValid).toEqual(false);
+      expect(manifestJSONParser.isValid).toEqual(true);
       expect(linter.collector.warnings).toEqual([]);
-      expect(linter.collector.errors).toEqual([
-        expect.objectContaining(messages.MANIFEST_UPDATE_URL),
-      ]);
+      expect(linter.collector.errors).toEqual([]);
     });
 
     it('does not emit an error when the update_url is defined in a self-hosted add-on', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-linter/issues/6155.

Allows enterprise add-ons to use update_url.
