### PR TITLE
Add a new release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions: {}
+
+jobs:
+  draft-release:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'releases/')
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to create the draft release.
+      contents: write
+      # Required to comment the draft release on the pull request.
+      pull-requests: write
+
+    steps:
+      # Ideally, we'd also update the link pointing to our process docs in the
+      # README.md file when this version changes.
+      - uses: mozilla/addons/.github/actions/release@442a70320c838d93bd0c34708471b8c5ca7ce86f # 1.1
+        with:
+          repo: ${{ github.repository }}
+          sha: ${{ github.event.pull_request.merge_commit_sha }}
+          pr: ${{ github.event.pull_request.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -219,9 +219,7 @@ Lastly when the processing is complete the linter will output the collected data
 
 ## Deploys
 
-We deploy to npm automatically using Circle CI. To release a new version, increment the version in `package.json` and create a PR. Make sure your version number conforms to the [semver][] format eg: `0.2.1`.
-
-After merging the PR, [create a new release][new release] with the same tag name as your new version. Once the build passes it will deploy. Magic! ✨
+This project follows the [semantic versioning](https://semver.org/) specification. To release a new version of this library on npmjs.org, please see [our release process][].
 
 ## Dispensary
 
@@ -279,6 +277,5 @@ Firefox name or logo.
 
 For more information, see: https://www.mozilla.org/foundation/licensing.html
 
-[new release]: https://github.com/mozilla/addons-linter/releases/new
-[semver]: http://semver.org/
+[our release process]: https://github.com/mozilla/addons/tree/1.1/.github/actions/release#release-process
 [prettier]: https://prettier.io/


### PR DESCRIPTION
This PR adds a new workflow to release the linter, using PRs.

Here is an example: https://github.com/mozilla/addons-scanner-utils/pull/1152#issuecomment-5633183536